### PR TITLE
Allow user to turn off onRowClick in columnMetadata

### DIFF
--- a/modules/gridRow.jsx.js
+++ b/modules/gridRow.jsx.js
@@ -111,7 +111,7 @@ var GridRow = React.createClass({
             if (_this.props.columnSettings.hasColumnMetadata() && typeof meta !== 'undefined' && meta !== null) {
                 if (typeof meta.customComponent !== 'undefined' && meta.customComponent !== null) {
                     var customComponent = React.createElement(meta.customComponent, { data: col[1], rowData: dataView, metadata: meta });
-                    returnValue = React.createElement('td', { onClick: _this.handleClick, className: meta.cssClassName, key: index, style: columnStyles }, customComponent);
+                    returnValue = React.createElement('td', { onClick: !meta.preventOnRowClick ? _this.handleClick : null, className: meta.cssClassName, key: index, style: columnStyles }, customComponent);
                 } else {
                     returnValue = React.createElement('td', { onClick: _this.handleClick, className: meta.cssClassName, key: index, style: columnStyles }, firstColAppend, _this.formatData(col[1]));
                 }

--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -108,7 +108,7 @@ var GridRow = React.createClass({
             if (this.props.columnSettings.hasColumnMetadata() && typeof meta !== 'undefined' && meta !== null) {
               if (typeof meta.customComponent !== 'undefined' && meta.customComponent !== null) {
                 var customComponent = <meta.customComponent data={col[1]} rowData={dataView} metadata={meta} />;
-                returnValue = <td onClick={this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{customComponent}</td>;
+                returnValue = <td onClick={!meta.preventOnRowClick ? this.handleClick : null} className={meta.cssClassName} key={index} style={columnStyles}>{customComponent}</td>;
               } else {
                 returnValue = <td onClick={this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{firstColAppend}{this.formatData(col[1])}</td>;
               }


### PR DESCRIPTION
Set `preventOnRowClick` to `true` in columnMetadata to stop `onRowClick` function from being called for that column. 