### PR TITLE
Remove circular dependency between griddle and gridRowContainer

### DIFF
--- a/scripts/gridRowContainer.jsx
+++ b/scripts/gridRowContainer.jsx
@@ -84,7 +84,7 @@ var GridRowContainer = React.createClass({
               var key = that.props.rowSettings.getRowKey(row, index);
 
               if(typeof row["children"] !== "undefined"){
-                var Griddle = require('./griddle.jsx');
+                var Griddle = this.constructor.Griddle;
                 return (
                   <tr key={key} style={{paddingLeft: 5}}>
                     <td colSpan={that.props.columnSettings.getVisibleColumnCount()} className="griddle-parent" style={that.props.useGriddleStyles ? {border: "none", "padding": "0 0 0 5px"} : null}>

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -12,6 +12,7 @@ var GridPagination = require('./gridPagination.jsx');
 var GridSettings = require('./gridSettings.jsx');
 var GridNoData = require('./gridNoData.jsx');
 var GridRow = require('./gridRow.jsx');
+var GridRowContainer = require('./gridRowContainer.jsx');
 var CustomRowComponentContainer = require('./customRowComponentContainer.jsx');
 var CustomPaginationContainer = require('./customPaginationContainer.jsx');
 var CustomFilterContainer = require('./customFilterContainer.jsx');
@@ -808,4 +809,4 @@ var Griddle = React.createClass({
     }
 });
 
-module.exports = Griddle;
+GridRowContainer.Griddle = module.exports = Griddle;


### PR DESCRIPTION
We're using a webpack/browserify-style bundler internally (to be open-sourced at some point) that only supports es6-style requires at the top of the file, so a dynamic require like used here to resolve a circular dependency doesn't work. I changed the code to have griddle inject the class instead.

cc @kevinhughes27 