### PR TITLE
Remove unnecessary replacement of filteredColumns

### DIFF
--- a/build/Griddle.js
+++ b/build/Griddle.js
@@ -464,10 +464,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	            this.columnSettings.allColumns = [];
 	        }
 
-	        if (nextProps.columns !== this.columnSettings.filteredColumns) {
-	            this.columnSettings.filteredColumns = nextProps.columns;
-	        }
-
 	        if (nextProps.selectedRowIds) {
 	            var visibleRows = this.getDataForRender(this.getCurrentResults(nextProps.results), this.columnSettings.getColumns(), true);
 

--- a/modules/griddle.jsx.js
+++ b/modules/griddle.jsx.js
@@ -401,10 +401,6 @@ var Griddle = React.createClass({
             this.columnSettings.allColumns = [];
         }
 
-        if (nextProps.columns !== this.columnSettings.filteredColumns) {
-            this.columnSettings.filteredColumns = nextProps.columns;
-        }
-
         if (nextProps.selectedRowIds) {
             var visibleRows = this.getDataForRender(this.getCurrentResults(nextProps.results), this.columnSettings.getColumns(), true);
 

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -399,10 +399,6 @@ var Griddle = React.createClass({
             this.columnSettings.allColumns = [];
         }
 
-        if(nextProps.columns !== this.columnSettings.filteredColumns){
-            this.columnSettings.filteredColumns = nextProps.columns;
-        }
-
         if(nextProps.selectedRowIds) {
             var visibleRows = this.getDataForRender(this.getCurrentResults(nextProps.results), this.columnSettings.getColumns(), true);
 


### PR DESCRIPTION
The removed statement overwrites filteredColumns with the columns prop, preventing filteredColumns from being controlled by column settings. This PR allows filteredColumns to be dynamic and controlled externally via state.