### PR TITLE
Implement RowDefinition cssFunction

### DIFF
--- a/src/components/CellContainer.js
+++ b/src/components/CellContainer.js
@@ -11,6 +11,7 @@ import {
   classNamesForComponentSelector,
   stylesForComponentSelector
 } from '../selectors/dataSelectors';
+import { valueOrResult } from '../utils/valueUtils';
 
 function hasWidthOrStyles(cellProperties) {
   return cellProperties.hasOwnProperty('width') || cellProperties.hasOwnProperty('styles');
@@ -49,7 +50,7 @@ const ComposedCellContainer = OriginalComponent => compose(
   mapProps(props => {
     return ({
     ...props,
-    className: props.cellProperties.cssClassName || props.className,
+    className: valueOrResult(props.cellProperties.cssClassName, props) || props.className,
     style: getCellStyles(props.cellProperties, props.style),
     value: props.customComponent ?
       <props.customComponent {...props} /> :

--- a/src/components/ColumnDefinition.js
+++ b/src/components/ColumnDefinition.js
@@ -11,11 +11,11 @@ export default class ColumnDefinition extends Component {
     //Determines whether or not the user can disable this column from the settings.
     locked: React.PropTypes.bool,
 
-    //The css class name to apply to the header for the column
-    headerCssClassName: React.PropTypes.string,
+    //The css class name, or a function to generate a class name from props, to apply to the header for the column.
+    headerCssClassName: PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.func]),
 
-    //The css class name to apply to this column.
-    cssClassName: React.PropTypes.string,
+    //The css class name, or a function to generate a class name from props, to apply to this column.
+    cssClassName: PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.func]),
 
     //The display name for the column. This is used when the name in the column heading and settings should be different from the data passed in to the Griddle component.
     title: React.PropTypes.string,

--- a/src/components/RowContainer.js
+++ b/src/components/RowContainer.js
@@ -27,7 +27,7 @@ const ComposedRowContainer = OriginalComponent => compose(
     const { components, rowProperties, className, ...otherProps } = props;
     return {
       Cell: components.Cell,
-      className: (rowProperties.cssFunction && rowProperties.cssFunction(props.rowData, props.index)) || props.className,
+      className: (rowProperties.cssFunction && rowProperties.cssFunction(props)) || props.className,
       ...otherProps,
     };
   }),

--- a/src/components/RowContainer.js
+++ b/src/components/RowContainer.js
@@ -3,7 +3,13 @@ import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
-import { columnIdsSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+
+import {
+  columnIdsSelector,
+  rowPropertiesSelector,
+  classNamesForComponentSelector,
+  stylesForComponentSelector,
+} from '../selectors/dataSelectors';
 
 const ComposedRowContainer = OriginalComponent => compose(
   getContext({
@@ -11,14 +17,16 @@ const ComposedRowContainer = OriginalComponent => compose(
   }),
   connect((state, props) => ({
     columnIds: columnIdsSelector(state),
+    rowProperties: rowPropertiesSelector(state),
     className: classNamesForComponentSelector(state, 'Row'),
     style: stylesForComponentSelector(state, 'Row'),
   })),
   mapProps(props => {
-    const { components, ...otherProps } = props;
+    const { components, rowProperties, className, ...otherProps } = props;
     return {
       Cell: components.Cell,
-      ...otherProps
+      className: (rowProperties.cssFunction && rowProperties.cssFunction(props.rowData, props.index)) || props.className,
+      ...otherProps,
     };
   }),
 )(props => (

--- a/src/components/RowContainer.js
+++ b/src/components/RowContainer.js
@@ -11,6 +11,7 @@ import {
   classNamesForComponentSelector,
   stylesForComponentSelector,
 } from '../selectors/dataSelectors';
+import { valueOrResult } from '../utils/valueUtils';
 
 const ComposedRowContainer = OriginalComponent => compose(
   getContext({
@@ -27,7 +28,7 @@ const ComposedRowContainer = OriginalComponent => compose(
     const { components, rowProperties, className, ...otherProps } = props;
     return {
       Cell: components.Cell,
-      className: (rowProperties.cssFunction && rowProperties.cssFunction(props)) || props.className,
+      className: valueOrResult(rowProperties.cssClassName, props) || props.className,
       ...otherProps,
     };
   }),

--- a/src/components/RowContainer.js
+++ b/src/components/RowContainer.js
@@ -6,6 +6,7 @@ import getContext from 'recompose/getContext';
 
 import {
   columnIdsSelector,
+  rowDataSelector,
   rowPropertiesSelector,
   classNamesForComponentSelector,
   stylesForComponentSelector,
@@ -18,6 +19,7 @@ const ComposedRowContainer = OriginalComponent => compose(
   connect((state, props) => ({
     columnIds: columnIdsSelector(state),
     rowProperties: rowPropertiesSelector(state),
+    rowData: rowDataSelector(state, props),
     className: classNamesForComponentSelector(state, 'Row'),
     style: stylesForComponentSelector(state, 'Row'),
   })),

--- a/src/components/RowDefinition.js
+++ b/src/components/RowDefinition.js
@@ -17,9 +17,8 @@ export default class RowDefinition extends Component {
     //By default this will be "children"
     childColumnName: React.PropTypes.string,
 
-    //This property allows an to set a css class on a row based on
-    //its props. This should return a css-class name
-    cssFunction: React.PropTypes.func
+    //The css class name, or a function to generate a class name from props, to apply to this row.
+    cssClassName: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.func]),
   }
 
   render () {

--- a/src/components/RowDefinition.js
+++ b/src/components/RowDefinition.js
@@ -18,7 +18,7 @@ export default class RowDefinition extends Component {
     childColumnName: React.PropTypes.string,
 
     //This property allows an to set a css class on a row based on
-    //the data within. This should return a css-class name
+    //its props. This should return a css-class name
     cssFunction: React.PropTypes.func
   }
 

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const TableBody = ({ rowIds, Row, style, className }) => (
   <tbody style={style} className={className}>
-    { rowIds && rowIds.map(r => <Row key={r} griddleKey={r} />) }
+    { rowIds && rowIds.map((k, i) => <Row key={k} griddleKey={k} index={i} />) }
   </tbody>
 );
 

--- a/src/components/TableHeadingCellContainer.js
+++ b/src/components/TableHeadingCellContainer.js
@@ -5,6 +5,7 @@ import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 
 import { sortPropertyByIdSelector, iconsForComponentSelector, classNamesForComponentSelector, stylesForComponentSelector, customHeadingComponentSelector, cellPropertiesSelector } from '../selectors/dataSelectors';
+import { valueOrResult } from '../utils/valueUtils';
 
 const DefaultTableHeadingCellContent = ({title, icon}) => (
   <span>
@@ -41,7 +42,7 @@ const EnhancedHeadingCell = OriginalComponent => compose(
     const title = props.customHeadingComponent ?
       <props.customHeadingComponent {...props} icon={icon} /> :
       <DefaultTableHeadingCellContent title={props.title} icon={icon} />;
-    const className = props.cellProperties.headerCssClassName || props.className;
+    const className = valueOrResult(props.cellProperties.headerCssClassName, props) || props.className;
 
     return {
       ...props,

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -17,10 +17,9 @@ export interface RowDefinitionProps {
     //By default this will be "children"
     childColumnName?: string;
 
-    // TODO: Unused?
     //This property allows an to set a css class on a row based on
     //the data within. This should return a css-class name
-    cssFunction?: Function;
+    cssFunction?: (rowData: any, index?: number) => string;
 
     // Allow custom plugin props
     [x: string]: any,
@@ -295,6 +294,7 @@ export interface GriddlePageProperties {
 interface RowRenderProperties {
     rowKey?: string;
     childColumnName?: string;
+    cssFunction?: (rowData: any, index?: number) => string;
     props?: {
         children: components.ColumnDefinition[];
     };

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -17,9 +17,8 @@ export interface RowDefinitionProps {
     //By default this will be "children"
     childColumnName?: string;
 
-    //This property allows an to set a css class on a row based on
-    //its props. This should return a css-class name
-    cssFunction?: (props: any) => string;
+    //The css class name, or a function to generate a class name from props, to apply to this row.
+    cssClassName?: string | ((props: any) => string);
 
     // Allow custom plugin props
     [x: string]: any,
@@ -39,11 +38,11 @@ export interface ColumnDefinitionProps {
     //Determines whether or not the user can disable this column from the settings.
     locked?: boolean,
 
-    //The css class name to apply to the header for the column
-    headerCssClassName?: string,
+    //The css class name, or a function to generate a class name from props, to apply to the header for the column.
+    headerCssClassName?: string | ((props: any) => string);
 
-    //The css class name to apply to this column.
-    cssClassName?: string,
+    //The css class name, or a function to generate a class name from props, to apply to this column.
+    cssClassName?: string | ((props: any) => string);
 
     //The display name for the column. This is used when the name in the column heading and settings should be different from the data passed in to the Griddle component.
     title?: string,
@@ -294,7 +293,7 @@ export interface GriddlePageProperties {
 interface RowRenderProperties {
     rowKey?: string;
     childColumnName?: string;
-    cssFunction?: (props: any) => string;
+    cssClassName?: string | ((props: any) => string);
     props?: {
         children: components.ColumnDefinition[];
     };

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -18,8 +18,8 @@ export interface RowDefinitionProps {
     childColumnName?: string;
 
     //This property allows an to set a css class on a row based on
-    //the data within. This should return a css-class name
-    cssFunction?: (rowData: any, index?: number) => string;
+    //its props. This should return a css-class name
+    cssFunction?: (props: any) => string;
 
     // Allow custom plugin props
     [x: string]: any,
@@ -294,7 +294,7 @@ export interface GriddlePageProperties {
 interface RowRenderProperties {
     rowKey?: string;
     childColumnName?: string;
-    cssFunction?: (rowData: any, index?: number) => string;
+    cssFunction?: (props: any) => string;
     props?: {
         children: components.ColumnDefinition[];
     };

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -41,11 +41,9 @@ export interface ColumnDefinitionProps {
     //Determines whether or not the user can disable this column from the settings.
     locked?: boolean,
 
-    // TODO: Unused? Rename to headingCssClassName?
     //The css class name to apply to the header for the column
     headerCssClassName?: string,
 
-    // TODO: Unused?
     //The css class name to apply to this column.
     cssClassName?: string,
 

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -13,7 +13,6 @@ export interface RowDefinitionProps {
     //if this is not set it will make one up (not efficient)
     rowKey?: string;
 
-    // TODO: Unused?
     //The column that will be known used to track child data
     //By default this will be "children"
     childColumnName?: string;

--- a/src/plugins/local/components/RowContainer.js
+++ b/src/plugins/local/components/RowContainer.js
@@ -27,7 +27,7 @@ const ComposedRowContainer = OriginalComponent => compose(
     const { components, rowProperties, className, ...otherProps } = props;
     return {
       Cell: components.Cell,
-      className: (rowProperties.cssFunction && rowProperties.cssFunction(props.rowData, props.index)) || props.className,
+      className: (rowProperties.cssFunction && rowProperties.cssFunction(props)) || props.className,
       ...otherProps,
     };
   }),

--- a/src/plugins/local/components/RowContainer.js
+++ b/src/plugins/local/components/RowContainer.js
@@ -3,21 +3,36 @@ import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
-import { columnIdsSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/localSelectors';
+
+import {
+  columnIdsSelector,
+  rowDataSelector,
+  rowPropertiesSelector,
+  classNamesForComponentSelector,
+  stylesForComponentSelector,
+} from '../selectors/localSelectors';
 
 const ComposedRowContainer = OriginalComponent => compose(
   getContext({
     components: PropTypes.object
   }),
   connect((state) => ({
+    rowProperties: rowPropertiesSelector(state),
+  })),
+  connect((state, props) => ({
     columnIds: columnIdsSelector(state),
+    rowData: props.rowProperties.cssFunction ? rowDataSelector(state, props) : null,
     className: classNamesForComponentSelector(state, 'Row'),
     style: stylesForComponentSelector(state, 'Row'),
   })),
-  mapProps(props => ({
-    Cell: props.components.Cell,
-    ...props
-  })),
+  mapProps((props) => {
+    const { components, rowProperties, className, ...otherProps } = props;
+    return {
+      Cell: components.Cell,
+      className: (rowProperties.cssFunction && rowProperties.cssFunction(props.rowData, props.index)) || props.className,
+      ...otherProps,
+    };
+  }),
 )(({Cell, columnIds, griddleKey, style, className }) => (
   <OriginalComponent
     griddleKey={griddleKey}

--- a/src/plugins/local/components/RowContainer.js
+++ b/src/plugins/local/components/RowContainer.js
@@ -16,12 +16,10 @@ const ComposedRowContainer = OriginalComponent => compose(
   getContext({
     components: PropTypes.object
   }),
-  connect((state) => ({
-    rowProperties: rowPropertiesSelector(state),
-  })),
   connect((state, props) => ({
     columnIds: columnIdsSelector(state),
-    rowData: props.rowProperties.cssFunction ? rowDataSelector(state, props) : null,
+    rowProperties: rowPropertiesSelector(state),
+    rowData: rowDataSelector(state, props),
     className: classNamesForComponentSelector(state, 'Row'),
     style: stylesForComponentSelector(state, 'Row'),
   })),

--- a/src/plugins/local/components/RowContainer.js
+++ b/src/plugins/local/components/RowContainer.js
@@ -11,6 +11,7 @@ import {
   classNamesForComponentSelector,
   stylesForComponentSelector,
 } from '../selectors/localSelectors';
+import { valueOrResult } from '../../../utils/valueUtils';
 
 const ComposedRowContainer = OriginalComponent => compose(
   getContext({
@@ -27,7 +28,7 @@ const ComposedRowContainer = OriginalComponent => compose(
     const { components, rowProperties, className, ...otherProps } = props;
     return {
       Cell: components.Cell,
-      className: (rowProperties.cssFunction && rowProperties.cssFunction(props)) || props.className,
+      className: valueOrResult(rowProperties.cssClassName, props) || props.className,
       ...otherProps,
     };
   }),

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -7,6 +7,7 @@ import withHandlers from 'recompose/withHandlers';
 import { sortPropertyByIdSelector, iconsForComponentSelector, customHeadingComponentSelector, stylesForComponentSelector, classNamesForComponentSelector, cellPropertiesSelector } from '../../../selectors/dataSelectors';
 import { setSortColumn } from '../../../actions';
 import { setSortProperties } from '../../../utils/sortUtils';
+import { valueOrResult } from '../../../utils/valueUtils';
 
 const DefaultTableHeadingCellContent = ({title, icon}) => (
   <span>
@@ -49,7 +50,7 @@ const EnhancedHeadingCell = (OriginalComponent => compose(
     const title = props.customHeadingComponent ?
       <props.customHeadingComponent {...props} icon={icon} /> :
       <DefaultTableHeadingCellContent title={props.title} icon={icon} />;
-    const className = props.cellProperties.headerCssClassName || props.className;
+    const className = valueOrResult(props.cellProperties.headerCssClassName, props) || props.className;
 
     return {
       ...props,

--- a/src/plugins/local/selectors/localSelectors.js
+++ b/src/plugins/local/selectors/localSelectors.js
@@ -177,13 +177,7 @@ export const columnIdsSelector = createSelector(
  */
 export const columnTitlesSelector = dataSelectors.columnTitlesSelector;
 export const cellValueSelector = dataSelectors.cellValueSelector;
-
-// TODO: Needs tests and jsdoc
-export const rowDataSelector = (state, { griddleKey }) => {
-  return state.get('data')
-    .find(r => r.get('griddleKey') === griddleKey).toJSON();
-};
-
+export const rowDataSelector = dataSelectors.rowDataSelector;
 export const iconsForComponentSelector = dataSelectors.iconsForComponentSelector;
 export const iconsByNameSelector = dataSelectors.iconsForComponentSelector;
 export const stylesForComponentSelector = dataSelectors.stylesForComponentSelector;

--- a/src/plugins/local/selectors/localSelectors.js
+++ b/src/plugins/local/selectors/localSelectors.js
@@ -188,3 +188,6 @@ export const iconsForComponentSelector = dataSelectors.iconsForComponentSelector
 export const iconsByNameSelector = dataSelectors.iconsForComponentSelector;
 export const stylesForComponentSelector = dataSelectors.stylesForComponentSelector;
 export const classNamesForComponentSelector = dataSelectors.classNamesForComponentSelector;
+
+export const rowPropertiesSelector = dataSelectors.rowPropertiesSelector;
+export const cellPropertiesSelector = dataSelectors.cellPropertiesSelector;

--- a/src/selectors/dataSelectors.js
+++ b/src/selectors/dataSelectors.js
@@ -271,11 +271,10 @@ export const cellValueSelector = (state, props) => {
   }
 };
 
-// TODO: Needs tests and jsdoc
-export const cellPropertiesSelector = (state, { griddleKey, columnId }) => {
+/** Gets the column render properties for the specified columnId
+ */
+export const cellPropertiesSelector = (state, { columnId }) => {
   const item = state.getIn(['renderProperties', 'columnProperties', columnId]);
 
-  return item ?
-    item.toJSON() :
-    null;
-}
+  return (item && item.toJSON()) || {};
+};

--- a/src/selectors/dataSelectors.js
+++ b/src/selectors/dataSelectors.js
@@ -271,6 +271,12 @@ export const cellValueSelector = (state, props) => {
   }
 };
 
+// TODO: Needs tests and jsdoc
+export const rowDataSelector = (state, { griddleKey }) => {
+  return state.get('data')
+    .find(r => r.get('griddleKey') === griddleKey).toJSON();
+};
+
 /** Gets the row render properties
  */
 export const rowPropertiesSelector = (state) => {

--- a/src/selectors/dataSelectors.js
+++ b/src/selectors/dataSelectors.js
@@ -271,6 +271,14 @@ export const cellValueSelector = (state, props) => {
   }
 };
 
+/** Gets the row render properties
+ */
+export const rowPropertiesSelector = (state) => {
+  const row = state.getIn(['renderProperties', 'rowProperties']);
+
+  return (row && row.toJSON()) || {};
+};
+
 /** Gets the column render properties for the specified columnId
  */
 export const cellPropertiesSelector = (state, { columnId }) => {

--- a/src/utils/valueUtils.js
+++ b/src/utils/valueUtils.js
@@ -1,0 +1,6 @@
+export function valueOrResult(arg, ...args) {
+  if (typeof arg === 'function') {
+    return arg.apply(null, args);
+  }
+  return arg;
+}

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -177,6 +177,27 @@ storiesOf('Griddle main', module)
       </div>
     );
   })
+  .add('with cssFunction on RowDefinition', () => {
+    const css = `
+      .row-1 { background-color: #ccc; }
+      .row-2 { background-color: #999; }
+      .lucky { background-color: #cfc; color: #060; }
+      `;
+    return (
+      <div>
+      <style type="text/css">
+        {css}
+      </style>
+      <small>Uses cssFunction to apply calculated class names</small>
+      <Griddle data={fakeData} plugins={[LocalPlugin]}>
+        <RowDefinition cssFunction={(d, i) => d && d.favoriteNumber === 7 ? 'lucky' : `row-${i%3}`}>
+          <ColumnDefinition id="name" />
+          <ColumnDefinition id="state" />
+        </RowDefinition>
+      </Griddle>
+      </div>
+    );
+  })
   .add('with custom component on name', () => {
     return (
       <div>

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -189,7 +189,7 @@ storiesOf('Griddle main', module)
       </style>
       <small>Uses cssFunction to apply calculated class names</small>
       <Griddle data={fakeData} plugins={[LocalPlugin]}>
-        <RowDefinition cssFunction={(d, i) => d && d.favoriteNumber === 7 ? 'lucky' : `row-${i%3}`}>
+        <RowDefinition cssFunction={({ rowData: d, index: i }) => d && d.favoriteNumber === 7 ? 'lucky' : `row-${i%3}`}>
           <ColumnDefinition id="name" />
           <ColumnDefinition id="state" />
         </RowDefinition>

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -160,23 +160,48 @@ storiesOf('Griddle main', module)
     .customHeaderClassName {
       color: red;
     }
+    .blue { color: blue; }
+    .asc { background-color: #666; color: white; }
+    .desc { background-color: #999; color: black; }
     `;
     return (
       <div>
       <style type="text/css">
         {css}
       </style>
-      <small>Sets css-class names on state column (different for header and body), for example to use css rules defined elsewhere</small>
+      <small>Sets dynamic (name - click to sort) and static (state) class names on header and body cells</small>
       <Griddle data={fakeData} plugins={[LocalPlugin]}>
         <RowDefinition>
-          <ColumnDefinition id="name" />
+          <ColumnDefinition id="name"
+            headerCssClassName={({sortProperty}) => sortProperty && (sortProperty.sortAscending ? 'asc' : 'desc')}
+            cssClassName={({value}) => value.startsWith('L') && 'blue'}
+            />
           <ColumnDefinition id="state" cssClassName="customClassName" headerCssClassName="customHeaderClassName"/>
         </RowDefinition>
       </Griddle>
       </div>
     );
   })
-  .add('with cssFunction on RowDefinition', () => {
+  .add('with cssClassName string on RowDefinition', () => {
+    const css = `
+      .lucky { background-color: #cfc; color: #060; }
+      `;
+    return (
+      <div>
+      <style type="text/css">
+        {css}
+      </style>
+      <small>Uses cssClassName to apply static class name</small>
+      <Griddle data={fakeData} plugins={[LocalPlugin]}>
+        <RowDefinition cssClassName="lucky">
+          <ColumnDefinition id="name" />
+          <ColumnDefinition id="state" />
+        </RowDefinition>
+      </Griddle>
+      </div>
+    );
+  })
+  .add('with cssClassName function on RowDefinition', () => {
     const css = `
       .row-1 { background-color: #ccc; }
       .row-2 { background-color: #999; }
@@ -187,9 +212,9 @@ storiesOf('Griddle main', module)
       <style type="text/css">
         {css}
       </style>
-      <small>Uses cssFunction to apply calculated class names</small>
+      <small>Uses cssClassName to apply calculated class names</small>
       <Griddle data={fakeData} plugins={[LocalPlugin]}>
-        <RowDefinition cssFunction={({ rowData: d, index: i }) => d && d.favoriteNumber === 7 ? 'lucky' : `row-${i%3}`}>
+        <RowDefinition cssClassName={({ rowData: d, index: i }) => d && d.favoriteNumber === 7 ? 'lucky' : `row-${i%3}`}>
           <ColumnDefinition id="name" />
           <ColumnDefinition id="state" />
         </RowDefinition>

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -15,7 +15,6 @@ const { Cell, Row, Table, TableContainer, TableBody, TableHeading, TableHeadingC
 const { SettingsWrapper, SettingsToggle, Settings } = components;
 
 const { LocalPlugin, PositionPlugin } = plugins;
-const { rowDataSelector } = LocalPlugin.selectors;
 
 import fakeData, { FakeData } from './fakeData';
 import { person, fakeData2, personClass, fakeData3 } from './fakeData2';
@@ -67,7 +66,7 @@ const MakeBlueComponent = (props) => (
 )
 
 const EnhanceWithRowData = connect((state, props) => ({
-  rowData: rowDataSelector(state, props)
+  rowData: selectors.rowDataSelector(state, props)
 }));
 
 const EnhancedCustomComponent = EnhanceWithRowData(MakeBlueComponent);


### PR DESCRIPTION
## Griddle major version

1.*

## Changes proposed in this pull request

1. `rowDataSelector` is no longer limited to `LocalPlugin`
2. `rowData` and `index` (on current page) have been added to `Row` `props`.
3. `RowDefinition` `cssFunction` is now called if it exists to get a `Row`'s `className`.

The expected signature of `cssFunction` was unclear, so I ultimately opted for accepting the `Row`'s `props`, which seems more flexible than the `rowData` and `index` I initially implemented.

Setting the current implementation aside, I wonder about renaming `cssFunction` as `cssClassName` (aligned with the `ColumnDefinition` prop, and not a breaking change since it has never worked) and allowing both to accept either a function (which we would call with the current `Row`/`Cell` `props`) or a plain string.

## Why these changes are made

Fixes #643

## Are there tests?

No, but there's a story!