### PR TITLE
Adding nested property columns, fixing broken unit tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -93,7 +93,7 @@ module.exports = function(grunt) {
       },
       modules: {
         files: [
-          {expand: true, src: ['compiled/columnProperties.js', 'compiled/rowProperties.js', 'compiled/powerPick.js'], dest: 'modules', flatten: true}
+          {expand: true, src: ['compiled/columnProperties.js', 'compiled/rowProperties.js', 'compiled/deep.js'], dest: 'modules', flatten: true}
         ]
       }
     },

--- a/scripts/__tests__/gridRow-test.js
+++ b/scripts/__tests__/gridRow-test.js
@@ -2,7 +2,7 @@
 jest.dontMock('../gridRow.jsx');
 jest.dontMock('../columnProperties.js');
 jest.dontMock('../rowProperties.js');
-jest.dontMock('../powerPick.js');
+jest.dontMock('../deep.js');
 
 var React = require('react/addons');
 var _ = require('underscore'); 
@@ -15,8 +15,10 @@ var TestUtils = React.addons.TestUtils;
       {
         "id": 0,
         "name": "Mayer Leonard",
-        "city": "Kapowsin",
-        "state": "Hawaii",
+        "address": {
+          "city": "Kapowsin",
+          "state": "Hawaii"
+        },
         "country": "United Kingdom",
         "company": "Ovolo",
         "favoriteNumber": 7
@@ -24,8 +26,10 @@ var TestUtils = React.addons.TestUtils;
       {
         "id": 1,
         "name": "Koch Becker",
-        "city": "Johnsonburg",
-        "state": "New Jersey",
+        "address": {
+          "city": "Johnsonburg",
+          "state": "New Jersey"
+        },
         "country": "Madagascar",
         "company": "Eventage",
         "favoriteNumber": 2
@@ -36,8 +40,10 @@ var TestUtils = React.addons.TestUtils;
 	  {
 	    "id": 0,
 	    "name": "Mayer Leonard",
-	    "city": "Kapowsin",
-	    "state": "Hawaii",
+      "address": {
+        "city": "Kapowsin",
+        "state": "Hawaii"
+      },
 	    "country": "United Kingdom",
 	    "company": "Ovolo",
 	    "favoriteNumber": 7,
@@ -45,8 +51,10 @@ var TestUtils = React.addons.TestUtils;
 	        {
 	          "id": 273,
 	          "name": "Hull Wade",
-	          "city": "Monument",
-	          "state": "Nebraska",
+            "address": {
+              "city": "Monument",
+              "state": "Nebraska"
+            },
 	          "country": "Cyprus",
 	          "company": "Indexia",
 	          "favoriteNumber": 10,
@@ -54,8 +62,10 @@ var TestUtils = React.addons.TestUtils;
 	            {
 	              "id": 5,
 	              "name": "Ola Fernandez",
-	              "city": "Deltaville",
-	              "state": "Delaware",
+                "address": {
+                  "city": "Deltaville",
+                  "state": "Delaware"
+                },
 	              "country": "Virgin Islands (US)",
 	              "company": "Pawnagra",
 	              "favoriteNumber": 7
@@ -63,8 +73,10 @@ var TestUtils = React.addons.TestUtils;
 	            {
 	              "id": 6,
 	              "name": "Park Carr",
-	              "city": "Welda",
-	              "state": "Kentucky",
+                "address": {
+                  "city": "Welda",
+                  "state": "Kentucky"
+                },
 	              "country": "Sri Lanka",
 	              "company": "Cosmetex",
 	              "favoriteNumber": 7
@@ -72,8 +84,10 @@ var TestUtils = React.addons.TestUtils;
 	            {
 	              "id": 7,
 	              "name": "Laverne Johnson",
-	              "city": "Rosburg",
-	              "state": "New Mexico",
+                "address": {
+                  "city": "Rosburg",
+                  "state": "New Mexico"
+                },
 	              "country": "Croatia",
 	              "company": "Housedown",
 	              "favoriteNumber": 9
@@ -83,8 +97,10 @@ var TestUtils = React.addons.TestUtils;
 	        {
 	          "id": 274,
 	          "name": "Blanca Sheppard",
-	          "city": "Wadsworth",
-	          "state": "West Virginia",
+            "address": {
+              "city": "Wadsworth",
+              "state": "West Virginia"
+            },
 	          "country": "Nicaragua",
 	          "company": "Gogol",
 	          "favoriteNumber": 7
@@ -92,8 +108,10 @@ var TestUtils = React.addons.TestUtils;
 	        {
 	          "id": 275,
 	          "name": "Stella Luna",
-	          "city": "Dubois",
-	          "state": "Oregon",
+            "address": {
+              "city": "Dubois",
+              "state": "Oregon"
+            },
 	          "country": "Czech Republic",
 	          "company": "Intrawear",
 	          "favoriteNumber": 1
@@ -103,8 +121,10 @@ var TestUtils = React.addons.TestUtils;
 	  {
 	    "id": 1,
 	    "name": "Koch Becker",
-	    "city": "Johnsonburg",
-	    "state": "New Jersey",
+      "address": {
+        "city": "Johnsonburg",
+        "state": "New Jersey"
+      },
 	    "country": "Madagascar",
 	    "company": "Eventage",
 	    "favoriteNumber": 2,
@@ -112,8 +132,10 @@ var TestUtils = React.addons.TestUtils;
 	        {
 	          "id": 273,
 	          "name": "Hull Wade",
-	          "city": "Monument",
-	          "state": "Nebraska",
+            "address": {
+              "city": "Monument",
+              "state": "Nebraska"
+            },
 	          "country": "Cyprus",
 	          "company": "Indexia",
 	          "favoriteNumber": 10
@@ -121,8 +143,10 @@ var TestUtils = React.addons.TestUtils;
 	        {
 	          "id": 274,
 	          "name": "Blanca Sheppard",
-	          "city": "Wadsworth",
-	          "state": "West Virginia",
+            "address": {
+              "city": "Wadsworth",
+              "state": "West Virginia"
+            },
 	          "country": "Nicaragua",
 	          "company": "Gogol",
 	          "favoriteNumber": 7
@@ -130,8 +154,10 @@ var TestUtils = React.addons.TestUtils;
 	        {
 	          "id": 275,
 	          "name": "Stella Luna",
-	          "city": "Dubois",
-	          "state": "Oregon",
+            "address": {
+              "city": "Dubois",
+              "state": "Oregon"
+            },
 	          "country": "Czech Republic",
 	          "company": "Intrawear",
 	          "favoriteNumber": 1
@@ -141,8 +167,10 @@ var TestUtils = React.addons.TestUtils;
 	  {
 	    "id": 2,
 	    "name": "Lowery Hopkins",
-	    "city": "Blanco",
-	    "state": "Arizona",
+      "address": {
+        "city": "Blanco",
+        "state": "Arizona"
+      },
 	    "country": "Ukraine",
 	    "company": "Comtext",
 	    "favoriteNumber": 3,
@@ -150,8 +178,10 @@ var TestUtils = React.addons.TestUtils;
 	        {
 	          "id": 273,
 	          "name": "Hull Wade",
-	          "city": "Monument",
-	          "state": "Nebraska",
+            "address": {
+              "city": "Monument",
+              "state": "Nebraska"
+            },
 	          "country": "Cyprus",
 	          "company": "Indexia",
 	          "favoriteNumber": 10
@@ -159,8 +189,10 @@ var TestUtils = React.addons.TestUtils;
 	        {
 	          "id": 274,
 	          "name": "Blanca Sheppard",
-	          "city": "Wadsworth",
-	          "state": "West Virginia",
+            "address": {
+              "city": "Wadsworth",
+              "state": "West Virginia"
+            },
 	          "country": "Nicaragua",
 	          "company": "Gogol",
 	          "favoriteNumber": 7
@@ -168,8 +200,10 @@ var TestUtils = React.addons.TestUtils;
 	        {
 	          "id": 275,
 	          "name": "Stella Luna",
-	          "city": "Dubois",
-	          "state": "Oregon",
+            "address": {
+              "city": "Dubois",
+              "state": "Oregon"
+            },
 	          "country": "Czech Republic",
 	          "company": "Intrawear",
 	          "favoriteNumber": 1

--- a/scripts/__tests__/gridRow-test.js
+++ b/scripts/__tests__/gridRow-test.js
@@ -2,6 +2,7 @@
 jest.dontMock('../gridRow.jsx');
 jest.dontMock('../columnProperties.js');
 jest.dontMock('../rowProperties.js');
+jest.dontMock('../powerPick.js');
 
 var React = require('react/addons');
 var _ = require('underscore'); 

--- a/scripts/__tests__/griddle-test.js
+++ b/scripts/__tests__/griddle-test.js
@@ -1,7 +1,8 @@
 /** @jsx React.DOM */
 jest.dontMock('../griddle.jsx');
 jest.dontMock('../columnProperties.js'); 
-jest.dontMock('../rowProperties.js'); 
+jest.dontMock('../rowProperties.js');
+jest.dontMock('../powerPick.js');
 
 var React = require('react/addons');
 var Griddle = require('../griddle.jsx');
@@ -544,7 +545,7 @@ it('should not show footer when useCustomGridComponent is true', function(){
 
   it('should call the onRowClick callback when clicking a row', function () {
     var clicked = false;
-    var onRowClick = function onRowClick(){
+    var onRowClick = function(){
       clicked = true;
     };
     var grid2 = TestUtils.renderIntoDocument(<Griddle results={fakeData}

--- a/scripts/__tests__/griddle-test.js
+++ b/scripts/__tests__/griddle-test.js
@@ -2,7 +2,7 @@
 jest.dontMock('../griddle.jsx');
 jest.dontMock('../columnProperties.js'); 
 jest.dontMock('../rowProperties.js');
-jest.dontMock('../powerPick.js');
+jest.dontMock('../deep.js');
 
 var React = require('react/addons');
 var Griddle = require('../griddle.jsx');
@@ -35,8 +35,8 @@ describe('Griddle', function() {
       var thRow = TestUtils.scryRenderedDOMComponentsWithTag(rows[0], "th");
       expect(thRow[0].getDOMNode().textContent).toBe("id");
       expect(thRow[1].getDOMNode().textContent).toBe("name");
-      expect(thRow[2].getDOMNode().textContent).toBe("city");
-      expect(thRow[3].getDOMNode().textContent).toBe("state");
+      expect(thRow[2].getDOMNode().textContent).toBe("address.city");
+      expect(thRow[3].getDOMNode().textContent).toBe("address.state");
       expect(thRow[4].getDOMNode().textContent).toBe("country");
       expect(thRow[5].getDOMNode().textContent).toBe("company");
       expect(thRow[6].getDOMNode().textContent).toBe("favoriteNumber");
@@ -67,8 +67,10 @@ describe('Griddle', function() {
       {
         "id": 0,
         "name": "Mayer Leonard",
-        "city": "Kapowsin",
-        "state": "Hawaii",
+        "address": {
+          "city": "Kapowsin",
+          "state": "Hawaii"
+        },
         "country": "United Kingdom",
         "company": "Ovolo",
         "favoriteNumber": 7
@@ -76,8 +78,10 @@ describe('Griddle', function() {
       {
         "id": 1,
         "name": "Koch Becker",
-        "city": "Johnsonburg",
-        "state": "New Jersey",
+        "address": {
+          "city": "Johnsonburg",
+          "state": "New Jersey"
+        },
         "country": "Madagascar",
         "company": "Eventage",
         "favoriteNumber": 2
@@ -88,8 +92,10 @@ describe('Griddle', function() {
       {
         "id": 0,
         "name": "Mayer Leonard",
-        "city": "Kapowsin",
-        "state": "Hawaii",
+        "address": {
+          "city": "Kapowsin",
+          "state": "Hawaii"
+        },
         "country": "United Kingdom",
         "company": "Ovolo",
         "favoriteNumber": 7
@@ -97,8 +103,10 @@ describe('Griddle', function() {
       {
         "id": 1,
         "name": "Koch Becker",
-        "city": "Johnsonburg",
-        "state": "New Jersey",
+        "address": {
+          "city": "Johnsonburg",
+          "state": "New Jersey"
+        },
         "country": "Madagascar",
         "company": "Eventage",
         "favoriteNumber": 2
@@ -183,21 +191,21 @@ describe('Griddle', function() {
     expect(7).toEqual(cols.length);
     expect(cols[0]).toEqual('id');
     expect(cols[1]).toEqual('name');
-    expect(cols[2]).toEqual('city');
-    expect(cols[3]).toEqual('state');
+    expect(cols[2]).toEqual('address.city');
+    expect(cols[3]).toEqual('address.state');
     expect(cols[4]).toEqual('country');
     expect(cols[5]).toEqual('company');
     expect(cols[6]).toEqual('favoriteNumber');
   });
 
   it('shows only the specified columns', function(){
-    var cols = ["id", "name", "city"];
+    var cols = ["id", "name", "address.city"];
     grid.setColumns(cols);
     var cols2 = grid.columnSettings.getColumns();
     expect(cols2.length).toEqual(cols.length);
     expect(cols2[0]).toEqual('id');
     expect(cols2[1]).toEqual('name');
-    expect(cols2[2]).toEqual('city');
+    expect(cols2[2]).toEqual('address.city');
   });
 
   it('sets next page correctly', function(){
@@ -235,16 +243,16 @@ describe('Griddle', function() {
 
   it('sets sort filter correctly', function(){
     expect(grid.state.sortColumn).toEqual("");
-    grid.changeSort("name");
-    expect(grid.state.sortColumn).toEqual("name");
+    grid.changeSort("address.state");
+    expect(grid.state.sortColumn).toEqual("address.state");
   });
 
   it('sets sort direction correctly', function(){
     expect(grid.state.sortColumn).toEqual("");
-    grid.changeSort("name");
-    expect(grid.state.sortColumn).toEqual("name");
+    grid.changeSort("address.state");
+    expect(grid.state.sortColumn).toEqual("address.state");
     expect(grid.state.sortAscending).toEqual(true);
-    grid.changeSort("name");
+    grid.changeSort("address.state");
     expect(grid.state.sortAscending).toEqual(false);
   });
 

--- a/scripts/deep.js
+++ b/scripts/deep.js
@@ -43,10 +43,9 @@ function getPath (obj, ks) {
   return i === length ? obj : void 0;
 }
 
-
 // Based on the origin underscore _.pick function
 // Credit: https://github.com/jashkenas/underscore/blob/master/underscore.js
-module.exports = function(object, keys) {
+function powerPick (object, keys) {
   var result = {}, obj = object, iteratee;
   iteratee = function(key, obj) { return key in obj; };
 
@@ -57,5 +56,44 @@ module.exports = function(object, keys) {
     if (iteratee(key, obj)) result[key] = getPath(obj, key);
   }
 
-  return result;  
+  return result;
+}
+
+// Gets all the keys for a flattened object structure.
+// Doesn't flatten arrays.
+// Input:
+// {
+//  a: {
+//    x: 1,
+//    y: 2
+//  },
+//  b: [3, 4],
+//  c: 5
+// }
+// Output:
+// [
+//  "a.x",
+//  "a.y",
+//  "b",
+//  "c"
+// ]
+function getKeys (obj, prefix) {
+  var keys = [];
+
+  _.each( obj, function(value, key) {
+    var fullKey = prefix ? prefix + "." + key : key;
+    if(_.isObject(value) && !_.isArray(value) && !_.isFunction(value)) {
+      keys = keys.concat( getKeys(value, fullKey) );
+    } else {
+      keys.push(fullKey);
+    }
+  });
+
+  return keys;
+}
+
+module.exports = {
+  pick: powerPick,
+  getAt: getPath,
+  keys: getKeys
 };

--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -4,7 +4,7 @@
 var React = require('react');
 var _ = require('underscore');
 var ColumnProperties = require('./columnProperties.js');
-var powerPick = require('./powerPick.js');
+var deep = require('./deep.js');
 
 var GridRow = React.createClass({
     getDefaultProps: function(){
@@ -80,7 +80,7 @@ var GridRow = React.createClass({
 
         _.defaults(dataView, defaults);
 
-        var data = _.pairs(powerPick(dataView, columns));
+        var data = _.pairs(deep.pick(dataView, columns));
 
         var nodes = data.map((col, index) => {
             var returnValue = null;

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -16,6 +16,7 @@ var CustomRowComponentContainer = require('./customRowComponentContainer.jsx');
 var CustomPaginationContainer = require('./customPaginationContainer.jsx');
 var ColumnProperties = require('./columnProperties');
 var RowProperties = require('./rowProperties');
+var deep = require('./deep');
 var _ = require('underscore');
 
 var Griddle = React.createClass({
@@ -134,9 +135,9 @@ var Griddle = React.createClass({
         // Obtain the state results.
        updatedState.filteredResults = _.filter(this.props.results,
        function(item) {
-            var arr = _.values(item);
+            var arr = deep.keys(item);
             for(var i = 0; i < arr.length; i++){
-               if ((arr[i]||"").toString().toLowerCase().indexOf(filter.toLowerCase()) >= 0){
+               if ((deep.getAt(item, arr[i])||"").toString().toLowerCase().indexOf(filter.toLowerCase()) >= 0){
                 return true;
                }
             }
@@ -275,6 +276,7 @@ var Griddle = React.createClass({
             this.columnSettings.filteredColumns = nextProps.columns;
         }
 
+
         if(nextProps.selectedRowIds) {
             var visibleRows = this.getDataForRender(this.getCurrentResults(), this.columnSettings.getColumns(), true);
 
@@ -305,7 +307,7 @@ var Griddle = React.createClass({
         this.verifyCustom();
 
         this.columnSettings = new ColumnProperties(
-            this.props.results.length > 0 ? _.keys(this.props.results[0]) : [],
+            this.props.results.length > 0 ? deep.keys(this.props.results[0]) : [],
             this.props.columns,
             this.props.childrenColumnName,
             this.props.columnMetadata,
@@ -383,11 +385,11 @@ var Griddle = React.createClass({
             //get the correct page size
             if(this.state.sortColumn !== "" || this.props.initialSort !== ""){
                 var sortProperty = _.where(this.props.columnMetadata, {columnName: this.state.sortColumn});
-                sortProperty = (sortProperty.length > 0 && sortProperty[0].hasOwnProperty("sortProperty") && sortProperty[0]["sortProperty"]) || null
+                sortProperty = (sortProperty.length > 0 && sortProperty[0].hasOwnProperty("sortProperty") && sortProperty[0]["sortProperty"]) || null;
 
                 data = _.sortBy(data, function(item){
-                    return sortProperty ? item[that.state.sortColumn||that.props.initialSort][sortProperty] :
-                        item[that.state.sortColumn||that.props.initialSort];
+                    return sortProperty ? deep.getAt( item, that.state.sortColumn||that.props.initialSort )[sortProperty] :
+                        deep.getAt( item, that.state.sortColumn||that.props.initialSort );
                 });
 
                 if(this.state.sortAscending === false){
@@ -734,7 +736,7 @@ var Griddle = React.createClass({
         var meta = this.columnSettings.getMetadataColumns();
 
         // Grab the column keys from the first results
-        keys = _.keys(_.omit(results[0], meta));
+        keys = deep.keys(_.omit(results[0], meta));
 
         // sort keys by order
         keys = this.columnSettings.orderColumns(keys);


### PR DESCRIPTION
This change allows griddle to access nested object properties as columns and refer to those columns in the columnMetaData.  

`{
  prop1: 1212,
  prop2: {
    nestedProp1: "something",
    nestedProp2:  "other thing"
  }
}`