### PR TITLE
Fixed Many-ColumnDefinition Ordering

### DIFF
--- a/src/plugins/local/selectors/localSelectors.js
+++ b/src/plugins/local/selectors/localSelectors.js
@@ -67,15 +67,7 @@ export const allColumnsSelector = createSelector(
 
 /** Gets the column properties objects sorted by order
  */
-export const sortedColumnPropertiesSelector = createSelector(
-  renderPropertiesSelector,
-  (renderProperties) => (
-    renderProperties && renderProperties.get('columnProperties') && renderProperties.get('columnProperties').size !== 0 ?
-      renderProperties.get('columnProperties')
-        .sortBy(col => (col && col.get('order'))||MAX_SAFE_INTEGER) :
-      null
-  )
-);
+export const sortedColumnPropertiesSelector = dataSelectors.sortedColumnPropertiesSelector;
 
 /** Gets the visible columns either obtaining the sorted column properties or all columns
  */

--- a/src/utils/__tests__/columnUtilsTests.js
+++ b/src/utils/__tests__/columnUtilsTests.js
@@ -1,24 +1,13 @@
 import test from 'ava';
 
-import { getColumnProperties, getColumnPropertiesFromColumnArray } from '../columnUtils';
-
-test('get column properties from array returns object', test => {
-  const columns = ['one', 'two', 'three'];
-  const columnProperties = getColumnPropertiesFromColumnArray(columns);
-
-  test.deepEqual(columnProperties, {
-    one: { id: 'one' },
-    two: { id: 'two' },
-    three: { id: 'three' }
-  });
-});
+import { getColumnProperties } from '../columnUtils';
 
 test('get column properties works with array', test => {
   const rowProperties = {
     props: {
       children: [
         { props: { id: 1, name: "one"}},
-        { props: { id: 2, name: "two"}}
+        { props: { id: 2, name: "two", order: 5 }}
       ]
     }
   };
@@ -26,22 +15,22 @@ test('get column properties works with array', test => {
   const columnProperties = getColumnProperties(rowProperties);
 
   test.deepEqual(columnProperties, {
-    1: { id: 1, name: "one"},
-    2: { id: 2, name: "two"}
+    1: { id: 1, name: "one", order: 1000 },
+    2: { id: 2, name: "two", order: 5 },
   });
 });
 
 test('get column properties works with single column property object', test => {
   const rowProperties = {
     props: {
-      children: { props: { id: 1, name: 'one' }}
+      children: { props: { id: 1, name: 'one' }},
     }
   };
 
   const columnProperties = getColumnProperties(rowProperties);
 
   test.deepEqual(columnProperties, {
-    1: { id: 1, name: 'one' }
+    1: { id: 1, name: 'one', order: 1000 },
   });
 });
 
@@ -55,8 +44,8 @@ test('get column properties returns all columns when no property columns specifi
   const columnProperties = getColumnProperties(rowProperties, allColumns);
 
   test.deepEqual(columnProperties, {
-    one: { id: 'one' },
-    two: { id: 'two' },
-    three: { id: 'three' }
+    one: { id: 'one', order: 1000 },
+    two: { id: 'two', order: 1001 },
+    three: { id: 'three', order: 1002 }
   })
 })

--- a/src/utils/columnUtils.js
+++ b/src/utils/columnUtils.js
@@ -1,23 +1,12 @@
-function containsColumnPropertiesArray(rowProperties) {
-  return (rowProperties &&
-    rowProperties.props &&
-    rowProperties.props.children &&
-    Array.isArray(rowProperties.props.children));
-}
-
-function containsColumnPropertiesObject(rowProperties) {
-  return rowProperties && rowProperties.props && rowProperties.props.children;
-}
-
 /** Gets a column properties object from an array of columnNames
  * @param {Array<string>} columns - array of column names
  */
-export function getColumnPropertiesFromColumnArray(columns) {
+export function getColumnPropertiesFromColumnArray(columnProperties, columns) {
   return columns.reduce((previous, current) => {
     previous[current] = {id: current};
     return previous;
   },
-  {});
+  columnProperties);
 }
 
 /** Gets the column properties object from a react component (rowProperties) that contains child component(s) for columnProperties.
@@ -26,22 +15,24 @@ export function getColumnPropertiesFromColumnArray(columns) {
  * @param {Array<string> optional} allColumns - An optional array of colummn names. This will be used to generate the columnProperties when they are not defined in rowProperties
  */
 export function getColumnProperties(rowProperties, allColumns=[]) {
-  let columnProperties = {};
+  const children = rowProperties && rowProperties.props && rowProperties.props.children;
+  const columnProperties = {};
+
   // Working against an array of columnProperties
-  if (containsColumnPropertiesArray(rowProperties)) {
+  if (Array.isArray(children)) {
     // build one object that contains all of the column properties keyed by id
-    columnProperties = rowProperties.props.children.reduce((previous, current) => {
+    children.reduce((previous, current) => {
       previous[current.props.id] = current.props;
       return previous;
-    }, {});
+    }, columnProperties);
 
   // Working against a lone, columnProperties object
-  } else if (containsColumnPropertiesObject(rowProperties)) {
-    columnProperties[rowProperties.props.children.props.id] = rowProperties.props.children.props;
+  } else if (children && children.props) {
+    columnProperties[children.props.id] = children.props;
   }
 
   if(Object.keys(columnProperties).length === 0 && allColumns) {
-    columnProperties = getColumnPropertiesFromColumnArray(allColumns);
+    getColumnPropertiesFromColumnArray(columnProperties, allColumns);
   }
 
   return columnProperties; 

--- a/src/utils/columnUtils.js
+++ b/src/utils/columnUtils.js
@@ -1,9 +1,11 @@
+const offset = 1000;
+
 /** Gets a column properties object from an array of columnNames
  * @param {Array<string>} columns - array of column names
  */
-export function getColumnPropertiesFromColumnArray(columnProperties, columns) {
-  return columns.reduce((previous, current) => {
-    previous[current] = {id: current};
+function getColumnPropertiesFromColumnArray(columnProperties, columns) {
+  return columns.reduce((previous, current, i) => {
+    previous[current] = { id: current, order: offset + i };
     return previous;
   },
   columnProperties);
@@ -21,14 +23,14 @@ export function getColumnProperties(rowProperties, allColumns=[]) {
   // Working against an array of columnProperties
   if (Array.isArray(children)) {
     // build one object that contains all of the column properties keyed by id
-    children.reduce((previous, current) => {
-      previous[current.props.id] = current.props;
+    children.reduce((previous, current, i) => {
+      previous[current.props.id] = { order: offset + i, ...current.props };
       return previous;
     }, columnProperties);
 
   // Working against a lone, columnProperties object
   } else if (children && children.props) {
-    columnProperties[children.props.id] = children.props;
+    columnProperties[children.props.id] = { order: offset, ...children.props };
   }
 
   if(Object.keys(columnProperties).length === 0 && allColumns) {

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -384,6 +384,29 @@ storiesOf('Griddle main', module)
       </div>
     )
   })
+  .add('with many columns', () => {
+    return (
+      <div>
+        <small>
+          State should be first, name should be last, and the rest should be in order.
+          Default order increments from 1000.
+        </small>
+        <Griddle data={fakeData} plugins={[LocalPlugin]}>
+          <RowDefinition>
+            <ColumnDefinition id="name" order={2000} />
+            <ColumnDefinition id="col1" />
+            <ColumnDefinition id="col2" />
+            <ColumnDefinition id="col3" />
+            <ColumnDefinition id="col4" />
+            <ColumnDefinition id="col5" />
+            <ColumnDefinition id="col6" />
+            <ColumnDefinition id="col7" />
+            <ColumnDefinition id="state" order={1} />
+          </RowDefinition>
+        </Griddle>
+      </div>
+    );
+  })
   .add('with override row component', () => {
     const NewRow = (props) => <tr><td>hi</td></tr>
 


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

It's still not clear to me what precisely is causing the order to change, but it seems wise in general to set column `order` earlier to use everywhere (which fixes the bug).

Also cleaned up `columnUtils` a bit. 

## Why these changes are made

Fixes #619.

## Are there tests?

Story!