### PR TITLE
lock jest cli to version 0.4.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "grunt-react": "~0.10.0",
     "grunt-webpack": "~1.0.8",
     "6to5-jest": "*",
-    "jest-cli": "*",
+    "jest-cli": "~0.4.19",
     "jsx-loader": "~0.12.x",
     "react-chartist": "~0.2.1",
     "react-tools": "~0.12.x",


### PR DESCRIPTION
 allow jest to run since 0.5.x supports iojs v2 and higher