### PR TITLE
setSortProperties adjustments + demo of unsortable column

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,26 +12,13 @@ import * as selectors from './selectors/dataSelectors';
 import { buildGriddleReducer, buildGriddleComponents } from './utils/compositionUtils';
 import { getColumnProperties } from './utils/columnUtils';
 import { getRowProperties } from './utils/rowUtils';
+import { setSortProperties } from './utils/sortUtils';
 import * as actions from './actions';
 
 const defaultEvents = {
   ...actions,
   onFilter: actions.setFilter,
-  setSortProperties: ({setSortColumn, sortProperty, columnId}) => {
-    return function(event) {
-      if (sortProperty === null) {
-        setSortColumn({ id: columnId, sortAscending: true });
-        return;
-      }
-
-      const newSortProperty = {
-        ...sortProperty,
-        sortAscending: !sortProperty.sortAscending
-      };
-
-      setSortColumn(newSortProperty);
-    };
-  }
+  setSortProperties
 };
 
 

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -364,7 +364,17 @@ export namespace utils {
     const compositionUtils: PropertyBag<Function>;
     const dataUtils: PropertyBag<Function>;
     const rowUtils: PropertyBag<Function>;
-    const sortUtils: PropertyBag<Function>;
+
+    interface SortProperties{
+      setSortColumn(sortProperties: ((GriddleSortKey) => void));
+      sortProperty: GriddleSortKey;
+      columnId: string;
+    }
+
+    namespace sortUtils {
+      function defaultSort(data: any[], column: string, sortAscending?: boolean);
+      function setSortProperties(sortProperties: SortProperties);
+    }
 }
 
 export namespace plugins {

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -5,6 +5,7 @@ import mapProps from 'recompose/mapProps';
 import withHandlers from 'recompose/withHandlers';
 import { sortPropertyByIdSelector, iconsForComponentSelector, customHeadingComponentSelector, stylesForComponentSelector, classNamesForComponentSelector } from '../../../selectors/dataSelectors';
 import { setSortColumn } from '../../../actions';
+import { setSortProperties } from '../../../utils/sortUtils';
 
 const DefaultTableHeadingCellContent = ({title, icon}) => (
   <span>
@@ -12,22 +13,6 @@ const DefaultTableHeadingCellContent = ({title, icon}) => (
     { icon && <span>{icon}</span> }
   </span>
 )
-
-function setSortProperties({setSortColumn, sortProperty, columnId}) {
-  return function(event) {
-    if (sortProperty === null) {
-      setSortColumn({ id: columnId, sortAscending: true });
-      return;
-    }
-
-    const newSortProperty = {
-      ...sortProperty,
-      sortAscending: !sortProperty.sortAscending
-    };
-
-    setSortColumn(newSortProperty);
-  };
-}
 
 function getIcon({sortProperty, sortAscendingIcon, sortDescendingIcon}) {
   if (sortProperty) {

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
+import getContext from 'recompose/getContext';
 import withHandlers from 'recompose/withHandlers';
 import { sortPropertyByIdSelector, iconsForComponentSelector, customHeadingComponentSelector, stylesForComponentSelector, classNamesForComponentSelector } from '../../../selectors/dataSelectors';
 import { setSortColumn } from '../../../actions';
@@ -23,6 +24,9 @@ function getIcon({sortProperty, sortAscendingIcon, sortDescendingIcon}) {
   return null;
 }
 const EnhancedHeadingCell = (OriginalComponent => compose(
+  getContext({
+    events: React.PropTypes.object,
+  }),
   connect(
     (state, props) => ({
       sortProperty: sortPropertyByIdSelector(state, props),
@@ -35,9 +39,9 @@ const EnhancedHeadingCell = (OriginalComponent => compose(
       setSortColumn
     }
   ),
-  withHandlers({
-    onClick: setSortProperties
-  }),
+  withHandlers(props => ({
+    onClick: props.events.setSortProperties || setSortProperties
+  })),
   //TODO: use with props on change or something more performant here
   mapProps(props => {
     const icon = getIcon(props);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,8 +1,8 @@
-import columnUtils from './columnUtils';
-import compositionUtils from './compositionUtils';
-import dataUtils from './dataUtils';
-import rowUtils from './rowUtils';
-import sortUtils from './sortUtils';
+import * as columnUtils from './columnUtils';
+import * as compositionUtils from './compositionUtils';
+import * as dataUtils from './dataUtils';
+import * as rowUtils from './rowUtils';
+import * as sortUtils from './sortUtils';
 
 export default {
   columnUtils,

--- a/src/utils/sortUtils.js
+++ b/src/utils/sortUtils.js
@@ -23,3 +23,19 @@ export function defaultSort(data, column, sortAscending = true) {
       }
     });
 }
+
+export function setSortProperties({ setSortColumn, sortProperty, columnId }) {
+  return () => {
+    if (sortProperty === null) {
+      setSortColumn({ id: columnId, sortAscending: true });
+      return;
+    }
+
+    const newSortProperty = {
+      ...sortProperty,
+      sortAscending: !sortProperty.sortAscending
+    };
+
+    setSortColumn(newSortProperty);
+  };
+}

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import _ from 'lodash';
 
-import GenericGriddle, { actions, components, selectors, plugins, ColumnDefinition, RowDefinition } from '../src/module';
+import GenericGriddle, { actions, components, selectors, plugins, utils, ColumnDefinition, RowDefinition } from '../src/module';
 const { Cell, Row, Table, TableContainer, TableBody, TableHeading, TableHeadingCell } = components;
 const { SettingsWrapper, SettingsToggle, Settings } = components;
 
@@ -119,6 +119,33 @@ storiesOf('Griddle main', module)
       <Griddle data={fakeData} plugins={[LocalPlugin]}>
         <RowDefinition>
           <ColumnDefinition id="name" order={2} title="NAME" sortMethod={sortBySecondCharacter} />
+          <ColumnDefinition id="state" order={1} />
+        </RowDefinition>
+      </Griddle>
+      </div>
+    );
+  })
+  .add('with sort disabled on name', () => {
+    const { setSortProperties } = utils.sortUtils;
+    const disableSortPlugin = (...columnsWithSortDisabled) => ({
+      events: {
+        setSortProperties: (sortProperties) => {
+          const { columnId } = sortProperties;
+          if (columnsWithSortDisabled.findIndex(c => c === columnId) >= 0) {
+            return () => {};
+          }
+
+          return setSortProperties(sortProperties);
+        }
+      },
+    });
+
+    return (
+      <div>
+      <small>Sorts name by second character</small>
+      <Griddle data={fakeData} plugins={[LocalPlugin,disableSortPlugin('name')]}>
+        <RowDefinition>
+          <ColumnDefinition id="name" order={2} />
           <ColumnDefinition id="state" order={1} />
         </RowDefinition>
       </Griddle>


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

1. Two identical default implementations of `setSortProperties` have been replaced with a version in `sortUtils`
2. `LocalPlugin` now respects `events.setSortProperties` before defaulting to the default implementation
3. Functions in the `utils` namespaces are now actually exported
4. Added a story demoing disabling sort on a column, an alternative to @hkasemir's in https://github.com/GriddleGriddle/Griddle/issues/591#issuecomment-292063561
5. Type definitions for `sortUtils`

## Why these changes are made

@hkasemir nerd sniped me:
> would be interested to know if there is a method that's more built-in, though!

I'm curious if anyone can think of a clean extensibility pattern that would allow either the custom `setSortProperties` or Heidi's `CustomSortTableHeader` to access a custom prop on `<ColumnDefinition />`.

## Are there tests?

Just a story 😞 