### PR TITLE
Fixes #589 - Fix for same column title

### DIFF
--- a/src/components/TableHeading.js
+++ b/src/components/TableHeading.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const TableHeading = ({ columnTitles, columnIds, TableHeadingCell, style, className }) => {
-  const headingCells = columnTitles && columnTitles.map((t, i) => <TableHeadingCell key={t} title={t} columnId={columnIds[i]} />);
+  const headingCells = columnTitles && columnTitles.map((t, i) => <TableHeadingCell key={columnIds[i]} title={t} columnId={columnIds[i]} />);
 
   return (
     <thead style={style} className={className}>

--- a/stories/index.js
+++ b/stories/index.js
@@ -390,6 +390,16 @@ storiesOf('Cell', module)
   });
 
 storiesOf('Bug fixes', module)
+  .add('Shared column title', () => {
+    return (
+      <Griddle data={fakeData} plugins={[LocalPlugin]}>
+        <RowDefinition>
+          <ColumnDefinition id="name" order={2} title="Same" />
+          <ColumnDefinition id="state" order={1} title="Same" />
+        </RowDefinition>
+      </Griddle>
+    );
+  })
   .add('Delete row', () => {
      const enhanceWithOnClick = onClick => class ComputeThing extends Component {
       static propTypes = {


### PR DESCRIPTION
Fixes a bug where we were using title as key for TableHeading. If there was a title that was shared between multiple columns, Griddle would throw an error. 