### PR TITLE
Remove jest-cli from before_install (global) and use `npm test` instead of jest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 node_js:
   - '0.10'
 before_install:
-  - 'npm install -g grunt-cli jest-cli'
+  - 'npm install -g grunt-cli'
 install:
   - 'npm install'
 script:
   - grunt build
-  - jest
+  - npm test


### PR DESCRIPTION
Travis CI `before_install` uses `npm install -g grunt-cli jest-cli` which is installing `jest-cli@0.7.0 `.

Travis CI build will fail current tests with`jest-cli@0.7.0`.
```
$ jest
/home/travis/.nvm/v0.10.40/lib/node_modules/jest-cli/bin/jest.js:12
const fs = require('fs');
^^^^^
SyntaxError: Use of const in strict mode.
```
To make it consistent, we should just `npm test` and use jest from package.json instead of using jest-cli installed from `npm install -g  jest-cl`.

See Travis CI build error here -  https://travis-ci.org/GriddleGriddle/Griddle/builds/89018241