### PR TITLE
fix rows to expand sub grids to handle touch events for mobile browsers

### DIFF
--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -6,6 +6,8 @@ var _ = require('underscore');
 var ColumnProperties = require('./columnProperties.js');
 var deep = require('./deep.js');
 
+React.initializeTouchEvents(true);
+
 var GridRow = React.createClass({
     getDefaultProps: function(){
       return {
@@ -98,10 +100,10 @@ var GridRow = React.createClass({
 
             if (this.props.columnSettings.hasColumnMetadata() && typeof meta !== "undefined"){
               var colData = (typeof meta.customComponent === 'undefined' || meta.customComponent === null) ? col[1] : <meta.customComponent data={col[1]} rowData={dataView} metadata={meta} />;
-              returnValue = (meta == null ? returnValue : <td onClick={this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{colData}</td>);
+              returnValue = (meta == null ? returnValue : <td onClick={this.handleClick} onTouchEnd={this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{colData}</td>);
             }
 
-            return returnValue || (<td onClick={this.handleClick} key={index} style={columnStyles}>{firstColAppend}{col[1]}</td>);
+            return returnValue || (<td onClick={this.handleClick} onTouchEnd={this.handleClick} key={index} style={columnStyles}>{firstColAppend}{col[1]}</td>);
         });
 
 		if(nodes && this.props.multipleSelectionSettings && this.props.multipleSelectionSettings.isMultipleSelection) {


### PR DESCRIPTION
Issue found in iPad 2, iPad Air. I’m sure other mobile devices that
their browsers support touch events would have this issue
