### PR TITLE
React 0.14 compatibility fixes

### DIFF
--- a/scripts/gridTable.jsx
+++ b/scripts/gridTable.jsx
@@ -56,7 +56,7 @@ var GridTable = React.createClass({
   gridScroll: function(){
     if (this.props.enableInfiniteScroll && !this.props.externalIsLoading) {
       // If the scroll height is greater than the current amount of rows displayed, update the page.
-      var scrollable = this.refs.scrollable.getDOMNode();
+      var scrollable = this.refs.scrollable;
       var scrollTop = scrollable.scrollTop
       var scrollHeight = scrollable.scrollHeight;
       var clientHeight = scrollable.clientHeight;

--- a/scripts/gridTable.jsx
+++ b/scripts/gridTable.jsx
@@ -26,7 +26,6 @@ var GridTable = React.createClass({
       "rowHeight": null,
       "infiniteScrollLoadTreshold": null,
       "bodyHeight": null,
-      "tableHeading": "",
       "useGriddleStyles": true,
       "useGriddleIcons": true,
       "isSubGriddle": false,
@@ -226,7 +225,7 @@ var GridTable = React.createClass({
 		  multipleSelectionSettings={this.props.multipleSelectionSettings}
           columnSettings={this.props.columnSettings}
           rowSettings={this.props.rowSettings}/>
-        : "");
+      : undefined);
 
     //check to see if any of the rows have children... if they don't wrap everything in a tbody so the browser doesn't auto do this
     if (!anyHasChildren){

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -645,7 +645,7 @@ var Griddle = React.createClass({
     },
     getPagingSection: function(currentPage, maxPage){
         if ((this.props.showPager && !this.isInfiniteScrollEnabled() && !this.props.useCustomGridComponent) === false) {
-            return "";
+            return undefined;
         }
 
         return (


### PR DESCRIPTION
This fixes the following issue with React 0.14:

```
Warning: validateDOMNesting(...): <span> cannot appear as a child of <table>. See Griddle > GridTable > table > span.
```

Also removes the unused "tableHeading" prop from GridTable.