### PR TITLE
Allows customComponent to know if children will be displayed or not

### DIFF
--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -101,7 +101,8 @@ var GridRow = React.createClass({
 
             if (this.props.columnSettings.hasColumnMetadata() && typeof meta !== 'undefined' && meta !== null) {
               if (typeof meta.customComponent !== 'undefined' && meta.customComponent !== null) {
-                var customComponent = <meta.customComponent data={col[1]} rowData={dataView} metadata={meta} />;
+                var customComponent = <meta.customComponent data={col[1]} rowData={dataView} metadata={meta}
+                                       hasChildren={this.props.hasChildren} showChildren={this.props.showChildren} />;
                 returnValue = <td onClick={this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{customComponent}</td>;
               } else {
                 returnValue = <td onClick={this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{firstColAppend}{col[1]}</td>;


### PR DESCRIPTION
By passing props `hasChildren` and `showChildren` to `customComponent`. Currently there's no way one can specify `parentRowExpandedComponent` and `parentRowCollapsedComponent` along with `customComponent`.