### PR TITLE
Add lookup to avoid costly filter in cell value

### DIFF
--- a/src/plugins/local/reducers/__tests__/localReducerTests.js
+++ b/src/plugins/local/reducers/__tests__/localReducerTests.js
@@ -17,6 +17,7 @@ test('it loads data', test => {
       {name: "one", griddleKey: 0},
       {name: "two", griddleKey: 1}
     ],
+    lookup: { 0: 0, 1: 1 },
     loading: false
   });
 });

--- a/src/reducers/__tests__/dataReducerTest.js
+++ b/src/reducers/__tests__/dataReducerTest.js
@@ -64,6 +64,7 @@ test('sets data', test => {
       {name: "one", griddleKey: 0},
       {name: "two", griddleKey: 1}
     ],
+    lookup: { 0: 0, 1: 1 },
     loading: false
   });
 });

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -117,9 +117,13 @@ export function GRIDDLE_TOGGLE_COLUMN(state, action) {
 }
 
 export function GRIDDLE_UPDATE_STATE(state, action) {
-  const data = transformDataToList(action.newState.data);
+  const transformedData = transformData(action.newState.data);
+  const data = transformedData.data;
+  const lookup = transformedData.lookup;
   const newState = _.omit(action.newState, data);
 
-  return state.mergeDeep(Immutable.fromJS(newState)).set('data', data);
+  return state.mergeDeep(Immutable.fromJS(newState))
+    .set('data', data)
+    .set('lookup', lookup);
 }
 

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -18,6 +18,7 @@ import {
   addKeyToCollection,
   addColumnPropertiesWhenNoneExist,
   transformDataToList,
+  transformData,
 } from '../utils/dataUtils';
 
 /** Sets the default render properties
@@ -35,7 +36,9 @@ export function GRIDDLE_INITIALIZED(initialState) {
   if(initialState.hasOwnProperty('data') &&
     initialState.data.length > 0 &&
     !initialState.data[0].hasOwnProperty('griddleKey')) {
-      tempState.data = transformDataToList(initialState.data);
+      const transformedData = transformData(initialState.data);
+      tempState.data = transformedData.data;
+      tempState.lookup = transformedData.lookup;
   }
 
   return Immutable.fromJS(tempState);
@@ -45,8 +48,12 @@ export function GRIDDLE_INITIALIZED(initialState) {
  * @param {Immutable} state- Immutable previous state object
  * @param {Object} action - The action object to work with
 */
-export function GRIDDLE_LOADED_DATA(state, action, helpers) {
-  return state.set('data', transformDataToList(action.data))
+export function GRIDDLE_LOADED_DATA(state, action) {
+  const transformedData = transformData(action.data);
+
+  return state
+    .set('data', transformedData.data)
+    .set('lookup', transformedData.lookup)
     .set('loading', false);
 }
 

--- a/src/selectors/dataSelectors.js
+++ b/src/selectors/dataSelectors.js
@@ -247,8 +247,11 @@ export const visibleRowCountSelector = createSelector(
 
 // TODO: Needs tests and jsdoc
 export const cellValueSelector = (state, { griddleKey, columnId }) => {
-  return state.get('data')
-    .find(r => r.get('griddleKey') === griddleKey)
+  //TODO: Make Griddle key a string in data utils
+  const lookup = state.getIn(['lookup', griddleKey.toString()]);
+
+  return state
+    .get('data').get(lookup)
     .getIn(columnId.split('.'));
 };
 

--- a/src/utils/__tests__/dataUtilsTests.js
+++ b/src/utils/__tests__/dataUtilsTests.js
@@ -3,7 +3,8 @@ import test from 'ava';
 import Immutable from 'immutable';
 
 import {
-  addKeyToCollection
+  addKeyToCollection,
+  transformData,
 } from '../dataUtils';
 
 const collection = Immutable.fromJS([
@@ -40,4 +41,22 @@ test('starts at given index', test => {
     { name: 'two', griddleKey: 6 },
     { name: 'three', griddleKey: 7 }
   ]);
+});
+
+test('transforms data', test => {
+  const data = [
+    { first: 'Luke', last: 'Skywalker' },
+    { first: 'Darth', last: 'Vader' }
+  ];
+
+  const transformedData = transformData(data);
+
+  test.deepEqual(Object.keys(transformedData), ['data', 'lookup']);
+
+  test.deepEqual(transformedData.data.toJSON(), [
+    { first: 'Luke', last: 'Skywalker', griddleKey: 0 },
+    { first: 'Darth', last: 'Vader', griddleKey: 1 }
+  ]);
+
+  test.deepEqual(transformedData.lookup.toJSON(), { 0: 0, 1: 1 });
 });

--- a/src/utils/dataUtils.js
+++ b/src/utils/dataUtils.js
@@ -22,16 +22,29 @@ function fromJSGreedy(js) {
       Immutable.Seq(js).map(fromJSGreedy).toMap();
 }
 
-export function transformDataToList(data, settings={}) {
+export function transformData(data, settings = {}) {
   const defaultSettings = { name: 'griddleKey', startIndex: 0, addGriddleKey: true };
   const localSettings = Object.assign({}, defaultSettings, settings);
 
   const getKey = getIncrementer(localSettings.startIndex);
 
-  return new Immutable.List(data.map(row => {
-    const map = fromJSGreedy(row);
-    return localSettings.addGriddleKey ? map.set(localSettings.name, getKey()) : map;
-  }));
+  const lookup = {};
+  const list = [];
+
+  // build up a new list of data and list lookup
+  for (let i = 0; i < data.length; i += 1) {
+    const key = getKey();
+    lookup[key] = i;
+
+    // get an Immutable map of the data item
+    const map = fromJSGreedy(data[i]);
+    list.push(localSettings.addGriddleKey ? map.set(localSettings.name, key) : map);
+  }
+
+  return {
+    data: new Immutable.List(list),
+    lookup: new Immutable.Map(lookup),
+  };
 }
 
 /** adds griddleKey to given collection

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { storiesOf, action, linkTo } from '@kadira/storybook';
 import withContext from 'recompose/withContext';
 import { connect } from 'react-redux';
@@ -388,6 +388,121 @@ storiesOf('Cell', module)
         </RowDefinition>
       </Griddle>);
   });
+
+storiesOf('Bug fixes', module)
+  .add('Delete row', () => {
+     const enhanceWithOnClick = onClick => class ComputeThing extends Component {
+      static propTypes = {
+        rowData: React.PropTypes.object.isRequired,
+      }
+
+      localClick = () => {
+        const { id } = this.props.rowData;
+
+        onClick(id);
+      }
+
+      render() {
+        const { rowData: { id } } = this.props;
+
+        return (
+          <button type='button' onClick={this.localClick}>
+            Remove {id}
+          </button>
+        )
+       }
+     }
+
+
+    class SomeComponent extends Component {
+      constructor(props) {
+        super(props);
+
+        this.state = {
+           data: [
+            {
+              "id": 0,
+              "name": "Mayer Leonard",
+              "country": "United Kingdom",
+              "city": "Kapowsin",
+              "state": "Hawaii",
+              "company": "Ovolo",
+              "favoriteNumber": 7
+            },
+            {
+              "id": 1,
+              "name": "Koch Becker",
+              "city": "Johnsonburg",
+              "state": "New Jersey",
+              "country": "Madagascar",
+              "company": "Eventage",
+              "favoriteNumber": 2
+            },
+            {
+              "id": 2,
+              "name": "Lowery Hopkins",
+              "city": "Blanco",
+              "state": "Arizona",
+              "country": "Ukraine",
+              "company": "Comtext",
+              "favoriteNumber": 3
+            },
+            {
+              "id": 3,
+              "name": "Walters Mays",
+              "city": "Glendale",
+              "state": "Illinois",
+              "country": "New Zealand",
+              "company": "Corporana",
+              "favoriteNumber": 6
+            },
+            {
+              "id": 4,
+              "name": "Shaw Lowe",
+              "city": "Coultervillle",
+              "state": "Wyoming",
+              "country": "Ecuador",
+              "company": "Isologica",
+              "favoriteNumber": 2
+            },
+            {
+              "id": 5,
+              "name": "Ola Fernandez",
+              "city": "Deltaville",
+              "state": "Delaware",
+              "country": "Virgin Islands (US)",
+              "company": "Pawnagra",
+              "favoriteNumber": 7
+            },
+          ]
+        }
+
+        this.Component = EnhanceWithRowData(enhanceWithOnClick(this.onRemove));
+
+      }
+
+      onRemove = (rowId) => {
+        const newData = this.state.data.filter(x => x.id !== rowId);
+        this.setState({data: newData});
+      }
+
+      render() {
+        return (
+          <Griddle data={this.state.data} plugins={[LocalPlugin]}>
+            <RowDefinition>
+              <ColumnDefinition id="id" />
+              <ColumnDefinition id="name" />
+              <ColumnDefinition id="somethingTotallyMadeUp" title="Compute thing" customComponent={this.Component} />
+            </RowDefinition>
+          </Griddle>
+        );
+       }
+     }
+
+    return (
+      <SomeComponent />
+    );
+})
 
 storiesOf('Row', module)
   .add('base row', () => {


### PR DESCRIPTION
Previously, we were doing a filter against griddle key to get cell values. That could be costly. Add lookup object instead and references this instead of filtering the data for cell values.