### PR TITLE
Add custom table row component

### DIFF
--- a/docs/assets/index.html
+++ b/docs/assets/index.html
@@ -254,7 +254,7 @@ var Griddle = require('griddle-react');</pre></code>
     var CustomRow = React.createClass({
       render: function(){
         var cols = _.pairs(this.props.data).map(function(col, index){
-          return <td>{col[0]}</td>
+          return <td><input type="text" defaultValue={col[1]} style={{width: "100%", height: "100%", color: "#CCC"}} /></td>
         });
         return (
           <tr>
@@ -264,7 +264,7 @@ var Griddle = require('griddle-react');</pre></code>
     });
 
     React.render(
-        <Griddle results={fakeData} customTableRowComponent={CustomRow} useCustomTableRowComponent={true} columnMetadata={columnMeta} rowMetadata={rowMeta} tableClassName="table" showFilter={true} showSettings={true} columns={["name", "city", "state", "country"]}/>, document.getElementById('grid-basic')
+        <Griddle results={fakeData} useCustomTableRowComponent={true} customTableRowComponent={CustomRow} columnMetadata={columnMeta} rowMetadata={rowMeta} tableClassName="table" showFilter={true} showSettings={true} columns={["name", "city", "state", "country"]}/>, document.getElementById('grid-basic')
     );
   </script>
   <script>

--- a/docs/assets/index.html
+++ b/docs/assets/index.html
@@ -251,20 +251,8 @@ var Griddle = require('griddle-react');</pre></code>
   <script src="scripts/fakeData.js"></script>
   <script type="text/jsx">
   /** @jsx React.DOM */
-    var CustomRow = React.createClass({
-      render: function(){
-        var cols = _.pairs(this.props.data).map(function(col, index){
-          return <td><input type="text" defaultValue={col[1]} style={{width: "100%", height: "100%", color: "#CCC"}} /></td>
-        });
-        return (
-          <tr>
-            {cols}
-          </tr>);
-      }
-    });
-
     React.render(
-        <Griddle results={fakeData} useCustomTableRowComponent={true} customTableRowComponent={CustomRow} columnMetadata={columnMeta} rowMetadata={rowMeta} tableClassName="table" showFilter={true} showSettings={true} columns={["name", "city", "state", "country"]}/>, document.getElementById('grid-basic')
+        <Griddle results={fakeData} columnMetadata={columnMeta} rowMetadata={rowMeta} tableClassName="table" showFilter={true} showSettings={true} columns={["name", "city", "state", "country"]}/>, document.getElementById('grid-basic')
     );
   </script>
   <script>

--- a/docs/assets/index.html
+++ b/docs/assets/index.html
@@ -19,7 +19,7 @@
 
   <!-- CSS
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  
+
   <link rel="stylesheet" href="styles/normalize.css">
   <link rel="stylesheet" href="styles/skeleton.css">
   <link rel="stylesheet" href="styles/site.css">
@@ -251,8 +251,20 @@ var Griddle = require('griddle-react');</pre></code>
   <script src="scripts/fakeData.js"></script>
   <script type="text/jsx">
   /** @jsx React.DOM */
+    var CustomRow = React.createClass({
+      render: function(){
+        var cols = _.pairs(this.props.data).map(function(col, index){
+          return <td>{col[0]}</td>
+        });
+        return (
+          <tr>
+            {cols}
+          </tr>);
+      }
+    });
+
     React.render(
-        <Griddle results={fakeData} columnMetadata={columnMeta} rowMetadata={rowMeta} tableClassName="table" showFilter={true} showSettings={true} columns={["name", "city", "state", "country"]}/>, document.getElementById('grid-basic')
+        <Griddle results={fakeData} customTableRowComponent={CustomRow} useCustomTableRowComponent={true} columnMetadata={columnMeta} rowMetadata={rowMeta} tableClassName="table" showFilter={true} showSettings={true} columns={["name", "city", "state", "country"]}/>, document.getElementById('grid-basic')
     );
   </script>
   <script>

--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -83,7 +83,7 @@ var GridRow = React.createClass({
 
             if (this.props.columnSettings.hasColumnMetadata() && typeof meta !== "undefined"){
               var colData = (typeof meta.customComponent === 'undefined' || meta.customComponent === null) ? col[1] : <meta.customComponent data={col[1]} rowData={dataView} metadata={meta} />;
-              returnValue = (meta == null ? returnValue : <td onClick={this.props.hasChildren && this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{colData}</td>);
+              returnValue = (meta == null ? returnValue : <td onClick={this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{colData}</td>);
             }
 
             return returnValue || (<td onClick={this.handleClick} key={index} style={columnStyles}>{firstColAppend}{col[1]}</td>);

--- a/scripts/gridRowContainer.jsx
+++ b/scripts/gridRowContainer.jsx
@@ -2,7 +2,6 @@
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
 var React = require('react');
-var GridRow = require('./gridRow.jsx');
 var ColumnProperties = require('./columnProperties.js');
 
 var GridRowContainer = React.createClass({
@@ -48,11 +47,10 @@ var GridRowContainer = React.createClass({
     render: function(){
       this.verifyProps();
       var that = this;
-
       if(typeof this.props.data === "undefined"){return (<tbody></tbody>);}
       var arr = [];
 
-      arr.push(<GridRow useGriddleStyles={this.props.useGriddleStyles} isSubGriddle={this.props.isSubGriddle} data={this.props.data} columnSettings={this.props.columnSettings} rowSettings={this.props.rowSettings}
+      arr.push(<this.props.rowSettings.rowComponent useGriddleStyles={this.props.useGriddleStyles} isSubGriddle={this.props.isSubGriddle} data={this.props.data} columnSettings={this.props.columnSettings} rowSettings={this.props.rowSettings}
         hasChildren={that.props.hasChildren} toggleChildren={that.toggleChildren} showChildren={that.state.showChildren} key={that.props.uniqueId} useGriddleIcons={that.props.useGriddleIcons}
         parentRowExpandedClassName={this.props.parentRowExpandedClassName} parentRowCollapsedClassName={this.props.parentRowCollapsedClassName}
         parentRowExpandedComponent={this.props.parentRowExpandedComponent} parentRowCollapsedComponent={this.props.parentRowCollapsedComponent}

--- a/scripts/gridRowContainer.jsx
+++ b/scripts/gridRowContainer.jsx
@@ -50,12 +50,30 @@ var GridRowContainer = React.createClass({
       if(typeof this.props.data === "undefined"){return (<tbody></tbody>);}
       var arr = [];
 
-      arr.push(<this.props.rowSettings.rowComponent useGriddleStyles={this.props.useGriddleStyles} isSubGriddle={this.props.isSubGriddle} data={this.props.data} columnSettings={this.props.columnSettings} rowSettings={this.props.rowSettings}
-        hasChildren={that.props.hasChildren} toggleChildren={that.toggleChildren} showChildren={that.state.showChildren} key={that.props.uniqueId} useGriddleIcons={that.props.useGriddleIcons}
-        parentRowExpandedClassName={this.props.parentRowExpandedClassName} parentRowCollapsedClassName={this.props.parentRowCollapsedClassName}
-        parentRowExpandedComponent={this.props.parentRowExpandedComponent} parentRowCollapsedComponent={this.props.parentRowCollapsedComponent}
-        paddingHeight={that.props.paddingHeight} rowHeight={that.props.rowHeight} onRowClick={that.props.onRowClick} />);
-        var children = null;
+      var columns = this.props.columnSettings.getColumns();
+
+      arr.push(<this.props.rowSettings.rowComponent 
+        useGriddleStyles={this.props.useGriddleStyles}
+        isSubGriddle={this.props.isSubGriddle} 
+        data={this.props.rowSettings.isCustom ? _.pick(this.props.data, columns) : this.props.data}
+        rowData={this.props.rowSettings.isCustom ? this.props.data : null }
+        columnSettings={this.props.columnSettings}
+        rowSettings={this.props.rowSettings}
+        hasChildren={that.props.hasChildren}
+        toggleChildren={that.toggleChildren}
+        showChildren={that.state.showChildren}
+        key={that.props.uniqueId}
+        useGriddleIcons={that.props.useGriddleIcons}
+        parentRowExpandedClassName={this.props.parentRowExpandedClassName}
+        parentRowCollapsedClassName={this.props.parentRowCollapsedClassName}
+        parentRowExpandedComponent={this.props.parentRowExpandedComponent}
+        parentRowCollapsedComponent={this.props.parentRowCollapsedComponent}
+        paddingHeight={that.props.paddingHeight}
+        rowHeight={that.props.rowHeight}
+        onRowClick={that.props.onRowClick} />
+      );
+
+      var children = null;
 
       if(that.state.showChildren){
           children =  that.props.hasChildren && this.props.data["children"].map(function(row, index){

--- a/scripts/gridRowContainer.jsx
+++ b/scripts/gridRowContainer.jsx
@@ -90,7 +90,7 @@ var GridRowContainer = React.createClass({
                         </tr>);
               }
 
-              return <GridRow useGriddleStyles={that.props.useGriddleStyles} isSubGriddle={that.props.isSubGriddle} data={row} columnSettings={that.props.columnSettings} isChildRow={true} columnMetadata={that.props.columnMetadata} key={that.props.rowSettings.getRowKey(row)} />
+              return <that.props.rowSettings.rowComponent useGriddleStyles={that.props.useGriddleStyles} isSubGriddle={that.props.isSubGriddle} data={row} columnSettings={that.props.columnSettings} isChildRow={true} columnMetadata={that.props.columnMetadata} key={that.props.rowSettings.getRowKey(row)} />
           });
       }
 

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -266,12 +266,13 @@ var Griddle = React.createClass({
             this.props.columnMetadata,
             this.props.metadataColumns
         );
-        debugger;
+
         this.rowSettings = new RowProperties(
             this.props.rowMetadata,
             (this.props.useCustomTableRowComponent && this.props.customTableRowComponent) ?
                 this.props.customTableRowComponent :
-                GridRow
+                GridRow,
+            this.props.useCustomTableRowComponent
         );
 
         this.setMaxPage();

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -11,6 +11,7 @@ var GridFilter = require('./gridFilter.jsx');
 var GridPagination = require('./gridPagination.jsx');
 var GridSettings = require('./gridSettings.jsx');
 var GridNoData = require('./gridNoData.jsx');
+var GridRow = require('./gridRow.jsx');
 var CustomRowComponentContainer = require('./customRowComponentContainer.jsx');
 var CustomPaginationContainer = require('./customPaginationContainer.jsx');
 var ColumnProperties = require('./columnProperties');
@@ -265,9 +266,12 @@ var Griddle = React.createClass({
             this.props.columnMetadata,
             this.props.metadataColumns
         );
-
+        debugger;
         this.rowSettings = new RowProperties(
-            this.props.rowMetadata
+            this.props.rowMetadata,
+            (this.props.useCustomTableRowComponent && this.props.customTableRowComponent) ?
+                this.props.customTableRowComponent :
+                GridRow
         );
 
         this.setMaxPage();
@@ -334,7 +338,7 @@ var Griddle = React.createClass({
             if(this.state.sortColumn !== "" || this.props.initialSort !== ""){
                 var sortProperty = _.where(this.props.columnMetadata, {columnName: this.state.sortColumn});
                 sortProperty = (sortProperty.length > 0 && sortProperty[0].hasOwnProperty("sortProperty") && sortProperty[0]["sortProperty"]) || null
-                
+
                 data = _.sortBy(data, function(item){
                     return sortProperty ? item[that.state.sortColumn||that.props.initialSort][sortProperty] :
                         item[that.state.sortColumn||that.props.initialSort];

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -19,6 +19,13 @@ var RowProperties = require('./rowProperties');
 var _ = require('underscore');
 
 var Griddle = React.createClass({
+    statics: {
+        GridTable: GridTable,
+        GridFilter: GridFilter,
+        GridPagination: GridPagination,
+        GridSettings: GridSettings,
+        GridRow: GridRow
+    },
     columnSettings: null,
     rowSettings: null,
     getDefaultProps: function() {

--- a/scripts/rowProperties.js
+++ b/scripts/rowProperties.js
@@ -1,10 +1,10 @@
 var _ = require('underscore');
 
 class RowProperties{
-  constructor (rowMetadata={}, rowComponent=null) {
+  constructor (rowMetadata={}, rowComponent=null, isCustom=false) {
     this.rowMetadata = rowMetadata;
     this.rowComponent = rowComponent;
-    debugger;
+    this.isCustom = isCustom;
   }
 
   getRowKey(row) {

--- a/scripts/rowProperties.js
+++ b/scripts/rowProperties.js
@@ -1,8 +1,10 @@
 var _ = require('underscore');
 
 class RowProperties{
-  constructor (rowMetadata={}){
+  constructor (rowMetadata={}, rowComponent=null) {
     this.rowMetadata = rowMetadata;
+    this.rowComponent = rowComponent;
+    debugger;
   }
 
   getRowKey(row) {


### PR DESCRIPTION
This allows custom table rows to be created. Documentation still needs to be updated and it would likely be good to state that the names on the custom components will likely change before ver 1 is out (aka customRow and customTableRow components are kind of confusing names).

A rough example of a `customTableRowComponent` is as follows: 

``` 
   var CustomRow = React.createClass({
      getInitialState: function() {
        return { editToggled: false };
      },
      handleClick: function(e){
        this.setState({editToggled: !this.state.editToggled });
      },
      render: function(){
        if(this.state.editToggled){
          var cols = _.map(_.pairs(this.props.data), function(col, index){
            return <td><input type="text" defaultValue={col[1]} style={{width: "100%", height: "100%", color: "#CCC"}} />{index === _.pairs(this.props.data).length -1 ? 
              <button onClick={this.handleClick} style={{position: "absolute", right: 0}}>Done</button> : null}</td>
          }, this);
        }
        return this.state.editToggled ?
          <tr>{cols}</tr> :
          <Griddle.GridRow {...this.props} onRowClick={this.handleClick} />;
      }
    });
```