### PR TITLE
feat(pagination): allow changing resultsPerPage outside of GridSettings

### DIFF
--- a/build/Griddle.js
+++ b/build/Griddle.js
@@ -429,6 +429,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    },
 	    componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
 	        this.setMaxPage(nextProps.results);
+	        if (nextProps.resultsPerPage !== this.props.resultsPerPage) {
+	            this.setPageSize(nextProps.resultsPerPage);
+	        }
+
 	        //This will updaet the column Metadata
 	        this.columnSettings.columnMetadata = nextProps.columnMetadata;
 	        if (nextProps.results.length > 0) {

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -360,6 +360,10 @@ var Griddle = React.createClass({
     },
     componentWillReceiveProps: function(nextProps) {
         this.setMaxPage(nextProps.results);
+        if (nextProps.resultsPerPage !== this.props.resultsPerPage) {
+            this.setPageSize(nextProps.resultsPerPage);
+        }
+
 	//This will updaet the column Metadata
 	this.columnSettings.columnMetadata = nextProps.columnMetadata;
         if(nextProps.results.length > 0)


### PR DESCRIPTION
When re-rendering Griddle with a different ```resultPerPage``` prop, it won't affect the results.

Lets say we have a wrapper component that holds in its state the number of results per page, and this number is being changed by another component outside of Griddle.
Currently Griddle won't use the new ```resultsPerPage``` value, won't set the page size, and won't re-render the grid.

Example:
```
...
getInitialState() {
  return {
     myResultsPerPage: 5
  };
}

onChange(newResults) {
   this.setState({ myResultsPerPage: newResults });
}

render() {
  return (
    <Griddle
      ....
      resultsPerPage={this.state.myResultsPerPage}
     />
  );
}
```