### PR TITLE
Use type=search for better UX when filtering

### DIFF
--- a/scripts/gridFilter.jsx
+++ b/scripts/gridFilter.jsx
@@ -13,7 +13,7 @@ var GridFilter = React.createClass({
         this.props.changeFilter(event.target.value);
     },
     render: function(){
-        return <div className="filter-container"><input type="text" name="filter" placeholder={this.props.placeholderText} className="form-control" onChange={this.handleChange} /></div>
+        return <div className="filter-container"><input type="search" name="filter" placeholder={this.props.placeholderText} className="form-control" onChange={this.handleChange} /></div>
     }
 });
 


### PR DESCRIPTION
Using `type="search"` in some browsers will give the input an "x" button to clear the search results.