### PR TITLE
Fix bug with React peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "main": "modules/griddle.jsx.js",
   "peerDependencies": {
-    "react": "0.14.3",
+    "react": "^0.14.3",
     "underscore": ">= 1.6.0 < 2"
   },
   "devDependencies": {


### PR DESCRIPTION
Griddle's throwing an error when trying to install alongside React 0.14.5.