### PR TITLE
WIP: TypeScript Definition + Stories

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -12,13 +12,10 @@ module.exports = {
   ],
   module: {
     loaders: [
-      { test: /\.jsx?$/,
-        loader: 'babel',
+      { test: /\.[jt]sx?$/,
+        loader: 'babel-loader?presets[]=es2016&presets[]=stage-0&presets[]=react!ts-loader',
         exclude: /node_modules/,
         cacheDirectory: true,
-        query: {
-          presets: ['es2015', 'stage-0', 'react']
-        }
       }
     ],
   },

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,3 +1,6 @@
+const path = require("path");
+const include = path.resolve(__dirname, '../');
+
 // you can use this file to add your custom webpack plugins, loaders and anything you like.
 // This is just the basic way to add addional webpack configurations.
 // For more information refer the docs: https://goo.gl/qPbSyX
@@ -10,13 +13,23 @@ module.exports = {
   plugins: [
     // your custom plugins
   ],
+  resolve: {
+    // Add `.ts` and `.tsx` as a resolvable extension.
+    extensions: ["", ".webpack.js", ".web.js", ".ts", ".tsx", ".js"]
+  },
   module: {
     loaders: [
-      { test: /\.[jt]sx?$/,
-        loader: 'babel-loader?presets[]=es2016&presets[]=stage-0&presets[]=react!ts-loader',
+      { test: /\.tsx?$/,
+        loader: 'babel-loader!ts-loader',
         exclude: /node_modules/,
         cacheDirectory: true,
+        include,
       }
     ],
+  },
+  ts: {
+    compilerOptions: {
+      noEmit: false,
+    },
   },
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@kadira/storybook": "^2.5.2",
+    "@types/react": "^15.0.17",
     "ava": "^0.17.0",
     "babel-cli": "^6.23.0",
     "babel-core": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -10,14 +10,16 @@
     "sort"
   ],
   "main": "dist/module/module.js",
+  "types": "dist/module/module.d.ts",
   "scripts": {
     "start": "start-storybook -p 6006",
     "test": "ava",
     "watch-test": "ava --watch",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "build": "npm run clean-dist && npm run build-modules && npm run build-umd",
+    "build": "npm run clean-dist && npm run build-modules && npm run build-umd && npm run build-ts",
     "clean-dist": "rimraf dist",
+    "build-ts": "cp src/module.d.ts dist/module/",
     "build-umd": "webpack --config webpack.config.js",
     "build-modules": "cross-env BABEL_ENV=build babel src --out-dir dist/module ",
     "ship-it": "npm run build && npm publish --tag next"
@@ -51,6 +53,8 @@
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.3.2",
     "rimraf": "^2.6.0",
+    "ts-loader": "^2.0.2",
+    "typescript": "^2.2.1",
     "webpack": "^1.14.0",
     "webpack-dev-server": "^1.16.2"
   },

--- a/src/components/CellContainer.js
+++ b/src/components/CellContainer.js
@@ -51,10 +51,7 @@ const ComposedCellContainer = OriginalComponent => compose(
     ...props,
     style: getCellStyles(props.cellProperties, props.style),
     value: props.customComponent ?
-      <props.customComponent
-        value={props.value}
-        griddleKey={props.griddleKey}
-      /> :
+      <props.customComponent {...props} /> :
       props.value
   })})
 )(({ value, style, className }) => (

--- a/src/components/ColumnDefinition.js
+++ b/src/components/ColumnDefinition.js
@@ -24,7 +24,7 @@ export default class ColumnDefinition extends Component {
     customComponent: React.PropTypes.object,
 
     //The component that should be used instead of the normal title
-    customHeaderComponent: React.PropTypes.object,
+    customHeadingComponent: React.PropTypes.object,
 
     //Can this column be sorted
     sortable: React.PropTypes.bool,

--- a/src/components/RowDefinition.js
+++ b/src/components/RowDefinition.js
@@ -11,7 +11,7 @@ export default class RowDefinition extends Component {
     ]),*/
     //The column value that should be used as the key for the row
     //if this is not set it will make one up (not efficient)
-    keyColumn: React.PropTypes.string,
+    rowKey: React.PropTypes.string,
 
     //The column that will be known used to track child data
     //By default this will be "children"

--- a/src/components/RowDefinition.js
+++ b/src/components/RowDefinition.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-export default class extends Component {
+export default class RowDefinition extends Component {
   static propTypes = {
     //Children can be either a single column definition or an array
     //of column definition objects

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -1,0 +1,393 @@
+import * as React from 'react';
+
+interface PropertyBag<T> {
+    [propName: string]: T;
+}
+
+type GriddleComponent<T> = (props: T) => string | JSX.Element | React.ComponentClass<T> | React.StatelessComponent<T>
+
+export namespace components {
+
+export interface RowDefinitionProps {
+    //The column value that should be used as the key for the row
+    //if this is not set it will make one up (not efficient)
+    rowKey?: string;
+
+    // TODO: Unused?
+    //The column that will be known used to track child data
+    //By default this will be "children"
+    childColumnName?: string;
+
+    // TODO: Unused?
+    //This property allows an to set a css class on a row based on
+    //the data within. This should return a css-class name
+    cssFunction?: Function;
+
+    // Allow custom plugin props
+    [x: string]: any,
+}
+
+export class RowDefinition extends React.Component<RowDefinitionProps, any> {
+}
+
+export interface ColumnDefinitionProps {
+    //The name of the column that this definition applies to.
+    id: string,
+
+    //The order that this column appears in. If not specified will just use the order that they are defined
+    order?: number,
+
+    // TODO: Unused?
+    //Determines whether or not the user can disable this column from the settings.
+    locked?: boolean,
+
+    // TODO: Unused? Rename to headingCssClassName?
+    //The css class name to apply to the header for the column
+    headerCssClassName?: string,
+
+    // TODO: Unused?
+    //The css class name to apply to this column.
+    cssClassName?: string,
+
+    //The display name for the column. This is used when the name in the column heading and settings should be different from the data passed in to the Griddle component.
+    title?: string,
+
+    //The component that should be rendered instead of the standard column data. This component will still be rendered inside of a TD element.
+    customComponent?: GriddleComponent<CellProps>,
+
+    //The component that should be used instead of the normal title
+    customHeadingComponent?: GriddleComponent<TableHeadingCellProps>,
+
+    // TODO: Unused?
+    //Can this column be sorted
+    sortable?: boolean,
+
+    // TODO: Unused?
+    //What sort type this column uses - magic string :shame:
+    sortType?: string,
+
+    // TODO: Unused?
+    //Any extra data that should be passed to each instance of this column
+    extraData?: any,
+
+    //The width of this column -- this is string so things like % can be specified
+    width?: number|string,
+
+    // TODO: Unused?
+    //The number of cells this column should extend. Default is 1.
+    colSpan?: number,
+
+    // Is this column visible
+    visible?: boolean,
+
+    // Is this column metadta
+    isMetadata?: boolean,
+
+    // Allow custom plugin props
+    [x: string]: any,
+}
+
+export class ColumnDefinition extends React.Component<ColumnDefinitionProps, any> {
+}
+
+export interface CellProps {
+    value?: any;
+    onClick?: Function;
+    onMouseEnter?: Function;
+    onMouseLeave?: Function;
+    className?: string;
+    style?: React.CSSProperties;
+}
+
+class Cell extends React.Component<CellProps, any> {
+}
+
+export interface RowProps {
+    Cell?: any;
+    griddleKey?: string;
+    columnIds?: number[];
+    onClick?: Function;
+    onMouseEnter?: Function;
+    onMouseLeave?: Function;
+    className?: string;
+    style?: React.CSSProperties;
+}
+
+class Row extends React.Component<RowProps, any> {
+}
+
+export interface TableProps {
+    visibleRows?: number,
+    TableHeading?: any,
+    TableBody?: any,
+    NoResults?: any,
+}
+
+class Table extends React.Component<TableProps, any> {
+}
+
+export interface TableBodyProps {
+    rowIds?: number[];
+    Row?: any;
+    style?: React.CSSProperties;
+    className?: string;
+}
+
+class TableBody extends React.Component<TableBodyProps, any> {
+}
+
+export interface TableHeadingProps {
+    columnIds?: number[];
+    columnTitles?: string[];
+    TableHeadingCell: any;
+}
+
+class TableHeading extends React.Component<TableHeadingProps, any> {
+}
+
+export interface TableHeadingCellProps {
+    title?: string;
+    columnId?: number;
+    onClick?: Function;
+    onMouseEnter?: Function;
+    onMouseLeave?: Function;
+    icon?: any;
+    className?: string;
+    style?: React.CSSProperties;
+}
+
+class TableHeadingCell extends React.Component<TableHeadingCellProps, any> {
+}
+
+const TableContainer: (OriginalComponent: any) => any;
+
+export interface SettingsWrapperProps {
+    SettingsToggle?: GriddleComponent<SettingsToggleProps>;
+    Settings?: GriddleComponent<SettingsProps>;
+    isEnabled?: boolean;
+    isVisible?: boolean;
+    className?: string;
+    style?: React.CSSProperties;
+}
+
+class SettingsWrapper extends React.Component<SettingsWrapperProps, any> {
+}
+
+const SettingsWrapperContainer: (OriginalComponent: any) => any;
+
+export interface SettingsToggleProps {
+    onClick?: Function;
+    text?: any;
+    className?: string;
+    style?: React.CSSProperties;
+}
+
+class SettingsToggle extends React.Component<SettingsToggleProps, any> {
+}
+
+const SettingsToggleContainer: (OriginalComponent: any) => any;
+
+export interface SettingsProps {
+    settingsComponents?: GriddleComponent<any>[];
+    className?: string;
+    style?: React.CSSProperties;
+}
+
+class Settings extends React.Component<SettingsProps, any> {
+}
+
+const SettingsContainer: (OriginalComponent: any) => any;
+
+const SettingsComponents: PropertyBag<GriddleComponent<any>>;
+
+} // namespace components
+
+export interface GriddleComponents {
+    Cell?: any;
+    CellContainer?: any;
+    ColumnDefinition?: any;
+    Row?: any;
+    RowContainer?: any;
+    RowDefinition?: any;
+    Table?: any;
+    TableBody?: any;
+    TableBodyContainer?: any;
+    TableHeading?: any;
+    TableHeadingContainer?: any;
+    TableHeadingCell?: any;
+    TableHeadingCellContainer?: any;
+    TableHeadingCellEnhancer?: any;
+    TableContainer?: any;
+    Layout?: any;
+    LayoutContainer?: any;
+    NextButton?: any;
+    NextButtonEnhancer?: any;
+    NextButtonContainer?: any;
+    NoResults?: any;
+    NoResultsContainer?: any;
+    PageDropdown?: any;
+    PageDropdownContainer?: any;
+    Pagination?: any;
+    PaginationContainer?: any;
+    PreviousButton?: any;
+    PreviousButtonEnhancer?: any;
+    PreviousButtonContainer?: any;
+    Filter?: any;
+    FilterEnhancer?: any;
+    FilterContainer?: any;
+    SettingsToggle?: any;
+    SettingsToggleContainer?: any;
+    SettingsWrapper?: any;
+    SettingsWrapperContainer?: any;
+    Settings?: any;
+    SettingsContainer?: any;
+    SettingsComponents?: PropertyBag<GriddleComponent<any>>;
+}
+
+export interface GriddleEvents {
+    onFilter?: (filterText: string) => void;
+    onSort?: (sortProperties: any) => void;
+    onNext?: () => void;
+    onPrevious?: () => void;
+    onGetPage?: (pageNumber: number) => void;
+}
+
+export interface GriddleSortKey {
+    id: string;
+    sortAscending: boolean;
+}
+
+export interface GriddleStyleElements<T> {
+    Cell?: T;
+    Filter?: T;
+    Loading?: T;
+    NextButton?: T;
+    NoResults?: T;
+    PageDropdown?: T;
+    Pagination?: T;
+    PreviousButton?: T;
+    Row?: T;
+    RowDefinition?: T;
+    Settings?: T;
+    SettingsToggle?: T;
+    Table?: T;
+    TableBody?: T;
+    TableHeading?: T;
+    TableHeadingCell?: T;
+    TableHeadingCellAscending?: T;
+    TableHeadingCellDescending?: T;
+}
+
+export interface GriddleStyleIcons {
+    sortAscendingIcon?: any;
+    sortDescendingIcon?: any;
+}
+
+export interface GriddleStyleConfig {
+    classNames?: GriddleStyleElements<string>;
+    icons?: GriddleStyleElements<GriddleStyleIcons>;
+    styles?: GriddleStyleElements<React.CSSProperties>;
+}
+
+export interface GriddlePageProperties {
+    currentPage?: number;
+    pageSize?: number;
+    recordCount?: number;
+}
+
+interface RowRenderProperties {
+    rowKey?: string;
+    childColumnName?: string;
+    props?: {
+        children: components.ColumnDefinition[];
+    };
+}
+
+interface ColumnRenderProperties {
+    id: string;
+    title?: string;
+    isMetadata?: boolean;
+    order?: number;
+    sortMethod?: (data: any[], column: string, sortAscending?: boolean) => number;
+    visible?: boolean;
+    customComponent?: GriddleComponent<any>;
+    customHeadingComponent?: GriddleComponent<any>;
+}
+
+export interface GriddleRenderProperties {
+    rowProperties?: RowRenderProperties;
+    columnProperties?: PropertyBag<ColumnRenderProperties>;
+}
+
+type Reducer = (state: any, action?: any) => void;
+type Selector = (state: any, props?: any) => any;
+
+interface SettingsComponentObject {
+    order: number;
+    component?: GriddleComponent<any>;
+}
+
+export interface GriddlePlugin {
+    components?: GriddleComponents,
+    renderProperties?: GriddleRenderProperties;
+    initialState?: PropertyBag<any>,
+    reducer?: PropertyBag<Reducer>,
+    selectors?: PropertyBag<Selector>,
+    settingsComponentObjects?: PropertyBag<SettingsComponentObject>,
+}
+
+export interface GriddleProps<T> {
+    plugins?: GriddlePlugin[];
+    data?: T[];
+    events?: GriddleEvents;
+    sortProperties?: GriddleSortKey[];
+    styleConfig?: GriddleStyleConfig;
+    pageProperties?: GriddlePageProperties;
+    components?: GriddleComponents;
+    renderProperties?: GriddleRenderProperties;
+    settingsComponentObjects?: PropertyBag<SettingsComponentObject>;
+}
+
+declare class Griddle<T> extends React.Component<GriddleProps<T>, any> {
+}
+
+export const actions: PropertyBag<Function>;
+
+export const constants: PropertyBag<string>;
+
+export const selectors: PropertyBag<Selector>;
+
+export const settingsComponentObjects: PropertyBag<SettingsComponentObject>;
+
+export namespace utils {
+    const columnUtils: PropertyBag<Function>;
+    const compositionUtils: PropertyBag<Function>;
+    const dataUtils: PropertyBag<Function>;
+    const rowUtils: PropertyBag<Function>;
+    const sortUtils: PropertyBag<Function>;
+}
+
+export namespace plugins {
+    var LocalPlugin : GriddlePlugin;
+
+    interface PositionSettings {
+        // The height of the table
+        tableHeight?: number|string;
+        // The width of the table
+        tableWidth?: number|string;
+        // The minimum row height
+        rowHeight?: number|string;
+        // The minimum column width
+        defaultColumnWidth?: number|string;
+        // Whether or not the header should be fixed
+        fixedHeader?: boolean;
+        // Disable pointer events while scrolling to improve performance
+        disablePointerEvents?: boolean;
+    }
+    var PositionPlugin : (settings: PositionSettings) => GriddlePlugin;
+}
+
+export const ColumnDefinition;
+export const RowDefinition;
+
+export default Griddle;

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -373,14 +373,22 @@ export namespace plugins {
     interface PositionSettings {
         // The height of the table
         tableHeight?: number|string;
+
         // The width of the table
         tableWidth?: number|string;
+
         // The minimum row height
         rowHeight?: number|string;
+
+        // TODO: Unused?
         // The minimum column width
         defaultColumnWidth?: number|string;
+
+        // TODO: Unused?
         // Whether or not the header should be fixed
         fixedHeader?: boolean;
+
+        // TODO: Unused?
         // Disable pointer events while scrolling to improve performance
         disablePointerEvents?: boolean;
     }

--- a/stories/fakeData.d.ts
+++ b/stories/fakeData.d.ts
@@ -1,0 +1,13 @@
+export interface FakeData {
+    id: number;
+    name: string;
+    city: string;
+    state: string;
+    country: string;
+    company: string;
+    favoriteNumber: number;
+}
+
+declare const fakeData: FakeData[];
+
+export default fakeData;

--- a/stories/fakeData2.d.ts
+++ b/stories/fakeData2.d.ts
@@ -1,0 +1,12 @@
+import { FakeData } from "./fakeData";
+
+declare class person {
+    constructor(data: FakeData);
+}
+
+declare class personClass {
+    constructor(data: FakeData);
+}
+
+declare const fakeData2: person[];
+declare const fakeData3: personClass[];

--- a/stories/index.js
+++ b/stories/index.js
@@ -8,27 +8,16 @@ import withHandlers from 'recompose/withHandlers';
 import withState from 'recompose/withState';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-
-import Griddle from '../src/index';
-import Cell from '../src/components/Cell';
-import Row from '../src/components/Row';
-import TableBody from '../src/components/TableBody';
-import TableHeadingCell from '../src/components/TableHeadingCell';
-import TableHeading from '../src/components/TableHeading';
-import { Table } from '../src/components/Table';
-import TableContainer from '../src/components/TableContainer';
-import ColumnDefinition from '../src/components/ColumnDefinition';
-import RowDefinition from '../src/components/RowDefinition';
-const { SettingsWrapper, SettingsToggle, Settings } = '../src/components';
 import _ from 'lodash';
-import * as actions from '../src/actions';
-import * as selectors from '../src/selectors/dataSelectors';
-import { rowDataSelector } from '../src/plugins/local/selectors/localSelectors';
+
+import Griddle, { actions, components, selectors, plugins, ColumnDefinition, RowDefinition } from '../src/module';
+const { Cell, Row, Table, TableContainer, TableBody, TableHeading, TableHeadingCell } = components;
+
+const { LocalPlugin, PositionPlugin } = plugins;
+const { rowDataSelector } = LocalPlugin.selectors;
+
 import fakeData from './fakeData';
 import {fakeData2, fakeData3} from './fakeData2';
-
-import LocalPlugin from '../src/plugins/local';
-import PositionPlugin from '../src/plugins/position';
 
 function sortBySecondCharacter(data, column, sortAscending = true) {
   return data.sort(

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1,5 +1,5 @@
-import React, { Component } from 'react';
-import { storiesOf, action, linkTo } from '@kadira/storybook';
+import * as React from 'react';
+import { module, storiesOf, action, linkTo } from '@kadira/storybook';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
@@ -10,14 +10,18 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import _ from 'lodash';
 
-import Griddle, { actions, components, selectors, plugins, ColumnDefinition, RowDefinition } from '../src/module';
+import GenericGriddle, { actions, components, selectors, plugins, ColumnDefinition, RowDefinition } from '../src/module';
 const { Cell, Row, Table, TableContainer, TableBody, TableHeading, TableHeadingCell } = components;
+const { SettingsWrapper, SettingsToggle, Settings } = components;
 
 const { LocalPlugin, PositionPlugin } = plugins;
 const { rowDataSelector } = LocalPlugin.selectors;
 
-import fakeData from './fakeData';
-import {fakeData2, fakeData3} from './fakeData2';
+import fakeData, { FakeData } from './fakeData';
+import { person, fakeData2, personClass, fakeData3 } from './fakeData2';
+
+type Griddle = new () => GenericGriddle<FakeData>;
+const Griddle = GenericGriddle as Griddle;
 
 function sortBySecondCharacter(data, column, sortAscending = true) {
   return data.sort(
@@ -149,7 +153,7 @@ storiesOf('Griddle main', module)
   })
   .add('with controlled griddle component', () => {
 
-    class Something extends React.Component {
+    class Something extends React.Component<void, any> {
       constructor() {
         super();
 
@@ -290,6 +294,9 @@ storiesOf('Griddle main', module)
     )
   })
   .add('set fakeData to constructed Objects', () => {
+    type Griddle = new () => GenericGriddle<person>;
+    const Griddle = GenericGriddle as Griddle;
+
     return (
       <Griddle data={fakeData2} plugins={[LocalPlugin]}>
         <RowDefinition>
@@ -298,6 +305,9 @@ storiesOf('Griddle main', module)
     )
   })
   .add('set fakeData to class Objects', () => {
+    type Griddle = new () => GenericGriddle<personClass>;
+    const Griddle = GenericGriddle as Griddle;
+
     return (
       <Griddle data={fakeData3} plugins={[LocalPlugin]}>
         <RowDefinition>
@@ -306,7 +316,22 @@ storiesOf('Griddle main', module)
     )
   })
   .add('with nested column data', () => {
-    const localData = [
+    interface NestedData {
+        id: number,
+        name: string,
+        location: {
+            country: string,
+            city: string,
+            state: string,
+        },
+        company: string,
+        favoriteNumber: number,
+    }
+
+    type Griddle = new () => GenericGriddle<NestedData>;
+    const Griddle = GenericGriddle as Griddle;
+
+    const localData: NestedData[] = [
       {
         "id": 0,
         "name": "Mayer Leonard",
@@ -425,6 +450,16 @@ storiesOf('Bug fixes', module)
     );
   })
   .add('Date values converted to null', () => {
+    interface DateData {
+        _id: number,
+        foo: string,
+        date: Date,
+        bar: string,
+    }
+
+    type Griddle = new () => GenericGriddle<DateData>;
+    const Griddle = GenericGriddle as Griddle;
+
     const dateData = [
       {
         _id: 1,
@@ -451,7 +486,7 @@ storiesOf('Bug fixes', module)
     );
   })
   .add('Delete row', () => {
-     const enhanceWithOnClick = onClick => class ComputeThing extends Component {
+     const enhanceWithOnClick = onClick => class ComputeThing extends React.Component<any, any> {
       static propTypes = {
         rowData: React.PropTypes.object.isRequired,
       }
@@ -474,7 +509,9 @@ storiesOf('Bug fixes', module)
      }
 
 
-    class SomeComponent extends Component {
+    class SomeComponent extends React.Component<void, {data: FakeData[]}> {
+      private Component;
+
       constructor(props) {
         super(props);
 
@@ -772,7 +809,7 @@ storiesOf('TableContainer', module)
       </tbody>
     );
 
-    class BaseWithContext extends React.Component {
+    class BaseWithContext extends React.Component<any, void> {
       static childContextTypes = {
         components: React.PropTypes.object.isRequired
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,6 @@
     "forceConsistentCasingInFileNames": true
   },
   "files": [
+    "stories/index.tsx"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6",
+      "dom"
+    ],
+    "allowJs": true,
+    "jsx": "preserve",
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false,
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+  ]
+}


### PR DESCRIPTION
This should close #611, eventually. I figure the questions asked there are better answered with visuals.

> The other thought is would it be possible to test the types via unit tests instead or would that be way more work? I'd love it if there was something that would allow those who are using JavaScript to continue doing so with Griddle codebase but also make life easier for folks who are using Griddle in a typescript project all while ensuring that the types are up-to-date as we make changes in Griddle.

Ultimately type definitions are about codifying valid usage of the library, so they are best tested with real-world use cases. That could be achieved using a [standalone `tsx` test file](https://github.com/NewBoCo/DefinitelyTyped/blob/b16bfba18fc6c227fba117c4e30fa6b5691ce358/griddle-react/griddle-react-tests.tsx), but I'm not sure if doubling the work would be worth it.

> I do like the thought of validating this through stories but I have some potential concern around converting the storybook over. We are hoping that when bugs are encountered that people will submit a PR with a story that demonstrates the issue. Would converting the storybook over to TypeScript also mean that people would have to use TypeScript for this venture?

I wasn't sure how to quantify how much would need to change, so I just went through with the conversion to demonstrate what needs to be done differently. I'll add a review to this PR to walk through what needed to change, but in short: not much, especially if they can use `fakeData`.

Unfortunately, I apparently don't know Storybook and Webpack well enough to get this over the finish line. I'm getting a rather confusing error that I'm hoping someone can help me troubleshoot:

```
ERROR in ./.storybook/config.js
Module build failed: Error: Could not find file: 'C:\Dev\NewBoCo\Griddle\.storybook\config.js'.
    at getValidSourceFile (C:\Dev\NewBoCo\Griddle\node_modules\typescript\lib\typescript.js:81080:23)
    at Object.getEmitOutput (C:\Dev\NewBoCo\Griddle\node_modules\typescript\lib\typescript.js:81446:30)
    at getEmit (C:\Dev\NewBoCo\Griddle\node_modules\ts-loader\dist\index.js:99:43)
    at Object.loader (C:\Dev\NewBoCo\Griddle\node_modules\ts-loader\dist\index.js:27:11)
```

Finally, I could use some feedback on the the type definition itself. I believe it's relatively complete, except the component types and `GriddleComponents` properties.

**Update:**

* [x] Griddle
  * [ ] GriddleComponents
* [ ] actions
* [ ] components
  * [x] Cell
  * [ ] CellContainer
  * [x] ColumnDefinition
  * [x] Row
  * [ ] RowContainer
  * [x] RowDefinition
  * [x] Table
  * [x] TableBody
  * [ ] TableBodyContainer
  * [x] TableHeading
  * [ ] TableHeadingContainer
  * [x] TableHeadingCell
  * [ ] TableHeadingCellContainer
  * [ ] TableHeadingCellEnhancer
  * [ ] TableContainer
  * [ ] Layout
  * [ ] LayoutContainer
  * [ ] NextButton
  * [ ] NextButtonEnhancer
  * [ ] NextButtonContainer
  * [ ] NoResults
  * [ ] NoResultsContainer
  * [ ] PageDropdown
  * [ ] PageDropdownContainer
  * [ ] Pagination
  * [ ] PaginationContainer
  * [ ] PreviousButton
  * [ ] PreviousButtonEnhancer
  * [ ] PreviousButtonContainer
  * [ ] Filter
  * [ ] FilterEnhancer
  * [ ] FilterContainer
  * [x] SettingsToggle
  * [ ] SettingsToggleContainer
  * [x] SettingsWrapper
  * [ ] SettingsWrapperContainer
  * [x] Settings
  * [ ] SettingsContainer
* [ ] selectors
* [x] settingsComponentObjects
* [ ] utils
* [x] plugins
* [x] ColumnDefintion
* [x] RowDefinition