### PR TITLE
Table/NoResults Improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "npm run clean-dist && npm run build-modules && npm run build-umd",
     "clean-dist": "rimraf dist",
     "build-umd": "webpack --config webpack.config.js",
-    "build-modules": "BABEL_ENV=build babel src --out-dir dist/module ",
+    "build-modules": "cross-env BABEL_ENV=build babel src --out-dir dist/module ",
     "ship-it": "npm run build && npm publish --tag next"
   },
   "peerDependencies": {
@@ -36,6 +36,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.0.0",
     "babel-register": "^6.9.0",
+    "cross-env": "^3.2.4",
     "enzyme": "^2.7.1",
     "eslint": "^3.9.1",
     "eslint-config-airbnb": "^14.0.0",

--- a/src/components/NoResults.js
+++ b/src/components/NoResults.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const NoResults = (className, style) => (
+const NoResults = ({ className, style }) => (
   <div style={style} className={className}>
     No results found.
   </div>

--- a/src/components/NoResultsContainer.js
+++ b/src/components/NoResultsContainer.js
@@ -3,8 +3,7 @@ import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
-
-import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+import { columnTitlesSelector, columnIdsSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
 const NoResultsContainer = OriginalComponent => compose(
   getContext({
@@ -12,6 +11,8 @@ const NoResultsContainer = OriginalComponent => compose(
   }),
   connect(
     state => ({
+      columnTitles: columnTitlesSelector(state),
+      columnIds: columnIdsSelector(state),
       className: classNamesForComponentSelector(state, 'NoResults'),
       style: stylesForComponentSelector(state, 'NoResults'),
     })

--- a/src/components/NoResultsContainer.js
+++ b/src/components/NoResultsContainer.js
@@ -3,7 +3,8 @@ import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
-import { columnTitlesSelector, columnIdsSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+
+import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
 const NoResultsContainer = OriginalComponent => compose(
   getContext({
@@ -11,8 +12,6 @@ const NoResultsContainer = OriginalComponent => compose(
   }),
   connect(
     state => ({
-      columnTitles: columnTitlesSelector(state),
-      columnIds: columnIdsSelector(state),
       className: classNamesForComponentSelector(state, 'NoResults'),
       style: stylesForComponentSelector(state, 'NoResults'),
     })

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -8,7 +8,7 @@ export const Table = ({ TableHeading, TableBody, NoResults, style, className, vi
     </table>
   ) :
   (
-    <NoResults />
+    NoResults && <NoResults />
   );
 
 export default Table;

--- a/src/components/TableHeading.js
+++ b/src/components/TableHeading.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const TableHeading = ({ columnTitles, columnIds, TableHeadingCell, style, className }) => {
-  const headingCells = columnTitles && columnTitles.map((t, i) => <TableHeadingCell key={columnIds[i]} title={t} columnId={columnIds[i]} />);
+  const headingCells = columnIds && columnTitles && columnTitles.map((t, i) => <TableHeadingCell key={columnIds[i]} title={t} columnId={columnIds[i]} />);
 
   return (
     <thead style={style} className={className}>

--- a/src/components/__tests__/CellTest.js
+++ b/src/components/__tests__/CellTest.js
@@ -27,8 +27,8 @@ test('onClick works', (t) => {
 test('onMouseEnter works', (t) => {
   let over = false;
 
-  const onMouseOver = () => { over = true; };
-  const wrapper = shallow(<Cell onMouseEnter={onMouseOver} />);
+  const onMouseEnter = () => { over = true; };
+  const wrapper = shallow(<Cell onMouseEnter={onMouseEnter} />);
   wrapper.simulate('mouseEnter');
 
   t.true(over);

--- a/src/reducers/__tests__/dataReducerTest.js
+++ b/src/reducers/__tests__/dataReducerTest.js
@@ -50,7 +50,24 @@ test('does not adjust column properties if exists already', test => {
   test.deepEqual(state.getIn(['renderProperties', 'columnProperties']).toJSON(), {
     one: { id: 'one', visible: true }
   });
-})
+});
+
+[undefined, null].map(data =>
+  test(`does not adjust column properties if data is ${data}`, (assert) => {
+    const state = reducers.GRIDDLE_INITIALIZED({
+      data,
+      renderProperties: {
+        columnProperties: {
+          one: { id: 'one', visible: true }
+        }
+      }
+    });
+
+    assert.deepEqual(state.getIn(['renderProperties', 'columnProperties']).toJSON(), {
+      one: { id: 'one', visible: true }
+    });
+  })
+);
 
 test('sets data', test => {
   const reducedState = reducers.GRIDDLE_LOADED_DATA(Immutable.fromJS({ renderProperties: {} }),

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -49,7 +49,7 @@ export function GRIDDLE_INITIALIZED(initialState) {
   //TODO: could probably make this more efficient by removing data
   // making the rest of the properties initial state and
   // setting the mapped data on the new initial state immutable object
-  if(initialState.hasOwnProperty('data') &&
+  if (initialState.data &&
     initialState.data.length > 0) {
       const transformedData = transformData(initialState.data, initialState.renderProperties);
       tempState.data = transformedData.data;

--- a/src/selectors/__tests__/dataSelectorsTest.js
+++ b/src/selectors/__tests__/dataSelectorsTest.js
@@ -279,3 +279,25 @@ test('it gets columnTitles in the correct order', test => {
 
   test.deepEqual(selectors.columnTitlesSelector(state), ['Two', 'One']);
 });
+
+[undefined, null].map(data =>
+  test(`visibleRowIds is empty if data is ${data}`, (assert) => {
+    const state = new Immutable.fromJS({
+      data
+    });
+
+    assert.deepEqual(selectors.visibleRowIdsSelector(state), new Immutable.List());
+  })
+);
+
+test('visibleRowIds gets griddleKey from data', (assert) => {
+  const state = new Immutable.fromJS({
+    data: [
+      { griddleKey: 2 },
+      { griddleKey: 4 },
+      { griddleKey: 6 },
+    ],
+  });
+
+  assert.deepEqual(selectors.visibleRowIdsSelector(state), new Immutable.List([2, 4, 6]));
+});

--- a/src/selectors/dataSelectors.js
+++ b/src/selectors/dataSelectors.js
@@ -241,7 +241,7 @@ export const columnTitlesSelector = createSelector(
 /** Gets the griddleIds for the visible rows */
 export const visibleRowIdsSelector = createSelector(
   dataSelector,
-  currentPageData => currentPageData.map(c => c.get('griddleKey'))
+  currentPageData => currentPageData ? currentPageData.map(c => c.get('griddleKey')) : new Immutable.List()
 );
 
 /** Gets the count of visible rows */

--- a/src/selectors/dataSelectors.js
+++ b/src/selectors/dataSelectors.js
@@ -215,21 +215,18 @@ export const textSelector = (state, { key}) => {
 /** Gets the column ids for the visible columns
 */
 export const columnIdsSelector = createSelector(
-  dataSelector,
   renderPropertiesSelector,
   visibleColumnsSelector,
-  (visibleData, renderProperties, visibleColumns) => {
+  (renderProperties, visibleColumns) => {
     const offset = 1000;
     // TODO: Make this better -- This is pretty inefficient
-    if (visibleData.size > 0) {
-      return visibleColumns
-        .map((k, index) => ({
-          id: renderProperties.getIn(['columnProperties', k, 'id']) || k,
-          order: renderProperties.getIn(['columnProperties', k, 'order']) || offset + index
-        }))
-        .sort((first, second) => first.order - second.order)
-        .map(item => item.id);
-    }
+    return visibleColumns
+      .map((k, index) => ({
+        id: renderProperties.getIn(['columnProperties', k, 'id']) || k,
+        order: renderProperties.getIn(['columnProperties', k, 'order']) || offset + index
+      }))
+      .sort((first, second) => first.order - second.order)
+      .map(item => item.id);
   }
 );
 

--- a/src/utils/__tests__/dataUtilsTests.js
+++ b/src/utils/__tests__/dataUtilsTests.js
@@ -3,6 +3,7 @@ import test from 'ava';
 import Immutable from 'immutable';
 
 import {
+  hasData,
   transformData,
 } from '../dataUtils';
 
@@ -11,6 +12,28 @@ const collection = Immutable.fromJS([
   { name: 'two' },
   { name: 'three' }
 ]);
+
+test('hasData is false when data does not exist', (assert) => {
+  const res = hasData({});
+  assert.is(res, false);
+});
+
+[undefined, null].map(data =>
+  test(`hasData is false when data is ${data}`, (assert) => {
+    const res = hasData({ data });
+    assert.is(res, false);
+  })
+);
+
+test('hasData is false when data is empty', (assert) => {
+  const res = hasData({ data: [] });
+  assert.is(res, false);
+});
+
+test('hasData is false when data is not empty', (assert) => {
+  const res = hasData({ data: [{}] });
+  assert.is(res, true);
+});
 
 test('transforms data', test => {
   const data = [

--- a/src/utils/dataUtils.js
+++ b/src/utils/dataUtils.js
@@ -109,11 +109,9 @@ export function hasColumnProperties(stateObject) {
 
 /** Does this initial state object have data?
  * @param (object) stateObject - a non-immutable state object for initialization
- *
- * TODO: Needs tests
  */
 export function hasData(stateObject) {
-  return stateObject.hasOwnProperty('data') && stateObject.data.length > 0;
+  return !!stateObject.data && stateObject.data.length > 0;
 }
 
 /** Gets a new state object (not immutable) that has columnProperties if none exist

--- a/stories/index.js
+++ b/stories/index.js
@@ -660,6 +660,18 @@ storiesOf('TableHeading', module)
 
 storiesOf('Table', module)
   .add('base table', () => {
+    const noResults = props => (
+      <p>Nothing!</p>
+    );
+
+    return (
+      <Table
+        NoResults={noResults}
+      />
+    );
+  })
+
+  .add('base table with visibleRows', () => {
     const tableHeading = props => (
       <thead>
         <tr>
@@ -682,6 +694,7 @@ storiesOf('Table', module)
 
     return (
       <Table
+        visibleRows={1}
         TableHeading={tableHeading}
         TableBody={tableBody}
       />

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
 import { storiesOf, action, linkTo } from '@kadira/storybook';
+import compose from 'recompose/compose';
+import mapProps from 'recompose/mapProps';
+import getContext from 'recompose/getContext';
 import withContext from 'recompose/withContext';
 import { connect } from 'react-redux';
 
@@ -14,6 +17,7 @@ import TableContainer from '../src/components/TableContainer';
 import ColumnDefinition from '../src/components/ColumnDefinition';
 import RowDefinition from '../src/components/RowDefinition';
 import _ from 'lodash';
+import { columnIdsSelector, stylesForComponentSelector } from '../src/selectors/dataSelectors';
 import { rowDataSelector } from '../src/plugins/local/selectors/localSelectors';
 import fakeData from './fakeData';
 import {fakeData2, fakeData3} from './fakeData2';
@@ -678,6 +682,21 @@ storiesOf('Table', module)
           <TableHeading />
           { visibleRows ? (TableBody && <TableBody />) : (NoResults && <NoResults />) }
         </table>
+      ),
+      NoResultsContainer: compose(
+        getContext({
+          components: React.PropTypes.object,
+        }),
+        connect(
+          state => ({
+            columnIds: columnIdsSelector(state),
+            style: stylesForComponentSelector(state, 'NoResults'),
+          })
+        ),
+        mapProps(props => ({
+          NoResults: props.components.NoResults,
+          ...props
+        }))
       ),
       NoResults: ({ columnIds, style }) => (
         <tr style={style}>

--- a/stories/index.js
+++ b/stories/index.js
@@ -671,6 +671,42 @@ storiesOf('Table', module)
     );
   })
 
+  .add('empty with columns', () => {
+    const components = {
+      Table: ({ TableHeading, TableBody, NoResults, style, visibleRows }) => (
+        <table style={style}>
+          <TableHeading />
+          { visibleRows ? (TableBody && <TableBody />) : (NoResults && <NoResults />) }
+        </table>
+      ),
+      NoResults: ({ columnIds, style }) => (
+        <tr style={style}>
+          <td colSpan={columnIds.length}>Nothing!</td>
+        </tr>
+      ),
+    };
+    const styleConfig = {
+      styles: {
+        NoResults: {
+          backgroundColor: "#eee",
+          textAlign: "center",
+        },
+        Table: {
+          width: "80%",
+        },
+      },
+    };
+
+    return (
+      <Griddle components={components} styleConfig={styleConfig}>
+        <RowDefinition>
+          <ColumnDefinition id="name" order={2} />
+          <ColumnDefinition id="state" order={1} />
+        </RowDefinition>
+      </Griddle>
+    );
+  })
+
   .add('base table with visibleRows', () => {
     const tableHeading = props => (
       <thead>

--- a/stories/index.js
+++ b/stories/index.js
@@ -398,8 +398,8 @@ storiesOf('Cell', module)
             className="someClass"
             style={{ fontSize: 20, color: "#FAB" }}
             onClick={() => console.log('clicked')}
-            onMouseOver={() => console.log('mouse over')}
-            onMouseOut={() => console.log('mouse out')}
+            onMouseEnter={() => console.log('mouse over')}
+            onMouseLeave={() => console.log('mouse out')}
           />
       </tr>
       </tbody>
@@ -568,20 +568,14 @@ storiesOf('Bug fixes', module)
 
 storiesOf('Row', module)
   .add('base row', () => {
-    const cells = [
-      <td>One</td>,
-      <td>Two</td>,
-      <td>Three</td>
-    ];
+    const columnIds = [ 1, 2, 3 ];
 
     return (
       <table>
         <tbody>
           <Row
-            cells={cells}
-            onClick={() => console.log('clicked')}
-            onMouseOver={() => console.log('mouse over')}
-            onMouseOut={() => console.log('mouse out')}
+            Cell={({columnId}) => <td>Cell {columnId}</td>}
+            columnIds={columnIds}
           />
         </tbody>
       </table>
@@ -644,8 +638,8 @@ storiesOf('TableHeadingCell', module)
             <TableHeadingCell
               title="New Title"
               onClick={() => console.log('clicked')}
-              onMouseOver={() => console.log('mouse over')}
-              onMouseOut={() => console.log('mouse out')}
+              onMouseEnter={() => console.log('mouse over')}
+              onMouseLeave={() => console.log('mouse out')}
             />
           </tr>
         </thead>


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

Acknowledging that #618 is a lot to handle, I figure I might as well pull some of it out (plus some changes) that should be easier to review in isolation.

* A few of the trivial storybook fixes from #618
* A few dev environment improvements:
  * For LF from Git on Windows
  * [cross-env](https://www.npmjs.com/package/cross-env) for builds on Windows
  * [EditorConfig](http://editorconfig.org/) for anyone
* `Table`, `TableHeading` and `NoResults` are now generally more resilient
* `NoResults` props actually work
* If `data` is `null` or `undefined`, `NoResults` is rendered instead of runtime errors (with tests!)
* `NoResults` now receives `columnIds` and `columnTitles` (consistent with `TableHeading`; mostly useful for column count)

## Why these changes are made

The primary use case, for which I added a story, is a `Table` component which renders `NoResults` below its `TableHeading` instead of having `NoResults` replace the whole `<table />`.

Closes #615 

## Are there tests?

Yes!