### PR TITLE
NoData Component has no colspan

### DIFF
--- a/build/Griddle.js
+++ b/build/Griddle.js
@@ -1078,7 +1078,8 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      // no data section
 	      if (this.props.showNoData) {
-	        nodes.push(React.createElement('tr', { key: 'no-data-section' }, React.createElement('td', null, this.props.noDataSection)));
+	        var colSpan = this.props.columnSettings.getVisibleColumnCount();
+	        nodes.push(React.createElement('tr', { key: 'no-data-section' }, React.createElement('td', { colSpan: colSpan }, this.props.noDataSection)));
 	      }
 
 	      // Add the spacer rows for nodes we're not rendering.

--- a/build/griddle.js
+++ b/build/griddle.js
@@ -1078,7 +1078,8 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      // no data section
 	      if (this.props.showNoData) {
-	        nodes.push(React.createElement('tr', { key: 'no-data-section' }, React.createElement('td', null, this.props.noDataSection)));
+	        var colSpan = this.props.columnSettings.getVisibleColumnCount();
+	        nodes.push(React.createElement('tr', { key: 'no-data-section' }, React.createElement('td', { colSpan: colSpan }, this.props.noDataSection)));
 	      }
 
 	      // Add the spacer rows for nodes we're not rendering.

--- a/scripts/gridTable.jsx
+++ b/scripts/gridTable.jsx
@@ -163,7 +163,8 @@ var GridTable = React.createClass({
 
       // no data section
       if (this.props.showNoData) {
-        nodes.push(<tr key="no-data-section"><td>{this.props.noDataSection}</td></tr>);
+        var colSpan = this.props.columnSettings.getVisibleColumnCount();
+        nodes.push(<tr key="no-data-section"><td colSpan={colSpan}>{this.props.noDataSection}</td></tr>);
       }
 
       // Add the spacer rows for nodes we're not rendering.


### PR DESCRIPTION
The cell used for the NoData component did not have a colspan applied, meaning that narrow columns would cause the contents to wrap unnecessarily or would not allow for centre aligning the content.

Before:
![screenshot from 2016-03-23 00-02-29](https://cloud.githubusercontent.com/assets/1327476/13972163/3322ec7a-f08e-11e5-94a6-88adaec4a7ae.png)

After:
![screenshot from 2016-03-23 00-25-01](https://cloud.githubusercontent.com/assets/1327476/13972164/3343a438-f08e-11e5-84cd-077fa87b0f52.png)