### PR TITLE
Add Griddle to bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,54 @@
+{
+  "name": "griddle-react",
+  "version": "0.2.14",
+  "homepage": "https://github.com/MMore/Griddle",
+  "authors": [
+    "Ryan Lanciaux"
+  ],
+  "description": "Griddle - A fast and flexible grid component for React.",
+  "main": "build/griddle.js",
+  "moduleType": [
+    "node"
+  ],
+  "keywords": [
+    "react-component",
+    "grid",
+    "react",
+    "pagination",
+    "sort"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "react": ">=0.12.0",
+    "underscore": ">= 1.6.0 < 2"
+  },
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-6to5": "^3.0.0",
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-connect": "^0.8.0",
+    "grunt-contrib-copy": "~0.7.0",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-include-replace": "~2.0.0",
+    "grunt-jsxhint": "^0.4.0",
+    "grunt-markdown": "~0.6.1",
+    "grunt-open": "^0.2.3",
+    "grunt-react": "~0.10.0",
+    "grunt-webpack": "~1.0.8",
+    "6to5-jest": "*",
+    "jest-cli": "*",
+    "jsx-loader": "~0.12.x",
+    "react-chartist": "~0.2.1",
+    "react-tools": "~0.12.x",
+    "underscore": "~1.6.0",
+    "webpack": "~1.3.3-beta1",
+    "webpack-dev-server": "~1.7.0"
+  },
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "griddle-react",
-  "version": "0.2.14",
-  "homepage": "https://github.com/MMore/Griddle",
+  "version": "0.2.13",
+  "homepage": "https://github.com/GriddleGriddle/Griddle",
   "authors": [
     "Ryan Lanciaux"
   ],


### PR DESCRIPTION
I added the `bower.json` file to just add it to bower. You have to register it afterwards as bower component. This allows people to integrate Griddle much easier when not using NPM.

For instance I will use it with [Rails Assets](https://rails-assets.org).