### PR TITLE
Fixes #592 - Custom component in settings

### DIFF
--- a/src/reducers/__tests__/dataReducerTest.js
+++ b/src/reducers/__tests__/dataReducerTest.js
@@ -144,3 +144,23 @@ test('toggle column sets true when no columnProperty for column but other column
   const state = reducers.GRIDDLE_TOGGLE_COLUMN(initialState, { columnId: 'state' });
   test.deepEqual(state.getIn(['renderProperties', 'columnProperties', 'state']).toJSON(), { id: 'state', visible: true });
 });
+
+test('toggle column works when there is no visible property', (t) => {
+  const initialState = Immutable.fromJS({
+    renderProperties: {
+      columnProperties: {
+        name: { id: 'name' }
+      }
+    }
+  });
+
+  // if column isn't in renderProperties->column properties, we should set visible to true
+  const state = reducers.GRIDDLE_TOGGLE_COLUMN(initialState, { columnId: 'state' });
+  t.deepEqual(state.getIn(['renderProperties', 'columnProperties', 'state']).toJSON(), { id: 'state', visible: true });
+
+  // if column is in reducerProperties but has no visible property should set to false
+  const otherState = reducers.GRIDDLE_TOGGLE_COLUMN(initialState, { columnId: 'name' });
+  t.deepEqual(otherState.getIn(['renderProperties', 'columnProperties', 'name']).toJSON(), { id: 'name', visible: false });
+
+
+});

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -21,6 +21,24 @@ import {
   transformData,
 } from '../utils/dataUtils';
 
+function isColumnVisible(state, columnId) {
+  const hasRenderProperty = state.getIn(['renderProperties', 'columnProperties', columnId]);
+  const currentlyVisibleProperty = state.getIn(['renderProperties', 'columnProperties', columnId, 'visible']);
+
+  // if there is a render property and visible is not set, visible is true
+  if (hasRenderProperty && currentlyVisibleProperty === undefined) {
+    return true;
+  }
+
+  // if there is no render property currently and visible is not set 
+  if (!hasRenderProperty && currentlyVisibleProperty === undefined) {
+    return false;
+  }
+
+  return currentlyVisibleProperty;
+}
+
+
 /** Sets the default render properties
  * @param {Immutable} state- Immutable previous state object
  * @param {Object} action - The action object to work with
@@ -103,22 +121,6 @@ export function GRIDDLE_TOGGLE_SETTINGS(state, action) {
   const showSettings = state.get('showSettings') || false;
 
   return state.set('showSettings', !showSettings);
-}
-
-function isColumnVisible(state, columnId) {
-  const hasRenderProperty = state.getIn(['renderProperties', 'columnProperties', columnId])
-  const currentlyVisibleProperty = state.getIn(['renderProperties', 'columnProperties', columnId, 'visible']);
-
-  // if there is a render property and visible is not set, visible is true
-  if (hasRenderProperty && currentlyVisibleProperty === undefined) {
-    return true;
-  }
-
-  if (!hasRenderProperty && currentlyVisibleProperty === undefined) {
-    return false;
-  }
-
-  return currentlyVisibleProperty;
 }
 
 export function GRIDDLE_TOGGLE_COLUMN(state, action) {

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -105,15 +105,33 @@ export function GRIDDLE_TOGGLE_SETTINGS(state, action) {
   return state.set('showSettings', !showSettings);
 }
 
+function isColumnVisible(state, columnId) {
+  const hasRenderProperty = state.getIn(['renderProperties', 'columnProperties', columnId])
+  const currentlyVisibleProperty = state.getIn(['renderProperties', 'columnProperties', columnId, 'visible']);
+
+  // if there is a render property and visible is not set, visible is true
+  if (hasRenderProperty && currentlyVisibleProperty === undefined) {
+    return true;
+  }
+
+  if (!hasRenderProperty && currentlyVisibleProperty === undefined) {
+    return false;
+  }
+
+  return currentlyVisibleProperty;
+}
+
 export function GRIDDLE_TOGGLE_COLUMN(state, action) {
   // flips the visible state if the column property exists
+  const currentlyVisible = isColumnVisible(state, action.columnId);
+
   return state.getIn(['renderProperties', 'columnProperties', action.columnId]) ?
     state.setIn(['renderProperties', 'columnProperties', action.columnId, 'visible'],
-      !state.getIn(['renderProperties', 'columnProperties', action.columnId, 'visible'])) :
+      !currentlyVisible) :
 
-  // if the columnProperty doesn't exist, create a new one and set the property to true
+    // if the columnProperty doesn't exist, create a new one and set the property to true
     state.setIn(['renderProperties', 'columnProperties', action.columnId],
-      new Immutable.Map({ id: action.columnId, visible: true }))
+      new Immutable.Map({ id: action.columnId, visible: true }));
 }
 
 export function GRIDDLE_UPDATE_STATE(state, action) {

--- a/src/selectors/__tests__/dataSelectorsTest.js
+++ b/src/selectors/__tests__/dataSelectorsTest.js
@@ -159,6 +159,23 @@ test('allColumnsSelector: gets empty array when data is empty', test => {
   test.deepEqual(selectors.allColumnsSelector(state), []);
 });
 
+test('allColumnsSelector accounts for made up columns', test => {
+  // this is to catch the case where someone has a column that they added through column
+  // definitions and something that's not in the data
+  const state = new Immutable.fromJS({
+    data: [
+      { one: 'one', two: 'two', three: 'three'}
+    ],
+    renderProperties: {
+      columnProperties: {
+        something: { id: 'one', title: 'One' },
+      }
+    }
+  });
+
+  test.deepEqual(selectors.allColumnsSelector(state), ['one', 'two', 'three', 'something']);
+});
+
 test('iconByNameSelector gets given icon', test => {
   const state = new Immutable.fromJS({
     styleConfig: {

--- a/src/selectors/dataSelectors.js
+++ b/src/selectors/dataSelectors.js
@@ -58,11 +58,19 @@ export const sortColumnsSelector = state => state.get('sortColumns') || [];
 /** Gets all the columns */
 export const allColumnsSelector = createSelector(
   dataSelector,
-  (data) => (
-    !data || data.size === 0 ?
+  renderPropertiesSelector,
+  (data, renderProperties) => {
+    const dataColumns = !data || data.size === 0 ?
       [] :
-      data.get(0).keySeq().toJSON()
-  )
+      data.get(0).keySeq().toJSON();
+
+    const columnPropertyColumns = (renderProperties && renderProperties.size > 0) ?
+      // TODO: Make this not so ugly
+      Object.keys(renderProperties.get('columnProperties').toJSON()) :
+      [];
+
+    return _.union(dataColumns, columnPropertyColumns);
+  }
 );
 
 /** Gets the column properties objects sorted by order


### PR DESCRIPTION
We were not taking ephemeral columns (columns that are made-up of render properties but do not exist in the data) into account when handling the showing/hiding of columns from settings. This addresses that.

_There still needs to be some tests and organization around the reducer changes before merging this one._ 

This one can be tested by cloning the repository followed by `npm install && npm run storybook`. From there, click on the `Bug fixes` -> `Delete row` story (This was for another potential bug but has the same sort of column). Changing the visibility state of the columns from settings should now work as intended.