### PR TITLE
Fix invariant violation by showPager

### DIFF
--- a/scripts/gridTable.jsx
+++ b/scripts/gridTable.jsx
@@ -233,7 +233,7 @@ var GridTable = React.createClass({
       nodes = <tbody>{nodes}</tbody>
     }
 
-    var pagingContent = "";
+    var pagingContent = <tbody />;
     if(this.props.showPager){
       var pagingStyles = this.props.useGriddleStyles ?
         {


### PR DESCRIPTION
If showPager fluxes between true and false, having `var pagingContent = ""` (which is equal to `var pagingContent = <span />;`) results in invariant violation (at least in Chrome). Change it to `<tbody />` solves all problems for me.