### PR TITLE
Fix #583 - Use of ColumnDefinition's cssClassName and headerCssClassName props

### DIFF
--- a/src/components/CellContainer.js
+++ b/src/components/CellContainer.js
@@ -49,6 +49,7 @@ const ComposedCellContainer = OriginalComponent => compose(
   mapProps(props => {
     return ({
     ...props,
+    className: props.cellProperties.cssClassName || props.className,
     style: getCellStyles(props.cellProperties, props.style),
     value: props.customComponent ?
       <props.customComponent {...props} /> :

--- a/src/components/TableHeadingCellContainer.js
+++ b/src/components/TableHeadingCellContainer.js
@@ -4,7 +4,7 @@ import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 
-import { sortPropertyByIdSelector, iconsForComponentSelector, classNamesForComponentSelector, stylesForComponentSelector, customHeadingComponentSelector } from '../selectors/dataSelectors';
+import { sortPropertyByIdSelector, iconsForComponentSelector, classNamesForComponentSelector, stylesForComponentSelector, customHeadingComponentSelector, cellPropertiesSelector } from '../selectors/dataSelectors';
 
 const DefaultTableHeadingCellContent = ({title, icon}) => (
   <span>
@@ -30,6 +30,7 @@ const EnhancedHeadingCell = OriginalComponent => compose(
     (state, props) => ({
       sortProperty: sortPropertyByIdSelector(state, props),
       customHeadingComponent: customHeadingComponentSelector(state, props),
+      cellProperties: cellPropertiesSelector(state, props),
       className: classNamesForComponentSelector(state, 'TableHeadingCell'),
       style: stylesForComponentSelector(state, 'TableHeadingCell'),
       ...iconsForComponentSelector(state, 'TableHeadingCell'),
@@ -40,11 +41,13 @@ const EnhancedHeadingCell = OriginalComponent => compose(
     const title = props.customHeadingComponent ?
       <props.customHeadingComponent {...props} icon={icon} /> :
       <DefaultTableHeadingCellContent title={props.title} icon={icon} />;
+    const className = props.cellProperties.headerCssClassName || props.className;
 
     return {
       ...props,
       icon,
-      title
+      title,
+      className
     };
   })
 )((props) => {

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -4,7 +4,7 @@ import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 import withHandlers from 'recompose/withHandlers';
-import { sortPropertyByIdSelector, iconsForComponentSelector, customHeadingComponentSelector, stylesForComponentSelector, classNamesForComponentSelector } from '../../../selectors/dataSelectors';
+import { sortPropertyByIdSelector, iconsForComponentSelector, customHeadingComponentSelector, stylesForComponentSelector, classNamesForComponentSelector, cellPropertiesSelector } from '../../../selectors/dataSelectors';
 import { setSortColumn } from '../../../actions';
 import { setSortProperties } from '../../../utils/sortUtils';
 
@@ -31,6 +31,7 @@ const EnhancedHeadingCell = (OriginalComponent => compose(
     (state, props) => ({
       sortProperty: sortPropertyByIdSelector(state, props),
       customHeadingComponent: customHeadingComponentSelector(state, props),
+      cellProperties: cellPropertiesSelector(state, props),
       className: classNamesForComponentSelector(state, 'TableHeadingCell'),
       style: stylesForComponentSelector(state, 'TableHeadingCell'),
       ...iconsForComponentSelector(state, 'TableHeadingCell'),
@@ -48,10 +49,13 @@ const EnhancedHeadingCell = (OriginalComponent => compose(
     const title = props.customHeadingComponent ?
       <props.customHeadingComponent {...props} icon={icon} /> :
       <DefaultTableHeadingCellContent title={props.title} icon={icon} />;
+    const className = props.cellProperties.headerCssClassName || props.className;
+
     return {
       ...props,
       icon,
-      title
+      title,
+      className
     };
   })
 )((props) => (

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -152,6 +152,31 @@ storiesOf('Griddle main', module)
       </div>
     );
   })
+  .add('with custom css-class names on state', () => {
+    const css = `
+    tr:nth-child(2n+1) .customClassName {
+      background-color: #eee;
+    }
+
+    .customHeaderClassName {
+      color: red;
+    }
+    `;
+    return (
+      <div>
+      <style type="text/css">
+        {css}
+      </style>
+      <small>Sets css-class names on state column (different for header and body), for example to use css rules defined elsewhere</small>
+      <Griddle data={fakeData}>
+        <RowDefinition>
+          <ColumnDefinition id="name" />
+          <ColumnDefinition id="state" cssClassName="customClassName" headerCssClassName="customHeaderClassName"/>
+        </RowDefinition>
+      </Griddle>
+      </div>
+    );
+  })
   .add('with custom component on name', () => {
     return (
       <div>

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -168,7 +168,7 @@ storiesOf('Griddle main', module)
         {css}
       </style>
       <small>Sets css-class names on state column (different for header and body), for example to use css rules defined elsewhere</small>
-      <Griddle data={fakeData}>
+      <Griddle data={fakeData} plugins={[LocalPlugin]}>
         <RowDefinition>
           <ColumnDefinition id="name" />
           <ColumnDefinition id="state" cssClassName="customClassName" headerCssClassName="customHeaderClassName"/>


### PR DESCRIPTION
## Griddle major version
1.3.0

## Changes proposed in this pull request
Props "cssClassName" and "headerCssClassName" of the ColumnDefinition component are now taken in consideration to compute class names of td and th elements.

## Why these changes are made
The two props are documented but currently ignored
Closes #583 #641 