### PR TITLE
Make non-sortable column default icon hidden

### DIFF
--- a/scripts/gridTitle.jsx
+++ b/scripts/gridTitle.jsx
@@ -47,7 +47,8 @@ var GridTitle = React.createClass({
 
     var nodes = this.props.columnSettings.getColumns().map(function(col, index){
         var columnSort = "";
-        var sortComponent = that.props.sortSettings.sortDefaultComponent;
+        var columnIsSortable = that.props.columnSettings.getMetadataColumnProperty(col, "sortable", true);
+        var sortComponent = columnIsSortable ? that.props.sortSettings.sortDefaultComponent : null;
 
         if(that.props.sortSettings.sortColumn == col && that.props.sortSettings.sortAscending){
             columnSort = that.props.sortSettings.sortAscendingClassName;
@@ -57,9 +58,7 @@ var GridTitle = React.createClass({
             sortComponent = that.props.useGriddleIcons && that.props.sortSettings.sortDescendingComponent;
         }
 
-
         var meta = that.props.columnSettings.getColumnMetadataByName(col);
-        var columnIsSortable = that.props.columnSettings.getMetadataColumnProperty(col, "sortable", true);
         var displayName = that.props.columnSettings.getMetadataColumnProperty(col, "displayName", col);
 
         columnSort = meta == null ? columnSort : (columnSort && (columnSort + " ")||columnSort) + that.props.columnSettings.getMetadataColumnProperty(col, "cssClassName", "");


### PR DESCRIPTION
Hey,
In my opinion, if the column is not sortable, I don't need to see the default sort component.