### PR TITLE
Migrate away from Jest to Karma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: node_js
 node_js:
-  - '4.2.2'
+  - '5'
+  - '4.2'
+  - '4.1'
+  - '0.12'
+  - '0.10'
 before_install:
   - 'npm install -g grunt-cli'
 install:
   - 'npm install'
 script:
   - grunt build
-  - npm test
+  - npm run test-single

--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -1,7 +1,0 @@
-var ReactTools = require('react-tools');
-
-module.exports = {
-  process: function(src) {
-    return ReactTools.transform(src);
-  }
-};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,52 @@
+'use strict';
+
+module.exports = function(config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine'],
+    files: [
+      './node_modules/phantomjs-polyfill/bind-polyfill.js',
+      './scripts/__tests__/**/*.js'
+    ],
+    exclude: [
+      'node_modules/**.*.js'
+    ],
+    preprocessors: {
+      './js/**/*.js': ['webpack'],
+      './scripts/__tests__/**/*.js': ['webpack']
+    },
+
+    webpack: {
+      resolve: {
+        extensions: ['', '.js', '.jsx']
+      },
+      module: {
+        loaders: [
+          {
+            test: /\.jsx?$/,
+            loader: 'babel-loader',
+            exclude: /node_modules/
+          }
+        ]
+      },
+      plugins: [
+      ]
+    },
+
+    reporters: ['progress'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['PhantomJS', 'Chrome'],
+    singleRun: false,
+
+    plugins: [
+      'karma-jasmine',
+      'karma-webpack',
+      'karma-babel-preprocessor',
+      'karma-phantomjs-launcher',
+      'karma-chrome-launcher'
+    ]
+  });
+};

--- a/package.json
+++ b/package.json
@@ -28,18 +28,26 @@
     "grunt-markdown": "~0.6.1",
     "grunt-open": "^0.2.3",
     "grunt-webpack": "^1.0.11",
+    "jasmine-core": "^2.3.4",
+    "karma": "^0.13.15",
+    "karma-babel-preprocessor": "^6.0.1",
+    "karma-chrome-launcher": "^0.2.1",
+    "karma-jasmine": "^0.3.6",
+    "karma-phantomjs-launcher": "^0.2.1",
+    "karma-webpack": "^1.7.0",
+    "phantomjs": "^1.9.18",
+    "phantomjs-polyfill": "0.0.1",
     "react": "^0.14.3",
-    "jest-cli": "0.7.1",
     "react-addons-test-utils": "0.14.3",
     "react-chartist": "~0.2.1",
     "react-dom": "0.14.3",
-    "react-tools": "~0.12.x",
     "underscore": "~1.6.0",
     "webpack": "1.12.3",
     "webpack-dev-server": "1.12.1"
   },
   "scripts": {
-    "test": "jest"
+    "test": "karma start --browsers PhantomJS",
+    "test-single": "karma start --singleRun true --browsers PhantomJS"
   },
   "repository": {
     "type": "git",
@@ -49,18 +57,6 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/GriddleGriddle/Griddle/issues"
-  },
-  "jest": {
-    "rootDir": "scripts",
-    "testFileExtensions": ["es6", "js"],
-    "moduleFileExtensions": ["js", "json", "es6"],
-    "scriptPreprocessor": "../node_modules/babel-jest",
-    "unmockedModulePathPatterns": [
-      "react",
-      "react-dom",
-      "react-addons-test-utils",
-      "fbjs"
-    ]
   },
   "homepage": "https://github.com/GriddleGriddle/Griddle"
 }

--- a/scripts/__tests__/gridFilter-test.js
+++ b/scripts/__tests__/gridFilter-test.js
@@ -1,5 +1,3 @@
-jest.dontMock('../gridFilter.jsx');
-
 var React = require('react');
 var TestUtils = require('react-addons-test-utils');
 var GridFilter = require('../gridFilter.jsx');
@@ -7,7 +5,7 @@ var GridFilter = require('../gridFilter.jsx');
 describe('GridFilter', function(){
 
 	it('calls change filter when clicked', function(){
-		var mock = jest.genMockFunction(); 
+		var mock = jasmine.createSpy(); 
 		var filter = TestUtils.renderIntoDocument(<GridFilter changeFilter={mock}/>);
 
 		var someEvent = {
@@ -19,6 +17,6 @@ describe('GridFilter', function(){
 		var input = TestUtils.findRenderedDOMComponentWithTag(filter, 'input');		
 		TestUtils.Simulate.change(input, someEvent);
 
-		expect(mock.mock.calls).toEqual([["hi"]]);
+		expect(mock.calls.argsFor(0)).toEqual(["hi"]);
 	})
 });

--- a/scripts/__tests__/gridPagination-test.js
+++ b/scripts/__tests__/gridPagination-test.js
@@ -1,12 +1,10 @@
-jest.dontMock('../gridPagination.jsx');
-
 var React = require('react');
 var GridPagination = require('../gridPagination.jsx');
 var TestUtils = require('react-addons-test-utils');
 
 describe('GridPagination', function(){
 	it('calls change filter when clicked', function(){
-		var mock = jest.genMockFunction(); 
+		var mock = jasmine.createSpy(); 
 		var pagination = TestUtils.renderIntoDocument(<GridPagination setPage={mock}/>);
 
 		var someEvent = {
@@ -18,6 +16,6 @@ describe('GridPagination', function(){
 		var input = TestUtils.findRenderedDOMComponentWithTag(pagination, 'select');		
 		TestUtils.Simulate.change(input, someEvent);
 
-		expect(mock.mock.calls).toEqual([[2]]);
+		expect(mock.calls.argsFor(0)).toEqual([2]);
 	})
 });

--- a/scripts/__tests__/gridRow-test.js
+++ b/scripts/__tests__/gridRow-test.js
@@ -1,8 +1,3 @@
-jest.dontMock('../gridRow.jsx');
-jest.dontMock('../columnProperties.js');
-jest.dontMock('../rowProperties.js');
-jest.dontMock('../deep.js');
-
 var _ = require('underscore'); 
 var React = require('react');
 var GridRow = require('../gridRow.jsx');
@@ -230,7 +225,7 @@ describe('GridRow', function(){
       getIsRowChecked: function(){}
 		};
 
-		var mock = jest.genMockFunction();
+		var mock = jasmine.createSpy();
 
     const FakeTable = React.createClass({
       render() {
@@ -249,7 +244,7 @@ describe('GridRow', function(){
 	  var row = TestUtils.renderIntoDocument(<FakeTable />);
 		expect(TestUtils.isCompositeComponent(row)).toBe(true);
 
-		expect(mock.mock.calls.length).toEqual(0);
+		expect(mock.calls.count()).toEqual(0);
 		var tr = TestUtils.findRenderedDOMComponentWithTag(row, 'tr');
 		expect(tr.length).not.toBe(null);
 
@@ -260,7 +255,7 @@ describe('GridRow', function(){
 
 		TestUtils.Simulate.click(first);
 
-		expect(mock.mock.calls.length).toEqual(0);
+		expect(mock.calls.count()).toEqual(0);
 	})
 
 
@@ -282,7 +277,7 @@ describe('GridRow', function(){
       getIsRowChecked: function(){}
 		};
 
-		var mock = jest.genMockFunction();
+		var mock = jasmine.createSpy();
 
     const FakeTable = React.createClass({
       render() {
@@ -301,7 +296,7 @@ describe('GridRow', function(){
 	  const row2 = TestUtils.renderIntoDocument(<FakeTable />);
 	  expect(TestUtils.isCompositeComponent(row2)).toBe(true);
 
-		expect(mock.mock.calls.length).toEqual(0);
+		expect(mock.calls.count()).toEqual(0);
 		var tr = TestUtils.findRenderedDOMComponentWithTag(row2, 'tr');
 		expect(tr.length).not.toBe(null);
 		var td = TestUtils.scryRenderedDOMComponentsWithTag(row2, 'td');
@@ -311,6 +306,6 @@ describe('GridRow', function(){
 
 		TestUtils.Simulate.click(first);
 
-		expect(mock.mock.calls.length).toEqual(1);
+		expect(mock.calls.count()).toEqual(1);
 	})
 });

--- a/scripts/__tests__/gridSettings-test.js
+++ b/scripts/__tests__/gridSettings-test.js
@@ -1,5 +1,3 @@
-jest.dontMock('../gridSettings.jsx');
-
 var React = require('react');
 var GridSettings = require('../gridSettings.jsx');
 var TestUtils = require('react-addons-test-utils');
@@ -8,7 +6,7 @@ describe('GridSettings', function() {
 
 	it('calls method when page sizing', function(){
 		var columns = ["one", "two", "three"];
-		var mock = jest.genMockFunction();
+		var mock = jasmine.createSpy();
 		var settings = TestUtils.renderIntoDocument(<GridSettings columns={columns} setPageSize={mock} />);
 
 		var someEvent = {
@@ -18,6 +16,6 @@ describe('GridSettings', function() {
 		};
 
 		settings.setPageSize(someEvent); 
-		expect(mock.mock.calls).toEqual([[3]]);
+		expect(mock.calls.argsFor(0)).toEqual([3]);
 	});
 });

--- a/scripts/__tests__/gridTitle-test.js
+++ b/scripts/__tests__/gridTitle-test.js
@@ -1,6 +1,3 @@
-jest.dontMock('../gridTitle.jsx');
-jest.dontMock('../columnProperties.js');
-
 var React = require('react');
 var GridTitle = require('../gridTitle.jsx');
 var TestUtils = require('react-addons-test-utils');

--- a/scripts/__tests__/griddle-test.js
+++ b/scripts/__tests__/griddle-test.js
@@ -1,8 +1,3 @@
-jest.dontMock('../griddle.jsx');
-jest.dontMock('../columnProperties.js'); 
-jest.dontMock('../rowProperties.js');
-jest.dontMock('../deep.js');
-
 var React = require('react');
 var Griddle = require('../griddle.jsx');
 var TestUtils = require('react-addons-test-utils');
@@ -131,21 +126,21 @@ describe('Griddle', function() {
   });
 
   it('calls the customFilterer for filtering if specified, with results and filter query', function(){
-    var customFilterer = jest.genMockFunction();
+    var customFilterer = jasmine.createSpy();
     var grid2 = TestUtils.renderIntoDocument(<Griddle results={fakeData} gridClassName="test" useCustomFilterer={true} customFilterer={customFilterer} />);
 
     grid2.setFilter('Mayer');
 
-    expect(customFilterer.mock.calls.length).toEqual(1);
-    expect(customFilterer.mock.calls[0]).toEqual([fakeData, 'Mayer']);
+    expect(customFilterer.calls.count()).toEqual(1);
+    expect(customFilterer.calls.argsFor(0)).toEqual([fakeData, 'Mayer']);
   });
 
   it('sets the results from the customFilterer, to the grid', function(){
-    var customFilterer = jest.genMockFunction();
+    var customFilterer = jasmine.createSpy();
     var empty = [];
     var grid2 = TestUtils.renderIntoDocument(<Griddle results={empty} gridClassName="test" useCustomFilterer={true} customFilterer={customFilterer} />);
 
-    customFilterer.mockReturnValue(fakeData)
+    customFilterer.and.returnValue(fakeData)
 
     grid2.setFilter('Mayer');
 
@@ -284,7 +279,7 @@ describe('Griddle', function() {
   });
 
   it('calls external sort function when clicked and useExternal is true', function(){
-      var mock = jest.genMockFunction();
+      var mock = jasmine.createSpy();
       var grid2 = TestUtils.renderIntoDocument(<Griddle externalResults={fakeData}
           results={fakeData2}
           useExternal={true}
@@ -295,11 +290,11 @@ describe('Griddle', function() {
       var thRow = TestUtils.scryRenderedDOMComponentsWithTag(grid2, 'th')
 
       TestUtils.Simulate.click(thRow[0].getDOMNode(), {target: {dataset: { title: "Test"}}});
-      expect(mock.mock.calls.length).toEqual(1);
+      expect(mock.calls.count()).toEqual(1);
   });
 
   it('does not call external sort function when useExternal is false', function(){
-          var mock = jest.genMockFunction();
+      var mock = jasmine.createSpy();
       var grid2 = TestUtils.renderIntoDocument(<Griddle externalResults={fakeData}
           results={fakeData2}
           useExternal={false}
@@ -310,32 +305,32 @@ describe('Griddle', function() {
       var thRow = TestUtils.scryRenderedDOMComponentsWithTag(grid2, "th");
 
       TestUtils.Simulate.click(thRow[0].getDOMNode(), {target: {dataset: { title: "Test"}}});
-      expect(mock.mock.calls.length).toEqual(0);
+      expect(mock.calls.count()).toEqual(0);
   });
 
   it('calls external filter when filter changed and useExternal is true', function(){
-      var mock = jest.genMockFunction();
+      var mock = jasmine.createSpy();
       var grid2 = TestUtils.renderIntoDocument(<Griddle externalResults={fakeData}
         useExternal={true} showFilter={true} externalSetFilter={mock} gridClassName="test" />);
 
       var input = TestUtils.findRenderedDOMComponentWithTag(grid2, "input");
       TestUtils.Simulate.change(input, {target: {value: 'Hi'}});
-      expect(mock.mock.calls.length).toEqual(1);
+      expect(mock.calls.count()).toEqual(1);
   });
 
   it('does not call external filter when filter changed and useExternal is false', function(){
-    var mock = jest.genMockFunction();
+    var mock = jasmine.createSpy();
     var grid2 = TestUtils.renderIntoDocument(<Griddle externalResults={fakeData}
       useExternal={false} showFilter={true} externalSetFilter={mock} gridClassName="test" />);
 
       var input = TestUtils.findRenderedDOMComponentWithTag(grid2, "input");
       TestUtils.Simulate.change(input, {target: {value: 'Hi'}});
-      expect(mock.mock.calls.length).toEqual(0);
+      expect(mock.calls.count()).toEqual(0);
   });
 
   //basically if external is true it should never use filteredResults
   it('does not set filtered results when filter changes and external results is true', function(){
-      var mock = jest.genMockFunction();
+      var mock = jasmine.createSpy();
       var grid2 = TestUtils.renderIntoDocument(<Griddle externalResults={fakeData}
         useExternal={true} showFilter={true} externalSetFilter={mock} gridClassName="test" />);
 
@@ -345,21 +340,21 @@ describe('Griddle', function() {
   });
 
   it('calls external set page when page changed and useExternal is true', function(){
-      var mock = jest.genMockFunction();
+      var mock = jasmine.createSpy();
       var grid2 = TestUtils.renderIntoDocument(<Griddle externalResults={fakeData}
         useExternal={true} showFilter={true} externalSetPage={mock} gridClassName="test" />);
 
       grid2.setPage(2);
-      expect(mock.mock.calls.length).toEqual(1);
+      expect(mock.calls.count()).toEqual(1);
   });
 
   it('calls external set page size when page changed and useExternal is true', function(){
-      var mock = jest.genMockFunction();
+      var mock = jasmine.createSpy();
       var grid2 = TestUtils.renderIntoDocument(<Griddle externalResults={fakeData}
         useExternal={true} showFilter={true} externalSetPageSize={mock} gridClassName="test" />);
 
       grid2.setPageSize(2);
-      expect(mock.mock.calls.length).toEqual(1);
+      expect(mock.calls.count()).toEqual(1);
   });
 
   it('uses external max pages when useExternal is true', function(){
@@ -400,7 +395,7 @@ describe('Griddle', function() {
   });
 
   it('should not log error with externalSetPage if it is available', function(){
-   var mock = jest.genMockFunction();
+   var mock = jasmine.createSpy();
    var grid2 = TestUtils.renderIntoDocument(<Griddle externalResults={fakeData}
     useExternal={true} externalSetPage={mock} gridClassName="test" />);
 
@@ -415,7 +410,7 @@ describe('Griddle', function() {
   });
 
   it('should not log error with externalChangeSort if it is available', function(){
-   var mock = jest.genMockFunction();
+   var mock = jasmine.createSpy();
    var grid2 = TestUtils.renderIntoDocument(<Griddle externalResults={fakeData}
     useExternal={true} externalChangeSort={mock} gridClassName="test" />);
 
@@ -430,7 +425,7 @@ describe('Griddle', function() {
   });
 
   it('should not log error with useExternal if externalSetFilter is available', function(){
-   var mock = jest.genMockFunction();
+   var mock = jasmine.createSpy();
    var grid2 = TestUtils.renderIntoDocument(<Griddle externalResults={fakeData}
     useExternal={true} externalSetFilter={mock} gridClassName="test" />);
 
@@ -445,7 +440,7 @@ describe('Griddle', function() {
   });
 
   it('should not log error with externalSetPage if it is available', function(){
-   var mock = jest.genMockFunction();
+   var mock = jasmine.createSpy();
    var grid2 = TestUtils.renderIntoDocument(<Griddle externalResults={fakeData}
     useExternal={true} externalSetPageSize={mock} gridClassName="test" />);
 
@@ -506,7 +501,7 @@ describe('Griddle', function() {
   });
 
   it('should not throw an error if useCustomFilterer is true and filterer is added', function(){
-    var customFilterer = jest.genMockFunction();
+    var customFilterer = jasmine.createSpy();
     var grid2 = TestUtils.renderIntoDocument(<Griddle results={fakeData} useCustomFilterer={true} customFilterer={customFilterer} />);
 
     expect(console.error).not.toHaveBeenCalledWith("useCustomFilterer is set to true but no custom filter function was specified.");


### PR DESCRIPTION
This PR migrates our tests away from Jest over to Karma so that we are able to run them in 0.10 and higher.  As of the upgrade to 0.14 (#262) the version of Jest does not support node versions lower than 4 and iojs 2. 

Test run against node's 0.10 thru 5:
https://travis-ci.org/kevinold/Griddle/builds/92616940
