### PR TITLE
Fix 'Rows per page' value problem for npm users

### DIFF
--- a/modules/griddle.jsx.js
+++ b/modules/griddle.jsx.js
@@ -244,6 +244,9 @@ var Griddle = React.createClass({
     },
     setPageSize: function setPageSize(size) {
         if (this.props.useExternal) {
+            this.setState({
+                resultsPerPage: size
+            });
             this.props.externalSetPageSize(size);
             return;
         }


### PR DESCRIPTION
Commit 26b44f sought to fix the external source 'rows per page' value
problem but did not update the modules/griddle.jsx.js, which is required
for users who install Griddle via npm.