### PR TITLE
Support ColumnDefinition Sortable

### DIFF
--- a/src/components/TableHeadingCellContainer.js
+++ b/src/components/TableHeadingCellContainer.js
@@ -43,11 +43,16 @@ const EnhancedHeadingCell = OriginalComponent => compose(
       <props.customHeadingComponent {...props} icon={icon} /> :
       <DefaultTableHeadingCellContent title={props.title} icon={icon} />;
     const className = valueOrResult(props.cellProperties.headerCssClassName, props) || props.className;
+    const style = {
+      ...(props.cellProperties.sortable === false || { cursor: 'pointer' }),
+      ...props.style,
+    };
 
     return {
       ...props,
       icon,
       title,
+      style,
       className
     };
   })

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -53,7 +53,6 @@ export interface ColumnDefinitionProps {
     //The component that should be used instead of the normal title
     customHeadingComponent?: GriddleComponent<TableHeadingCellProps>,
 
-    // TODO: Unused?
     //Can this column be sorted
     sortable?: boolean,
 

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -52,11 +52,16 @@ const EnhancedHeadingCell = (OriginalComponent => compose(
       <props.customHeadingComponent {...props} icon={icon} /> :
       <DefaultTableHeadingCellContent title={props.title} icon={icon} />;
     const className = valueOrResult(props.cellProperties.headerCssClassName, props) || props.className;
+    const style = {
+      ...(props.cellProperties.sortable === false || { cursor: 'pointer' }),
+      ...props.style,
+    };
 
     return {
       ...props,
       icon,
       title,
+      style,
       className
     };
   })

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -42,7 +42,8 @@ const EnhancedHeadingCell = (OriginalComponent => compose(
     }
   ),
   withHandlers(props => ({
-    onClick: props.events.setSortProperties || setSortProperties
+    onClick: props.cellProperties.sortable === false ? (() => () => {}) :
+      props.events.setSortProperties || setSortProperties,
   })),
   //TODO: use with props on change or something more performant here
   mapProps(props => {

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -124,7 +124,20 @@ storiesOf('Griddle main', module)
       </div>
     );
   })
-  .add('with sort disabled on name', () => {
+  .add('with sortable set to true/false', () => {
+    return (
+      <div>
+      <small>Using ColumnDefinition sortable (false on name, true on state).</small>
+      <Griddle data={fakeData} plugins={[LocalPlugin]}>
+        <RowDefinition>
+          <ColumnDefinition id="name" order={2} sortable={false} />
+          <ColumnDefinition id="state" order={1} sortable={true} />
+        </RowDefinition>
+      </Griddle>
+      </div>
+    );
+  })
+  .add('with sort disabled on name via plugin', () => {
     const { setSortProperties } = utils.sortUtils;
     const disableSortPlugin = (...columnsWithSortDisabled) => ({
       events: {
@@ -141,7 +154,7 @@ storiesOf('Griddle main', module)
 
     return (
       <div>
-      <small>Sorts name by second character</small>
+      <small>Using custom plugin to disable sort</small>
       <Griddle data={fakeData} plugins={[LocalPlugin,disableSortPlugin('name')]}>
         <RowDefinition>
           <ColumnDefinition id="name" order={2} />


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

`sortable`, which was already defined on `ColumnDefinition`, is now respected.

I also added a default `cursor: pointer` style to `sortable` columns. It occurs to me that there's not a great way to override this that is `sortable`-aware. Should we add `style`/`headerStyle` props to `ColumnDefinition` in imitation of `cssClassName`/`headerCssClassName`?

## Why these changes are made

Fixes #591.
Fixes #652. cc @andreme

## Are there tests?

Story!
