### PR TITLE
Add caution/warning to infiniteScroll.md documentation

### DIFF
--- a/docs/src/markdown/infiniteScroll.md
+++ b/docs/src/markdown/infiniteScroll.md
@@ -48,3 +48,18 @@ Feel free to scroll through your external data, too! When data is loading, the l
  loadingComponent={Loading} enableInfiniteScroll={true} useFixedHeader={true} bodyHeight={400}/>
 ```
 @@include('./infiniteScroll/infiniteScrollExternalResults.html')
+
+####Cautions:####
+When using infinite scroll on a table, re-renders of the Griddle component will cause the table to recreate itself - setting the scroll position back to 0, making the table appear to jump back to the top. To prevent this, specify the ```key``` attribute on ```rowMetadata```. For more information please see the (React page on reconciliation)[https://facebook.github.io/react/docs/reconciliation.html].
+```
+var rowMetadata = {
+      "key": "nameOfIndexInMyResultSet"
+    }
+};
+
+return (
+    <div className="griddle-container">
+        <Griddle results={this.state.rows} enableInfiniteScroll={true} rowMetadata={rowMetadata} />
+    </div>
+)
+```


### PR DESCRIPTION
Add cautions section note about using the "key" attribute on rowMetadata when re-rendering a table with infinite scrolling enabled.