### PR TITLE
Avoid importing entire lodash package

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
       "presets": ["es2015", "stage-0", "react"]
     },
     "build": {
+      "plugins": ["lodash"],
       "presets": ["es2015", "stage-0", "react"],
       "ignore": [
         "**/__tests__/*.js",


### PR DESCRIPTION
## Griddle major version
1.x
## Changes proposed in this pull request
Add lodash plugin to babelrc build config
## Why these changes are made
Currently the `babel-plugin-lodash` is only used by the babel-loader in the webpack build but since the `build-modules` npm script calls babel directly, the lodash plugin needs to be added to the babelrc also otherwise calling `import Griddle from 'griddle-react'` will also import all of lodash.
You can see it on line 23 here: https://unpkg.com/griddle-react@1.3.1/dist/module/index.js
## Are there tests?
Don't think there is any easy way to test for this