### PR TITLE
Update version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "griddle-react",
-  "version": "0.2.13",
+  "version": "0.4.1",
   "homepage": "https://github.com/GriddleGriddle/Griddle",
   "authors": [
     "Ryan Lanciaux"


### PR DESCRIPTION
To update the registered bower package, the upstream owner needs to update git tags:

git tag --annotate --force --message='0.4.1' v0.4.1 be3ea136af6219d544f50a61873db0b9687151d6
git push --tags

That should resolve the latest comment in #82.