### PR TITLE
Add Row Events: onRowClick #64

### DIFF
--- a/scripts/__tests__/griddle-test.js
+++ b/scripts/__tests__/griddle-test.js
@@ -537,8 +537,21 @@ it('should not show footer when useCustomGridComponent is true', function(){
   });
 
   it('throws error if useCustomGridComponent and useCustomRowComponent are both true', function(){
-    var grid2 = TestUtils.renderIntoDocument(<Griddle results={fakeData} useCustomGridComponent={true} customGridComponent={CustomGridComponent} useCustomRowComponent={true} customRowComponent={CustomGridComponent} />); 
-    expect(console.error).toHaveBeenCalledWith("Cannot currently use both customGridComponent and customRowComponent."); 
-    
-  })
+    var grid2 = TestUtils.renderIntoDocument(<Griddle results={fakeData} useCustomGridComponent={true} customGridComponent={CustomGridComponent} useCustomRowComponent={true} customRowComponent={CustomGridComponent} />);
+    expect(console.error).toHaveBeenCalledWith("Cannot currently use both customGridComponent and customRowComponent.");
+  });
+
+  it('should call the onRowClick callback when clicking a row', function () {
+    var clicked = false;
+    var onRowClick = function onRowClick(){
+      clicked = true;
+    };
+    var grid2 = TestUtils.renderIntoDocument(<Griddle results={fakeData}
+                                                      gridClassName="test"
+                                                      resultsPerPage={1}
+                                                      onRowClick={onRowClick} />);
+    var cells = TestUtils.scryRenderedDOMComponentsWithTag(grid2, 'td');
+    TestUtils.Simulate.click(cells[0].getDOMNode());
+    expect(clicked).toEqual(true);
+  });
 });

--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -22,11 +22,16 @@ var GridRow = React.createClass({
         "parentRowCollapsedClassName": "parent-row",
         "parentRowExpandedClassName": "parent-row expanded",
         "parentRowCollapsedComponent": "▶",
-        "parentRowExpandedComponent": "▼"
+        "parentRowExpandedComponent": "▼",
+        "onRowClick": null
       }
     },
-    handleClick: function(){
-      this.props.toggleChildren();
+    handleClick: function(e){
+        if(this.props.onRowClick !== null && _.isFunction(this.props.onRowClick) ){
+            this.props.onRowClick(this, e);
+        }else if(this.props.hasChildren){
+            this.props.toggleChildren();
+        }
     },
     verifyProps: function(){
         if(this.props.columnSettings === null){
@@ -81,7 +86,7 @@ var GridRow = React.createClass({
               returnValue = (meta == null ? returnValue : <td onClick={this.props.hasChildren && this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{colData}</td>);
             }
 
-            return returnValue || (<td onClick={this.props.hasChildren && this.handleClick} key={index} style={columnStyles}>{firstColAppend}{col[1]}</td>);
+            return returnValue || (<td onClick={this.handleClick} key={index} style={columnStyles}>{firstColAppend}{col[1]}</td>);
         });
 
         //Get the row from the row settings.

--- a/scripts/gridRowContainer.jsx
+++ b/scripts/gridRowContainer.jsx
@@ -18,7 +18,8 @@ var GridRowContainer = React.createClass({
         "parentRowCollapsedClassName": "parent-row",
         "parentRowExpandedClassName": "parent-row expanded",
         "parentRowCollapsedComponent": "▶",
-        "parentRowExpandedComponent": "▼"
+        "parentRowExpandedComponent": "▼",
+        "onRowClick": null
       };
     },
     getInitialState: function(){
@@ -55,7 +56,7 @@ var GridRowContainer = React.createClass({
         hasChildren={that.props.hasChildren} toggleChildren={that.toggleChildren} showChildren={that.state.showChildren} key={that.props.uniqueId} useGriddleIcons={that.props.useGriddleIcons}
         parentRowExpandedClassName={this.props.parentRowExpandedClassName} parentRowCollapsedClassName={this.props.parentRowCollapsedClassName}
         parentRowExpandedComponent={this.props.parentRowExpandedComponent} parentRowCollapsedComponent={this.props.parentRowCollapsedComponent}
-        paddingHeight={that.props.paddingHeight} rowHeight={that.props.rowHeight} />);
+        paddingHeight={that.props.paddingHeight} rowHeight={that.props.rowHeight} onRowClick={that.props.onRowClick} />);
         var children = null;
 
       if(that.state.showChildren){
@@ -73,7 +74,7 @@ var GridRowContainer = React.createClass({
                         </tr>);
               }
 
-              return <GridRow useGriddleStyles={that.props.useGriddleStyles} isSubGriddle={that.props.isSubGriddle} data={row} columnSettings={that.props.columnSettings} isChildRow={true} columnMetadata={that.props.columnMetadata} key={that.props.rowSettings.getRowKey(row)}/>
+              return <GridRow useGriddleStyles={that.props.useGriddleStyles} isSubGriddle={that.props.isSubGriddle} data={row} columnSettings={that.props.columnSettings} isChildRow={true} columnMetadata={that.props.columnMetadata} key={that.props.rowSettings.getRowKey(row)} />
           });
       }
 

--- a/scripts/gridTable.jsx
+++ b/scripts/gridTable.jsx
@@ -35,6 +35,7 @@ var GridTable = React.createClass({
       "parentRowExpandedComponent": "▼",
       "externalLoadingComponent": null,
       "externalIsLoading": false,
+      "onRowClick": null
     }
   },
   getInitialState: function(){
@@ -141,7 +142,7 @@ var GridTable = React.createClass({
             parentRowExpandedClassName={that.props.parentRowExpandedClassName} parentRowCollapsedClassName={that.props.parentRowCollapsedClassName}
             parentRowExpandedComponent={that.props.parentRowExpandedComponent} parentRowCollapsedComponent={that.props.parentRowCollapsedComponent}
             data={row} key={uniqueId + '-container'} uniqueId={uniqueId} columnSettings={that.props.columnSettings} rowSettings={that.props.rowSettings} paddingHeight={that.props.paddingHeight}
-            rowHeight={that.props.rowHeight} hasChildren={hasChildren} tableClassName={that.props.className}/>)
+            rowHeight={that.props.rowHeight} hasChildren={hasChildren} tableClassName={that.props.className} onRowClick={that.props.onRowClick} />)
       });
 
       // Add the spacer rows for nodes we're not rendering.

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -79,6 +79,7 @@ var Griddle = React.createClass({
             "useFixedLayout": true,
             "isSubGriddle": false,
             "enableSort": true,
+            "onRowClick": null,
             /* css class names */
             "sortAscendingClassName": "sort-ascending",
             "sortDescendingClassName": "sort-descending",
@@ -530,7 +531,8 @@ var Griddle = React.createClass({
                 infiniteScrollLoadTreshold={this.props.infiniteScrollLoadTreshold}
                 externalLoadingComponent={this.props.externalLoadingComponent}
                 externalIsLoading={this.props.externalIsLoading}
-                hasMorePages={hasMorePages} /></div>)
+                hasMorePages={hasMorePages}
+                onRowClick={this.props.onRowClick}/></div>)
     },
     getContentSection: function(data, cols, meta, pagingContent, hasMorePages){
         if(this.props.useCustomGridComponent && this.props.customGridComponent !== null){


### PR DESCRIPTION
Added onRowClick event to Griddle, passing it down to GridRow. The callback receives the gridRow component and the event. The gridRow is and instance of GridRow which has a 'props' property which has 'data', 'columnSettings', 'rowSettings', etc. This does not consider child-tables, yet. Usage example:

``` javascript
function(gridRow, event) {
    console.log("Grid row clicked with data:", gridRow.props.data);
}
// ...
<Griddle onRowClick={onRowClick} />
```