### PR TITLE
columnFilter to filter nested data

### DIFF
--- a/modules/deep.js
+++ b/modules/deep.js
@@ -4,6 +4,8 @@ var forEach = require('lodash/forEach');
 var isObject = require('lodash/isObject');
 var isArray = require('lodash/isArray');
 var isFunction = require('lodash/isFunction');
+var isPlainObject = require('lodash/isPlainObject');
+var forOwn = require('lodash/forOwn');
 
 // Credits: https://github.com/documentcloud/underscore-contrib
 // Sub module: underscore.object.selectors
@@ -106,8 +108,42 @@ function getKeys(obj, prefix) {
   return keys;
 }
 
+// Recursivly traverse plain objects and arrays calling `fn` on each
+// non-object/non-array leaf node.
+function iterObject(thing, fn) {
+  if (isArray(thing)) {
+    forEach(thing, function (item) {
+      iterObject(item, fn);
+    });
+  } else if (isPlainObject(thing)) {
+    forOwn(thing, function (item) {
+      iterObject(item, fn);
+    });
+  } else {
+    fn(thing);
+  }
+}
+
+// Recursivly traverse plain objects and arrays and build a list of all
+// non-object/non-array leaf nodes.
+//
+// Input:
+// { "array": [1, "two", {"tree": 3}], "string": "a string" }
+//
+// Output:
+// [1, 'two', 3, 'a string']
+//
+function getObjectValues(thing) {
+  var results = [];
+  iterObject(thing, function (value) {
+    results.push(value);
+  });
+  return results;
+}
+
 module.exports = {
   pick: powerPick,
   getAt: getPath,
-  keys: getKeys
+  keys: getKeys,
+  getObjectValues: getObjectValues
 };

--- a/modules/griddle.jsx.js
+++ b/modules/griddle.jsx.js
@@ -174,14 +174,19 @@ var Griddle = React.createClass({
         });
     },
 
+    defaultColumnFilter: function defaultColumnFilter(value, filter) {
+        return _filter(deep.getObjectValues(value), function (value) {
+            return value.toString().toLowerCase().indexOf(filter.toLowerCase()) >= 0;
+        }).length > 0;
+    },
+
     filterByColumnFilters: function filterByColumnFilters(columnFilters) {
+        var filterFunction = this.defaultColumnFilter;
         var filteredResults = Object.keys(columnFilters).reduce(function (previous, current) {
             return _filter(previous, function (item) {
-                if (deep.getAt(item, current || "").toString().toLowerCase().indexOf(columnFilters[current].toLowerCase()) >= 0) {
-                    return true;
-                }
-
-                return false;
+                var value = deep.getAt(item, current || "");
+                var filter = columnFilters[current];
+                return filterFunction(value, filter);
             });
         }, this.props.results);
 
@@ -467,11 +472,6 @@ var Griddle = React.createClass({
             return this.props.componentDidMount();
         }
     },
-    componentDidUpdate: function componentDidUpdate() {
-        if (this.props.componentDidUpdate && typeof this.props.componentDidUpdate === "function") {
-            return this.props.componentDidUpdate(this.state);
-        }
-    },
     //todo: clean these verify methods up
     verifyExternal: function verifyExternal() {
         if (this.props.useExternal === true) {
@@ -557,10 +557,14 @@ var Griddle = React.createClass({
                         }, [this.state.sortDirection]);
                     }
                 } else {
-                    var iteratees = [(row) => (_get(row, column) || '').toString().toLowerCase()];
+                    var iteratees = [function (row) {
+                        return (_get(row, column) || '').toString().toLowerCase();
+                    }];
                     var orders = [this.state.sortDirection];
                     multiSort.columns.forEach(function (col, i) {
-                        iteratees.push((row) => (_get(row, col) || '').toString().toLowerCase());
+                        iteratees.push(function (row) {
+                            return (_get(row, col) || '').toString().toLowerCase();
+                        });
                         if (multiSort.orders[i] === 'asc' || multiSort.orders[i] === 'desc') {
                             orders.push(multiSort.orders[i]);
                         } else {

--- a/scripts/__tests__/deep-test.js
+++ b/scripts/__tests__/deep-test.js
@@ -1,0 +1,17 @@
+var deep = require('../deep.js');
+
+describe('getObjectValues', function(){
+
+  it('returns a single string', function(){
+    let test = "test";
+    let results = deep.getObjectValues(test);
+    expect(results).toEqual(["test"]);
+  });
+
+  it('returns values from a more complex object', function(){
+    let test = { "array": [1, "two", {"tree": 3}], "string": "a string" };
+    let results = deep.getObjectValues(test);
+    expect(results).toEqual([1, 'two', 3, 'a string']);
+  });
+
+});

--- a/scripts/__tests__/griddle-test.js
+++ b/scripts/__tests__/griddle-test.js
@@ -149,6 +149,48 @@ describe('Griddle', function() {
     expect(grid2.state.filteredResults).toBe(fakeData);
   });
 
+  it('sets the filteredResults when filterByColumn called', function(){
+    grid.filterByColumn('Mayer', 'name');
+    expect(grid.state.filteredResults.length).toEqual(1);
+  });
+
+  it('sets the filteredResults when filterByColumn called on object field', function(){
+    grid.filterByColumn('Hawaii', 'address');
+    expect(grid.state.filteredResults.length).toEqual(1);
+  });
+
+
+  it('column filters are applied to nested objects values', function() {
+
+    class CustomComponent extends React.Component {
+      render() {
+        let addresses = this.props.rowData.addresses.map((address) => {
+          return <div key={ address.id } className="label label-warning">{address.state}</div>
+        });
+        return (<div>{addresses}</div>);
+      }
+    }
+
+    let fakeData = [
+      {
+        "addresses": [{
+          "id": 1,
+          "city": "Kapowsin",
+          "state": ["Hawaii"]
+        }]
+      }];
+
+    let columnMetadata = [{
+      "columnName": "addresses",
+      "customComponent": CustomComponent,
+    }];
+
+    grid = TestUtils.renderIntoDocument(<Griddle results={fakeData} columnMetadata={columnMetadata} gridClassName="test" />);
+
+    grid.filterByColumn('Hawaii', 'addresses');
+    expect(grid.state.filteredResults.length).toEqual(1);
+  });
+
   it('removes filter when filter is called with empty string', function(){
     grid.setFilter('Mayer');
     grid.setFilter('');
@@ -156,6 +198,11 @@ describe('Griddle', function() {
   });
 
   it('adds column filter  on filterByColumn', function() {
+    grid.filterByColumn('test', 'name');
+    expect(grid.state.columnFilters).toEqual({ name: 'test' })
+  });
+
+  it('filterByColumn filters results', function() {
     grid.filterByColumn('test', 'name');
     expect(grid.state.columnFilters).toEqual({ name: 'test' })
   });

--- a/scripts/deep.js
+++ b/scripts/deep.js
@@ -2,6 +2,8 @@ var forEach = require('lodash/forEach');
 var isObject = require('lodash/isObject');
 var isArray = require('lodash/isArray');
 var isFunction = require('lodash/isFunction');
+var isPlainObject = require('lodash/isPlainObject');
+var forOwn = require('lodash/forOwn');
 
 // Credits: https://github.com/documentcloud/underscore-contrib
 // Sub module: underscore.object.selectors
@@ -99,8 +101,42 @@ function getKeys (obj, prefix) {
   return keys;
 }
 
+// Recursivly traverse plain objects and arrays calling `fn` on each
+// non-object/non-array leaf node.
+function iterObject(thing, fn) {
+  if (isArray(thing)) {
+    forEach(thing, function(item) {
+      iterObject(item, fn);
+    });
+  } else if (isPlainObject(thing)) {
+    forOwn(thing, function(item) {
+      iterObject(item, fn);
+    });
+  } else {
+    fn(thing);
+  }
+}
+
+// Recursivly traverse plain objects and arrays and build a list of all
+// non-object/non-array leaf nodes.
+//
+// Input:
+// { "array": [1, "two", {"tree": 3}], "string": "a string" }
+//
+// Output:
+// [1, 'two', 3, 'a string']
+//
+function getObjectValues(thing) {
+  var results = []
+  iterObject(thing, function(value) {
+    results.push(value);
+  });
+  return results;
+}
+
 module.exports = {
   pick: powerPick,
   getAt: getPath,
-  keys: getKeys
+  keys: getKeys,
+  getObjectValues: getObjectValues
 };

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -164,16 +164,21 @@ var Griddle = React.createClass({
        });
     },
 
+    defaultColumnFilter(value, filter) {
+      return _filter(deep.getObjectValues(value), function(value) {
+        return value.toString().toLowerCase().indexOf(filter.toLowerCase()) >= 0;
+      }).length > 0;
+    },
+
     filterByColumnFilters(columnFilters) {
+      let filterFunction = this.defaultColumnFilter;
       var filteredResults = Object.keys(columnFilters).reduce(function(previous, current) {
         return _filter(
           previous,
           function(item) {
-            if(deep.getAt(item, current || "").toString().toLowerCase().indexOf(columnFilters[current].toLowerCase()) >= 0) {
-              return true;
-            }
-
-            return false;
+            let value = deep.getAt(item, current || "");
+            let filter = columnFilters[current];
+            return filterFunction(value, filter)
           }
         )
       }, this.props.results)


### PR DESCRIPTION
This fixes #65 "[make filter queries search through nested divs for custom components](https://github.com/GriddleGriddle/Griddle/issues/65)" which is tagged an [approved issue](https://github.com/GriddleGriddle/Griddle/issues?q=is%3Aopen+label%3Aapproved+no%3Aassignee). I needed exactly this myself, so I implemented it.

The basic feature is; given data like this:

    data = [
       {
          somethingElse: [{ blah: "one",
             blah2: ["two"] }],
          ...
      },
      ...
    ]

The column filters can now match "one" and "two".

I have some concerns about how this would perform on large objects, but I also think traversing the objects is a pretty good default. This could be implemented a little more efficient for some cases but in a vast majority of cases it should be fine.   

I will implement custom column filters functions on top of this commit ([as requested here](https://github.com/GriddleGriddle/Griddle/issues/490)) as I need them myself, I will also create a pull request for if this is accepted.

I think the feature works quite well and have added tests. If there are any minor changes desired to get this merged in please let me know, thanks.