### PR TITLE
Avoid unnecessary scroll actions

### DIFF
--- a/src/components/Cell.js
+++ b/src/components/Cell.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const Cell = ({ value, onMouseOver, onClick, className, style, onMouseOut }) => console.log('width', style) || (
+const Cell = ({ value, onMouseOver, onClick, className, style, onMouseOut }) => (
   <td
     style={style}
     onClick={onClick}

--- a/src/plugins/position/components/TableEnhancer.js
+++ b/src/plugins/position/components/TableEnhancer.js
@@ -9,10 +9,11 @@ const Table = OriginalComponent => compose(
     selectors: PropTypes.object,
   }),
   connect((state, props) => {
-      const { tableHeightSelector, tableWidthSelector } = props.selectors;
+      const { tableHeightSelector, tableWidthSelector, rowHeightSelector } = props.selectors;
       return {
         TableHeight: tableHeightSelector(state),
         TableWidth: tableWidthSelector(state),
+        RowHeight: rowHeightSelector(state),
       };
     },
     {
@@ -24,6 +25,11 @@ const Table = OriginalComponent => compose(
     return restProps;
   })
 )(class extends Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = { scrollTop: 0 };
+  }
   render() {
     const { TableHeight, TableWidth } = this.props;
     const scrollStyle = {
@@ -43,8 +49,10 @@ const Table = OriginalComponent => compose(
   }
 
   _scroll = () => {
-    const { setScrollPosition } = this.props;
-    if (this._scrollable) {
+    const { setScrollPosition, RowHeight } = this.props;
+    const { scrollTop } = this.state;
+
+    if (this._scrollable && Math.abs(this._scrollable.scrollTop - scrollTop) >= RowHeight) {
       setScrollPosition(
         this._scrollable.scrollLeft,
         this._scrollable.scrollWidth,
@@ -53,6 +61,7 @@ const Table = OriginalComponent => compose(
         this._scrollable.scrollHeight,
         this._scrollable.clientHeight
       );
+      this.setState({ scrollTop: this._scrollable.scrollTop });
     }
   }
 });


### PR DESCRIPTION
Update to infinite scroll plugin to only scroll when a new row will be rendered. 