### PR TITLE
Updating customization.md document to include information about custom column component metadata

### DIFF
--- a/docs/src/markdown/customization.md
+++ b/docs/src/markdown/customization.md
@@ -18,7 +18,7 @@ Use the `columns` property to set the default columns in a Griddle grid. Please 
 
 The column meta data property is used to specify column properties that are not part of the result data object. For instance, if you want to specify a displayName that is different than the property name in the result data, the `columnMetadata` property is where this would be defined. 
 
-The properties that the columnMetadata object can contain are as follows: 
+Griddle parses and evaluates the following columnMetadata object properties:
 
 <dl>
   <dt>columnName</dt>
@@ -48,6 +48,10 @@ The properties that the columnMetadata object can contain are as follows:
   <dt>customComponent</dt>
   <dd><strong>React Component</strong> - The component that should be rendered instead of the standard column data. This component will still be rendered inside of a `TD` element. (more information below in the [Custom Columns section](#customColumns).)</dd>
 </dl>
+
+However, you are also able to pass other properties in as columnMetadata. 
+
+[columnMetadata can be accessed on the `metadata` property of a Custom Column component.](#custom-columns)
 
 #####Example:#####
 
@@ -110,7 +114,7 @@ React.render(
 <a name="customColumns"></a>
 ###Custom Columns###
 
-Custom column components are defined in the [Column Metadata object](#). The components are passed **data** and **rowData** properties.
+Custom column components are defined in the [Column Metadata object](#). The components are passed **data**, **rowData**, **metadata** properties.
 
 <dl>
   <dt>data</dt>
@@ -120,6 +124,11 @@ Custom column components are defined in the [Column Metadata object](#). The com
 <dl>
   <dt>rowData</dt>
   <dd><strong>object</strong> - the data for all items in the same row</dd>
+</dl>
+
+<dl>
+  <dt>metadata</dt>
+  <dd><strong>object</strong> - The columnMetadata object</dd>
 </dl>
 
 #####Example:#####


### PR DESCRIPTION
To Whomever it May Concern,

First wanted to start off by saying thank you for building this awesome plugin!

I am building a Flux app using Alt, and needed a way to pass an actions object down to a column custom component as a prop. After further examining the source code, I noticed that the `metadata` property is being passed down to the component, and the action can be specified in the `customColumnMetadata` object.

However, the documentation did not mention any of these things. This PR updates the docs to better reflect this information. Please let me know if I need to change anything.


This is related to [this issue](https://github.com/GriddleGriddle/Griddle/issues/225)