### PR TITLE
to show all column settings

### DIFF
--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -377,28 +377,16 @@ var Griddle = React.createClass({
             this.setPageSize(nextProps.resultsPerPage);
         }
 	    //This will updaet the column Metadata
-	    this.columnSettings.columnMetadata = nextProps.columnMetadata;
-        if(nextProps.results.length > 0)
-        {
-            var deepKeys = deep.keys(nextProps.results[0]);
-
-            var is_same = (this.columnSettings.allColumns.length == deepKeys.length) && this.columnSettings.allColumns.every(function(element, index) {
-                return element === deepKeys[index];
+        if (nextProps.columnMetadata !== this.columnSettings.columnMetadata) {
+            this.columnSettings.columnMetadata = nextProps.columnMetadata;
+            this.columnSettings.allColumns = nextProps.columnMetadata.map(function(meta, index){
+                return meta.columnName
             });
-
-            if(!is_same) {
-                this.columnSettings.allColumns = deepKeys;
-            }
-        }
-        else if(this.columnSettings.allColumns.length > 0)
-        {
-            this.columnSettings.allColumns = [];
         }
 
         if(nextProps.columns !== this.columnSettings.filteredColumns){
             this.columnSettings.filteredColumns = nextProps.columns;
         }
-
 
         if(nextProps.selectedRowIds) {
             var visibleRows = this.getDataForRender(this.getCurrentResults(), this.columnSettings.getColumns(), true);
@@ -428,9 +416,12 @@ var Griddle = React.createClass({
     componentWillMount: function() {
         this.verifyExternal();
         this.verifyCustom();
+        var allColumns = this.props.columnMetadata.map(function(meta, index){
+                return meta.columnName
+            });
 
         this.columnSettings = new ColumnProperties(
-            this.props.results.length > 0 ? deep.keys(this.props.results[0]) : [],
+            allColumns,
             this.props.columns,
             this.props.childrenColumnName,
             this.props.columnMetadata,
@@ -910,8 +901,7 @@ var Griddle = React.createClass({
 
         var meta = this.columnSettings.getMetadataColumns();
 
-        // Grab the column keys from the first results
-        keys = deep.keys(omit(results[0], meta));
+        keys = this.columnSettings.allColumns;
 
         // sort keys by order
         keys = this.columnSettings.orderColumns(keys);


### PR DESCRIPTION
I want to add some custom column field that is not included in results.
But I can not to add columns that is not included in results, because `columnSettings.allColumns` include only keys in `results` prop, and do not check `columnMetadata`.

e.g.
I want to add `links` column that is not included in results, but I can use customComponent to make links.