### PR TITLE
 Add globalData prop to pass in user-specified global data through Griddle component to every customRowComponent instance.

### DIFF
--- a/scripts/customRowComponentContainer.jsx
+++ b/scripts/customRowComponentContainer.jsx
@@ -13,7 +13,8 @@ var CustomRowComponentContainer = React.createClass({
       "data": [],
       "metadataColumns": [],
       "className": "",
-      "customComponent": {}
+      "customComponent": {},
+      "globalData": {}
     }
   },
   render: function() {
@@ -25,7 +26,7 @@ var CustomRowComponentContainer = React.createClass({
     }
 
     var nodes = this.props.data.map(function(row, index){
-        return <that.props.customComponent data={row} metadataColumns={that.props.metadataColumns} key={index} />
+        return <that.props.customComponent data={row} metadataColumns={that.props.metadataColumns} key={index} globalData={that.props.globalData} />
     });
 
     var footer = this.props.showPager&&this.props.pagingContent;

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -67,6 +67,7 @@ var Griddle = React.createClass({
             "customPagerComponent": {},
             "customFilterComponent": null,
             "customFilterer": null,
+            "globalData": null,
             "enableToggleCustom":false,
             "noDataMessage":"There is no data to display.",
             "noDataClassName": "griddle-nodata",
@@ -686,8 +687,8 @@ var Griddle = React.createClass({
     getCustomGridSection: function(){
         return <this.props.customGridComponent data={this.props.results} className={this.props.customGridComponentClassName} {...this.props.gridMetadata} />
     },
-    getCustomRowSection: function(data, cols, meta, pagingContent){
-        return <div><CustomRowComponentContainer data={data} columns={cols} metadataColumns={meta}
+    getCustomRowSection: function(data, cols, meta, pagingContent, globalData){
+        return <div><CustomRowComponentContainer data={data} columns={cols} metadataColumns={meta} globalData={globalData}
             className={this.props.customRowComponentClassName} customComponent={this.props.customRowComponent}
             style={this.props.useGriddleStyles ? this.getClearFixStyles() : null} />{this.props.showPager&&pagingContent}</div>
     },
@@ -724,11 +725,11 @@ var Griddle = React.createClass({
                 hasMorePages={hasMorePages}
                 onRowClick={this.props.onRowClick}/></div>)
     },
-    getContentSection: function(data, cols, meta, pagingContent, hasMorePages){
+    getContentSection: function(data, cols, meta, pagingContent, hasMorePages, globalData){
         if(this.props.useCustomGridComponent && this.props.customGridComponent !== null){
            return this.getCustomGridSection();
         } else if(this.props.useCustomRowComponent){
-            return this.getCustomRowSection(data, cols, meta, pagingContent);
+            return this.getCustomRowSection(data, cols, meta, pagingContent, globalData);
         } else {
             return this.getStandardGridSection(data, cols, meta, pagingContent, hasMorePages);
         }
@@ -788,7 +789,7 @@ var Griddle = React.createClass({
         // Grab the paging content if it's to be displayed
         var pagingContent = this.getPagingSection(currentPage, maxPage);
 
-        var resultContent = this.getContentSection(data, cols, meta, pagingContent, hasMorePages);
+        var resultContent = this.getContentSection(data, cols, meta, pagingContent, hasMorePages, this.props.globalData);
 
         var columnSelector = this.getColumnSelectorSection(keys, cols);
 


### PR DESCRIPTION
This is a pull request that is detailed in #286, and a refining of the now closed PR #295.  The `globalData` prop passed into Griddle will be sent in as a prop to each customRowComponent instance allowing the row component to have access to any user-specified global data.  Without this a custom row component is in somewhat of a "black box" and requires inefficient methods to access state that isn't row specific (like having to connect each row to a flux/redux store).  Right now the `globalData` prop is only passed into instances of customRowComponent, but this could potentially be used in other places since the data can be as generic as a developer wants.