### PR TITLE
Fixed defaultColSpan when using externalLoadingComponent

### DIFF
--- a/scripts/gridTable.jsx
+++ b/scripts/gridTable.jsx
@@ -227,9 +227,9 @@ var GridTable = React.createClass({
           textAlign: "center",
           paddingBottom: "40px"
         };
-
-        defaultColSpan = this.props.columnSettings.getVisibleColumnCount();
       }
+	  
+	  defaultColSpan = this.props.columnSettings.getVisibleColumnCount();
 
       var loadingComponent = this.props.externalLoadingComponent ?
         (<this.props.externalLoadingComponent/>) :


### PR DESCRIPTION
Fixed defaultColSpan when using externalLoadingComponent and not using griddlestyles.

Moving the set statement of defaultColSpan out of the if where it checks whether the table is using griddle styles.

Previously this caused externalLoadingComponent to only have colspan = 1 and ending up in the left most column.