### PR TITLE
Fix object data

### DIFF
--- a/stories/fakeData2.js
+++ b/stories/fakeData2.js
@@ -1,0 +1,29 @@
+import fakeData from './fakeData';
+
+function person( id, name, city, state, country, company, favoriteNumber)
+{
+  this.id = id;
+  this.name = name;
+  this.city = city;
+  this.state = state;
+  this.country = country;
+  this.company = company;
+  this.favoriteNumber = favoriteNumber;
+}
+
+class personClass {
+  constructor(id, name, city, state, country, company, favoriteNumber) {
+    this.id = id;
+    this.name = name;
+    this.city = city;
+    this.state = state;
+    this.country = country;
+    this.company = company;
+    this.favoriteNumber = favoriteNumber;
+  }
+}
+
+var fakeData2 = fakeData.map( (x) => new person (...x));
+var fakeData3 = fakeData.map( (x) => new personClass (...x));
+
+export {fakeData2, fakeData3}

--- a/stories/index.js
+++ b/stories/index.js
@@ -15,10 +15,13 @@ import ColumnDefinition from '../src/components/ColumnDefinition';
 import RowDefinition from '../src/components/RowDefinition';
 import _ from 'lodash';
 import { rowDataSelector } from '../src/plugins/local/selectors/localSelectors';
-import fakeData from './fakeData';
+import fakeData1 from './fakeData';
+import {fakeData2, fakeData3} from './fakeData2';
 
 import LocalPlugin from '../src/plugins/local';
 import PositionPlugin from '../src/plugins/position';
+
+var fakeData = fakeData1;
 
 function sortBySecondCharacter(data, column, sortAscending = true) {
   return data.sort(
@@ -70,6 +73,24 @@ const EnhanceWithRowData = connect((state, props) => ({
 const EnhancedCustomComponent = EnhanceWithRowData(MakeBlueComponent);
 
 storiesOf('Griddle main', module)
+  .add('set fakeData to hash Objects', () => {
+    fakeData = fakeData1;
+    return (
+      <div> fakeData for all stories will now use hashed Objects</div>      
+    )
+  })
+  .add('set fakeData to constructed Objects', () => {
+    fakeData = fakeData2;
+    return (
+      <div> fakeData for all stories will now use constructed Objects</div>
+    )
+  })
+  .add('set fakeData to class Objects', () => {
+    fakeData = fakeData3;
+    return (
+      <div> fakeData for all stories will now use class Objects</div>
+    )
+  })
   .add('with local', () => {
     return (
       <Griddle data={fakeData} plugins={[LocalPlugin]}>


### PR DESCRIPTION
It was discovered that when the `data` passed to Griddle was created using either a class like:
```
class personClass {
  constructor(id, name, city, state, country, company, favoriteNumber) {
    this.id = id;
    this.name = name;
    this.city = city;
    this.state = state;
    this.country = country;
    this.company = company;
    this.favoriteNumber = favoriteNumber;
  }
}
```
or via a function like:

```
function person( id, name, city, state, country, company, favoriteNumber)
{
  this.id = id;
  this.name = name;
  this.city = city;
  this.state = state;
  this.country = country;
  this.company = company;
  this.favoriteNumber = favoriteNumber;
}
```
Griddle would fail do to missing `row` function.  This PR just creates test cases (stories) for this.
To switch between data sets there three stories:
* set fakeData to hash Objects
* set fakeData to constructed Objects
* set fakeData to class Objects


