### PR TITLE
feature request: allow a custom componentDidMount() method to be passed

### DIFF
--- a/modules/griddle.jsx.js
+++ b/modules/griddle.jsx.js
@@ -463,6 +463,11 @@ var Griddle = React.createClass({
             });
         }
     },
+    componentDidMount: function componentDidMount() {
+        if(this.props.componentDidMount && typeof this.props.componentDidMount === "function") {
+            return this.props.componentDidMount();
+        }
+    },
     //todo: clean these verify methods up
     verifyExternal: function verifyExternal() {
         if (this.props.useExternal === true) {


### PR DESCRIPTION
this would be useful, in case one needs to interact with the DOM after the Griddle table is rendered