### PR TITLE
Settings Component Customization

### DIFF
--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -3,7 +3,7 @@ import React from 'react';
 // This is responsible for rendering the individual settings sections
 const Settings = ({ settingsComponents, style, className }) => (
   <div style={style} className={className}>
-    {settingsComponents && settingsComponents.map((SettingsComponent, i) => <div key={SettingsComponent.key || i}><SettingsComponent /></div>)}
+    {settingsComponents && settingsComponents.map((SettingsComponent, i) => SettingsComponent && <div key={SettingsComponent.key || i}><SettingsComponent /></div>)}
   </div>
 )
 

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -3,7 +3,7 @@ import React from 'react';
 // This is responsible for rendering the individual settings sections
 const Settings = ({ settingsComponents, style, className }) => (
   <div style={style} className={className}>
-    {settingsComponents && settingsComponents.map((SettingsComponent) => <div><SettingsComponent /></div>)}
+    {settingsComponents && settingsComponents.map((SettingsComponent, i) => <div key={SettingsComponent.key || i}><SettingsComponent /></div>)}
   </div>
 )
 

--- a/src/components/SettingsContainer.js
+++ b/src/components/SettingsContainer.js
@@ -9,7 +9,7 @@ import { classNamesForComponentSelector, stylesForComponentSelector } from '../s
 function getSettingsComponentsArrayFromObject(settingsObject) {
   //TODO: determine if we need to make this faster
   return settingsObject ? Object.keys(settingsObject)
-    .map(key => settingsObject[key].component) : null;
+    .map(key => settingsObject[key] && settingsObject[key].component) : null;
 }
 
 const EnhancedSettings = OriginalComponent => compose(

--- a/src/components/SettingsContainer.js
+++ b/src/components/SettingsContainer.js
@@ -9,6 +9,10 @@ import { classNamesForComponentSelector, stylesForComponentSelector } from '../s
 function getSettingsComponentsArrayFromObject(settingsObject, settingsComponents) {
   //TODO: determine if we need to make this faster
   return settingsObject ? Object.keys(settingsObject)
+    .sort((a, b) => {
+      var oa = settingsObject[a], ob = settingsObject[b];
+      return ((oa && oa.order) || 0) - ((ob && ob.order) || 0);
+    })
     .map(key => (settingsObject[key] && settingsObject[key].component) || (settingsComponents && settingsComponents[key])) : null;
 }
 

--- a/src/components/SettingsContainer.js
+++ b/src/components/SettingsContainer.js
@@ -6,14 +6,15 @@ import getContext from 'recompose/getContext';
 
 import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
-function getSettingsComponentsArrayFromObject(settingsObject) {
+function getSettingsComponentsArrayFromObject(settingsObject, settingsComponents) {
   //TODO: determine if we need to make this faster
   return settingsObject ? Object.keys(settingsObject)
-    .map(key => settingsObject[key] && settingsObject[key].component) : null;
+    .map(key => (settingsObject[key] && settingsObject[key].component) || (settingsComponents && settingsComponents[key])) : null;
 }
 
 const EnhancedSettings = OriginalComponent => compose(
   getContext({
+    components: PropTypes.object,
     settingsComponentObjects: PropTypes.object
   }),
   connect(
@@ -23,9 +24,9 @@ const EnhancedSettings = OriginalComponent => compose(
     })
   ),
   mapProps(props => {
-    const { settingsComponentObjects, ...otherProps } = props;
+    const { components, settingsComponentObjects, ...otherProps } = props;
     return {
-      settingsComponents: getSettingsComponentsArrayFromObject(settingsComponentObjects),
+      settingsComponents: getSettingsComponentsArrayFromObject(settingsComponentObjects, components.SettingsComponents),
       ...otherProps,
     };
   })

--- a/src/components/__tests__/SettingsTest.js
+++ b/src/components/__tests__/SettingsTest.js
@@ -31,3 +31,10 @@ test('renders each settings component', (t) => {
   t.true(one.matchesElement(<div className="one">One</div>));
   t.true(two.matchesElement(<div className="two">Two</div>));
 });
+
+test('ignores missing components', (t) => {
+  const settingsComponents = [null, undefined];
+  const wrapper = shallow(<Settings settingsComponents={settingsComponents} />);
+
+  t.true(wrapper.matchesElement(<div />));
+});

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -26,6 +26,7 @@ import SettingsWrapper from './SettingsWrapper';
 import SettingsWrapperContainer from './SettingsWrapperContainer';
 import Settings from './Settings';
 import SettingsContainer from './SettingsContainer';
+import { components as SettingsComponents } from '../settingsComponentObjects';
 import NextButton from './NextButton';
 import NextButtonEnhancer from './NextButtonEnhancer';
 import NextButtonContainer from './NextButtonContainer';
@@ -76,6 +77,7 @@ const components = {
   SettingsWrapperContainer,
   Settings,
   SettingsContainer,
+  SettingsComponents,
 };
 
 export default components;

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ class Griddle extends Component {
   constructor(props) {
     super(props);
 
-    const { plugins=[], data, children:rowPropertiesComponent, events={}, sortProperties={}, styleConfig={}, pageProperties:importedPageProperties, components:userComponents, renderProperties:userRenderProperties={}} = props;
+    const { plugins=[], data, children:rowPropertiesComponent, events={}, sortProperties={}, styleConfig={}, pageProperties:importedPageProperties, components:userComponents, renderProperties:userRenderProperties={}, settingsComponentObjects:userSettingsComponentObjects } = props;
 
     const rowProperties = getRowProperties(rowPropertiesComponent);
     const columnProperties = getColumnProperties(rowPropertiesComponent);
@@ -88,7 +88,7 @@ class Griddle extends Component {
     //Combine / Compose the components to make a single component for each component type
     this.components = buildGriddleComponents([components, ...plugins.map(p => p.components), userComponents]);
 
-    this.settingsComponentObjects = Object.assign({}, settingsComponentObjects, ...plugins.map(p => p.settingsComponentObjects));
+    this.settingsComponentObjects = Object.assign({}, settingsComponentObjects, ...plugins.map(p => p.settingsComponentObjects), userSettingsComponentObjects);
 
     this.events = Object.assign({}, events, ...plugins.map(p => p.events));
 

--- a/src/settingsComponentObjects/ColumnChooser.js
+++ b/src/settingsComponentObjects/ColumnChooser.js
@@ -40,7 +40,7 @@ return (
             type="checkbox"
             name={visibleColumns[v].id}
             checked
-            onClick={onToggle}
+            onChange={onToggle}
           />
           {visibleColumns[v].title || visibleColumns[v].id}
         </label>
@@ -57,7 +57,7 @@ return (
           <input
             type="checkbox"
             name={hiddenColumns[v].id}
-            onClick={onToggle}
+            onChange={onToggle}
             defaultChecked={false}
           />
           {hiddenColumns[v].title || hiddenColumns[v].id}

--- a/src/settingsComponentObjects/index.js
+++ b/src/settingsComponentObjects/index.js
@@ -1,9 +1,12 @@
 import PageSizeSettings from './PageSizeSettings';
 import ColumnChooser from './ColumnChooser';
 
-const components = {
-  pageSizeSettings: { order: 1, component: PageSizeSettings },
-  columnChooser: { order: 2, component: ColumnChooser }
+export const components = {
+  pageSizeSettings: PageSizeSettings,
+  columnChooser: ColumnChooser,
 };
 
-export default components;
+export default {
+  pageSizeSettings: { order: 1 },
+  columnChooser: { order: 2 },
+};

--- a/stories/index.js
+++ b/stories/index.js
@@ -862,6 +862,18 @@ storiesOf('Settings', module)
       <Griddle data={fakeData} plugins={[LocalPlugin,plugin]} />
     );
   })
+  .add('reorder built-in settings', () => {
+    const settingsComponentObjects = {
+      before: { order: 1, component: () => <div>Before</div> },
+      columnChooser: { order: 2 },
+      between: { order: 3, component: () => <div>Between</div> },
+      pageSizeSettings: { order: 4 },
+      after: { order: 5, component: () => <div>After</div> },
+    };
+    return (
+      <Griddle data={fakeData} plugins={[LocalPlugin]} settingsComponentObjects={settingsComponentObjects} />
+    );
+  })
 
   .add('custom column chooser', () => {
     const columnChooser =

--- a/stories/index.js
+++ b/stories/index.js
@@ -16,6 +16,7 @@ import { Table } from '../src/components/Table';
 import TableContainer from '../src/components/TableContainer';
 import ColumnDefinition from '../src/components/ColumnDefinition';
 import RowDefinition from '../src/components/RowDefinition';
+const { SettingsWrapper, SettingsToggle, Settings } = '../src/components';
 import _ from 'lodash';
 import { columnIdsSelector, stylesForComponentSelector } from '../src/selectors/dataSelectors';
 import { rowDataSelector } from '../src/plugins/local/selectors/localSelectors';
@@ -807,5 +808,40 @@ storiesOf('TableContainer', module)
       <BaseWithContext>
         <TableComposed />
       </BaseWithContext>
+    );
+  })
+
+storiesOf('SettingsWrapper', module)
+  .add('base disabled', () => {
+    return (
+      <SettingsWrapper />
+    );
+  })
+  .add('base enabled not visible', () => {
+    const toggle = (props) => <div>Toggle!</div>;
+    return (
+      <SettingsWrapper isEnabled={true} SettingsToggle={toggle} />
+    );
+  })
+  .add('base enabled and visible', () => {
+    const settings = (props) => <div>Settings!</div>;
+    return (
+      <SettingsWrapper isEnabled={true} isVisible={true} Settings={settings} />
+    );
+  })
+
+storiesOf('SettingsToggle', module)
+  .add('base', () => {
+    const onClick = () => console.log('toggle');
+    return (
+      <SettingsToggle onClick={onClick} text={"Toggle!"} />
+    );
+  })
+
+storiesOf('Settings', module)
+  .add('base', () => {
+    const components = [1,2,3].map((n, i) => (props) => <div>Settings {n}</div>);
+    return (
+      <Settings settingsComponents={components} />
     );
   })

--- a/stories/index.js
+++ b/stories/index.js
@@ -851,9 +851,10 @@ storiesOf('Settings', module)
   })
   .add('remove built-in settings', () => {
     const plugin = {
+      components: {
+        SettingsComponents: null,
+      },
       settingsComponentObjects: {
-        pageSizeSettings: null,
-        columnChooser: { order: 0, component: null },
         fancy: { order: 1, component: () => <div>Fancy Settings Component</div> },
       },
     }
@@ -902,8 +903,10 @@ storiesOf('Settings', module)
       )});
 
     const SimpleColumnChooserPlugin = {
-      settingsComponentObjects: {
-        columnChooser: { order: 2, component: columnChooser },
+      components:{
+        SettingsComponents: {
+          columnChooser,
+        },
       },
     };
 
@@ -938,8 +941,10 @@ storiesOf('Settings', module)
       )});
 
     const PageSizeDropDownPlugin = (config) => ({
-      settingsComponentObjects: {
-        pageSizeSettings: { order: 1, component: pageSizeSettings(config) },
+      components: {
+        SettingsComponents: {
+          pageSizeSettings: pageSizeSettings(config),
+        },
       },
     });
 

--- a/stories/index.js
+++ b/stories/index.js
@@ -911,7 +911,7 @@ storiesOf('Settings', module)
     };
 
     return (
-      <Griddle data={fakeData} plugins={[LocalPlugin,SimpleColumnChooserPlugin]} />
+      <Griddle data={fakeData} plugins={[LocalPlugin,SimpleColumnChooserPlugin]} settingsComponentObjects={{ pageSizeSettings: null }} />
     );
   })
 
@@ -952,6 +952,6 @@ storiesOf('Settings', module)
       pageSizes: [5, 10, 20, 50],
     };
     return (
-      <Griddle data={fakeData} plugins={[LocalPlugin,PageSizeDropDownPlugin(pluginConfig)]} />
+      <Griddle data={fakeData} plugins={[LocalPlugin,PageSizeDropDownPlugin(pluginConfig)]} settingsComponentObjects={{ columnChooser: null }} />
     );
   })

--- a/stories/index.js
+++ b/stories/index.js
@@ -845,3 +845,15 @@ storiesOf('Settings', module)
       <Settings settingsComponents={components} />
     );
   })
+  .add('remove built-in settings', () => {
+    const plugin = {
+      settingsComponentObjects: {
+        pageSizeSettings: null,
+        columnChooser: { order: 0, component: null },
+        fancy: { order: 1, component: () => <div>Fancy Settings Component</div> },
+      },
+    }
+    return (
+      <Griddle data={fakeData} plugins={[LocalPlugin,plugin]} />
+    );
+  })

--- a/stories/index.js
+++ b/stories/index.js
@@ -5,6 +5,7 @@ import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 import withContext from 'recompose/withContext';
 import withHandlers from 'recompose/withHandlers';
+import withState from 'recompose/withState';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
@@ -908,5 +909,44 @@ storiesOf('Settings', module)
 
     return (
       <Griddle data={fakeData} plugins={[LocalPlugin,SimpleColumnChooserPlugin]} />
+    );
+  })
+
+  .add('custom page size settings', () => {
+    const pageSizeSettings = ({ pageSizes }) =>
+      compose(
+        connect(
+          (state) => ({
+            pageSize: selectors.pageSizeSelector(state),
+          }),
+          {
+            setPageSize: actions.setPageSize
+          }
+        ),
+        withHandlers({
+          onChange: props => e => {
+            props.setPageSize(+e.target.value);
+          },
+        }),
+      )(({ pageSize, onChange }) => {
+      return (
+        <div>
+          <select onChange={onChange} defaultValue={pageSize}>
+            { pageSizes.map(s => <option key={s}>{s}</option>) }
+          </select>
+        </div>
+      )});
+
+    const PageSizeDropDownPlugin = (config) => ({
+      settingsComponentObjects: {
+        pageSizeSettings: { order: 1, component: pageSizeSettings(config) },
+      },
+    });
+
+    const pluginConfig = {
+      pageSizes: [5, 10, 20, 50],
+    };
+    return (
+      <Griddle data={fakeData} plugins={[LocalPlugin,PageSizeDropDownPlugin(pluginConfig)]} />
     );
   })


### PR DESCRIPTION
## Griddle major version
1.x

## Changes proposed in this pull request

* `components` now exports a `SettingsComponents` key with the default components.
* If `component` is not defined on a `settingsComponentObjects` entry, the corresponding key from `components.SettingsComponents` is used.
  * This is how the default settings components are specified, as this configuration is most flexible.
* If a settings component cannot be found in `settingsComponentObjects` or `components.SettingsComponents`, the setting is ignored (instead of an error).
* A top-level `settingsComponentObjects` prop can now override default/plugin settings components, as with `components` and `renderProperties`.
* Settings components are now ordered by `order`.

Plus a few stories proving out scenarios that seem interesting.

## Why these changes are made

Hooking into `settingsComponentObjects` didn't really feel like the other extensibility points, so I started trying alternatives that might align with what I imagine to be the most common scenarios. Specifically:

1. Removing a settings component (set `components.SettingsComponent.key = null`)
2. Reordering the default settings components, without changing them (provide only `{ order: n }` for the appropriate key(s))
3. Swapping in a replacement component, without reordering (set `components.SettingsComponent.key`)

## Are there tests?

One test; mostly stories showing usage. The `SettingsContainer` changes are most deserving of a test, but there isn't any prior art for testing a container.