### PR TITLE
Only use default styling for CustomRowComponentContainer if useGriddleStyles is true

### DIFF
--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -672,7 +672,7 @@ var Griddle = React.createClass({
     getCustomRowSection: function(data, cols, meta, pagingContent){
         return <div><CustomRowComponentContainer data={data} columns={cols} metadataColumns={meta}
             className={this.props.customRowComponentClassName} customComponent={this.props.customRowComponent}
-            style={this.getClearFixStyles()} />{this.props.showPager&&pagingContent}</div>
+            style={this.props.useGriddleStyles ? this.getClearFixStyles() : null} />{this.props.showPager&&pagingContent}</div>
     },
     getStandardGridSection: function(data, cols, meta, pagingContent, hasMorePages){
         var sortProperties = this.getSortObject();


### PR DESCRIPTION
This adds a check that prevents the default container styles being applied to CustomRowComponentContainer if useGriddleStyles is false.