### PR TITLE
Added gridMetadata

### DIFF
--- a/build/griddle.js
+++ b/build/griddle.js
@@ -63,6 +63,8 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	"use strict";
 
+	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 	/*
 	   Griddle - Simple Grid Component for React
 	   https://github.com/DynamicTyped/Griddle
@@ -98,6 +100,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    getDefaultProps: function () {
 	        return {
 	            columns: [],
+	            gridMetadata: null,
 	            columnMetadata: [],
 	            rowMetadata: null,
 	            resultsPerPage: 5,
@@ -167,6 +170,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            /* icon components */
 	            sortAscendingComponent: " ▲",
 	            sortDescendingComponent: " ▼",
+	            sortDefaultComponent: null,
 	            parentRowCollapsedComponent: "▶",
 	            parentRowExpandedComponent: "▼",
 	            settingsIconComponent: "",
@@ -345,6 +349,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            this.columnSettings.filteredColumns = nextProps.columns;
 	        }
 
+
 	        if (nextProps.selectedRowIds) {
 	            var visibleRows = this.getDataForRender(this.getCurrentResults(), this.columnSettings.getColumns(), true);
 
@@ -510,7 +515,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	            sortAscendingClassName: this.props.sortAscendingClassName,
 	            sortDescendingClassName: this.props.sortDescendingClassName,
 	            sortAscendingComponent: this.props.sortAscendingComponent,
-	            sortDescendingComponent: this.props.sortDescendingComponent
+	            sortDescendingComponent: this.props.sortDescendingComponent,
+	            sortDefaultComponent: this.props.sortDefaultComponent
 	        };
 	    },
 	    _toggleSelectAll: function () {
@@ -695,7 +701,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            useGriddleStyles: this.props.useGriddleStyles, enableCustomFormatText: this.props.enableCustomFormatText, columnMetadata: this.props.columnMetadata }) : "";
 	    },
 	    getCustomGridSection: function () {
-	        return React.createElement(this.props.customGridComponent, { data: this.props.results, className: this.props.customGridComponentClassName });
+	        return React.createElement(this.props.customGridComponent, _extends({ data: this.props.results, className: this.props.customGridComponentClassName }, this.props.gridMetadata));
 	    },
 	    getCustomRowSection: function (data, cols, meta, pagingContent) {
 	        return React.createElement(
@@ -1149,7 +1155,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  _.each(obj, function (value, key) {
 	    var fullKey = prefix ? prefix + "." + key : key;
 	    if (_.isObject(value) && !_.isArray(value) && !_.isFunction(value)) {
-	      keys.push(getKeys(obj[key], fullKey));
+	      keys = keys.concat(getKeys(value, fullKey));
 	    } else {
 	      keys.push(fullKey);
 	    }
@@ -2124,7 +2130,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	        var nodes = this.props.columnSettings.getColumns().map(function (col, index) {
 	            var columnSort = "";
-	            var sortComponent = null;
+	            var sortComponent = that.props.sortSettings.sortDefaultComponent;
 
 	            if (that.props.sortSettings.sortColumn == col && that.props.sortSettings.sortAscending) {
 	                columnSort = that.props.sortSettings.sortAscendingClassName;

--- a/examples/customization/testChart.html
+++ b/examples/customization/testChart.html
@@ -30,6 +30,7 @@ var data = [
 
 var TestLineChart = React.createClass({
   render: function(){
+    var type = this.props.type || 'Line'
     var simpleLineChartData = {
       labels: _.keys(this.props.data[0]),
       series: []
@@ -38,10 +39,10 @@ var TestLineChart = React.createClass({
     _.each(this.props.data, function(item){
       simpleLineChartData.series.push(_.values(item));
     });
-    
-    return <ChartistGraph data={simpleLineChartData} type={'Line'} />
+
+    return <ChartistGraph data={simpleLineChartData} type={type} />
   }
 });
 
-React.render(<Griddle enableToggleCustom={true} showSettings={true} results={data} useCustomGridComponent={true} customGridComponent={TestLineChart} tableClassName="table"/>, document.getElementById('grid-chart'));
+React.render(<Griddle enableToggleCustom={true} showSettings={true} results={data} useCustomGridComponent={true} customGridComponent={TestLineChart} tableClassName="table" gridMetadata={{type: 'Bar'}}/>, document.getElementById('grid-chart'));
 </script>

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -32,6 +32,7 @@ var Griddle = React.createClass({
     getDefaultProps: function() {
         return{
             "columns": [],
+            "gridMetadata": null,
             "columnMetadata": [],
             "rowMetadata": null,
             "resultsPerPage":5,
@@ -649,7 +650,7 @@ var Griddle = React.createClass({
         ) : "";
     },
     getCustomGridSection: function(){
-        return <this.props.customGridComponent data={this.props.results} className={this.props.customGridComponentClassName} />
+        return <this.props.customGridComponent data={this.props.results} className={this.props.customGridComponentClassName} {... this.props.gridMetadata} />
     },
     getCustomRowSection: function(data, cols, meta, pagingContent){
         return <div><CustomRowComponentContainer data={data} columns={cols} metadataColumns={meta}

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -650,7 +650,7 @@ var Griddle = React.createClass({
         ) : "";
     },
     getCustomGridSection: function(){
-        return <this.props.customGridComponent data={this.props.results} className={this.props.customGridComponentClassName} {... this.props.gridMetadata} />
+        return <this.props.customGridComponent data={this.props.results} className={this.props.customGridComponentClassName} {...this.props.gridMetadata} />
     },
     getCustomRowSection: function(data, cols, meta, pagingContent){
         return <div><CustomRowComponentContainer data={data} columns={cols} metadataColumns={meta}


### PR DESCRIPTION
@ryanlanciaux  I understood discussion about duplicate functionality but the griddle-react package in npm needs this, like me right now. 

This is a very simple implementation, you pass all the data throw ```gridMetadata``` to the custom grid component. The only concern I have is about passing ```data``` or ```className``` because I didn't pass the metadata throw some scope like ```gridData``` just because I didn't like to create a extra scope for avoid these mistake, however, this is easy to change and depend of you.

About unit testing, you are using ```jest```, jest using ```iojs``` instead of node. I could't get it run properly. 
My suggestion is try to choose stack that people know, the big problem with JS is that one, too many packages with the same objective and I can't deal with everything, even was ```iojs``` problems which I have no idea what is the different from nodejs or even if I have to create a new environment for him because I can get node conflicts. I hope you understand my point

Related to https://github.com/GriddleGriddle/Griddle/issues/198