### PR TITLE
Allow "className" to be set on the filter component

### DIFF
--- a/build/griddle.js
+++ b/build/griddle.js
@@ -79,6 +79,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _ = __webpack_require__(3);
 
 	var Griddle = React.createClass({displayName: "Griddle",
+	    propTypes: {
+	        filterClassName: React.PropTypes.string,
+	    },
+
 	    getDefaultProps: function() {
 	        return{
 	            "columns": [],
@@ -92,6 +96,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            "customRowComponentClassName":"",
 	            "settingsText": "Settings",
 	            "filterPlaceholderText": "Filter Results",
+	            "filterClassName": "row filter-container",
 	            "nextText": "Next",
 	            "previousText": "Previous",
 	            "maxRowsText": "Rows per page",
@@ -903,16 +908,31 @@ return /******/ (function(modules) { // webpackBootstrap
 	var React = __webpack_require__(2);
 
 	var GridFilter = React.createClass({displayName: "GridFilter",
+	    propTypes: {
+	        className: React.PropTypes.string,
+	        placeholderText: React.PropTypes.string,
+	    },
+
 	    getDefaultProps: function(){
 	      return {
-	        "placeholderText": ""
+	        className: 'row filter-container',
+	        placeholderText: '',
 	      }
 	    },
 	    handleChange: function(event){
 	        this.props.changeFilter(event.target.value);
 	    },
 	    render: function(){
-	        return React.createElement("div", {className: "row filter-container"}, React.createElement("input", {type: "text", name: "filter", placeholder: this.props.placeholderText, className: "form-control", onChange: this.handleChange}))
+	        return (
+	            React.createElement("div", {className: this.props.className}, 
+	                React.createElement("input", {
+	                    type: "text", 
+	                    name: "filter", 
+	                    placeholder: this.props.placeholderText, 
+	                    className: "form-control", 
+	                    onChange: this.handleChange})
+	            )
+	        );
 	    }
 	});
 

--- a/build/griddle.js
+++ b/build/griddle.js
@@ -499,9 +499,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	        };
 	    },
 	    getFilter: function(){
-	     return ((this.props.showFilter && this.props.useCustomGridComponent === false) ? 
-	        React.createElement(GridFilter, {changeFilter: this.setFilter, placeholderText: this.props.filterPlaceholderText}) : 
-	        "");
+	        if (this.props.showFilter && this.props.useCustomGridComponent === false) {
+	            return (
+	                React.createElement(GridFilter, {
+	                    className: this.props.filterClassName, 
+	                    changeFilter: this.setFilter, 
+	                    placeholderText: this.props.filterPlaceholderText})
+	            );
+	        }
+
+	        return '';
 	    },
 	    getSettings: function(){
 	        return (this.props.showSettings ? 

--- a/scripts/__tests__/gridFilter-test.js
+++ b/scripts/__tests__/gridFilter-test.js
@@ -6,24 +6,38 @@ var GridFilter = require('../gridFilter.jsx');
 var TestUtils = React.addons.TestUtils;
 
 describe('GridFilter', function(){
-	var filter; 
-	beforeEach(function(){
-	    filter = TestUtils.renderIntoDocument(<GridFilter />);
-	});
+    var filter;
 
-	it('calls change filter when clicked', function(){
-		var mock = jest.genMockFunction(); 
-		filter.props.changeFilter = mock;
+    beforeEach(function(){
+        filter = TestUtils.renderIntoDocument(<GridFilter />);
+    });
 
-		var someEvent = {
-			"target":{
-				"value":"hi"
-			}
-		};
+    it('has the proper default className applied', function () {
+        var component = TestUtils.findRenderedDOMComponentWithTag(filter, 'div');
+        expect(component.getDOMNode().className).toEqual('row filter-container');
+    });
 
-		var input = TestUtils.findRenderedDOMComponentWithTag(filter, 'input');		
-		React.addons.TestUtils.Simulate.change(input, someEvent);
+    it('allows setting of className', function () {
+        var filterWithClassName = TestUtils.renderIntoDocument(
+            <GridFilter className='my-custom-class' />
+        );
+        var component = TestUtils.findRenderedDOMComponentWithTag(filterWithClassName, 'div');
+        expect(component.getDOMNode().className).toEqual('my-custom-class');
+    });
 
-		expect(mock.mock.calls).toEqual([["hi"]]);
-	})
+    it('calls change filter when clicked', function(){
+        var mock = jest.genMockFunction();
+        filter.props.changeFilter = mock;
+
+        var someEvent = {
+            "target":{
+                "value":"hi"
+            }
+        };
+
+        var input = TestUtils.findRenderedDOMComponentWithTag(filter, 'input');
+        React.addons.TestUtils.Simulate.change(input, someEvent);
+
+        expect(mock.mock.calls).toEqual([["hi"]]);
+    })
 });

--- a/scripts/gridFilter.jsx
+++ b/scripts/gridFilter.jsx
@@ -4,16 +4,31 @@
 var React = require('react');
 
 var GridFilter = React.createClass({
+    propTypes: {
+        className: React.PropTypes.string,
+        placeholderText: React.PropTypes.string,
+    },
+
     getDefaultProps: function(){
       return {
-        "placeholderText": ""
+        className: 'row filter-container',
+        placeholderText: '',
       }
     },
     handleChange: function(event){
         this.props.changeFilter(event.target.value);
     },
     render: function(){
-        return <div className="row filter-container"><input type="text" name="filter" placeholder={this.props.placeholderText} className="form-control" onChange={this.handleChange} /></div>
+        return (
+            <div className={this.props.className}>
+                <input
+                    type="text"
+                    name="filter"
+                    placeholder={this.props.placeholderText}
+                    className="form-control"
+                    onChange={this.handleChange} />
+            </div>
+        );
     }
 });
 

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -16,6 +16,10 @@ var CustomPaginationContainer = require('./customPaginationContainer.jsx');
 var _ = require('underscore');
 
 var Griddle = React.createClass({
+    propTypes: {
+        filterClassName: React.PropTypes.string,
+    },
+
     getDefaultProps: function() {
         return{
             "columns": [],
@@ -29,6 +33,7 @@ var Griddle = React.createClass({
             "customRowComponentClassName":"",
             "settingsText": "Settings",
             "filterPlaceholderText": "Filter Results",
+            "filterClassName": "row filter-container",
             "nextText": "Next",
             "previousText": "Previous",
             "maxRowsText": "Rows per page",
@@ -431,9 +436,16 @@ var Griddle = React.createClass({
         };
     },
     getFilter: function(){
-     return ((this.props.showFilter && this.props.useCustomGridComponent === false) ? 
-        <GridFilter changeFilter={this.setFilter} placeholderText={this.props.filterPlaceholderText} /> : 
-        "");
+        if (this.props.showFilter && this.props.useCustomGridComponent === false) {
+            return (
+                <GridFilter
+                    className={this.props.filterClassName}
+                    changeFilter={this.setFilter}
+                    placeholderText={this.props.filterPlaceholderText} />
+            );
+        }
+
+        return '';
     },
     getSettings: function(){
         return (this.props.showSettings ? 


### PR DESCRIPTION
I've added in the ability for a user to set the `className` for the wrapper HTML which should resolve #67.

I've added two test suites that should test both the default `className` and overriding it. 

*Note: I'm not sure if the default classes should be set where they are (right now in the `Griddle` and `GriddleFilter` components) or if we should set anything at all, please advise*

Let me know if I've missed something or if there is anything that should change.