### PR TITLE
Suppress implicit any

### DIFF
--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -361,14 +361,14 @@ export namespace utils {
     const rowUtils: PropertyBag<Function>;
 
     interface SortProperties{
-      setSortColumn(sortProperties: ((GriddleSortKey) => void));
+      setSortColumn(sortProperties: ((GriddleSortKey : any) => void)) : any;
       sortProperty: GriddleSortKey;
       columnId: string;
     }
 
     namespace sortUtils {
-      function defaultSort(data: any[], column: string, sortAscending?: boolean);
-      function setSortProperties(sortProperties: SortProperties);
+      function defaultSort(data: any[], column: string, sortAscending?: boolean) : any;
+      function setSortProperties(sortProperties: SortProperties) : any;
     }
 }
 
@@ -400,7 +400,7 @@ export namespace plugins {
     var PositionPlugin : (settings: PositionSettings) => GriddlePlugin;
 }
 
-export const ColumnDefinition;
-export const RowDefinition;
+export const ColumnDefinition : any;
+export const RowDefinition : any;
 
 export default Griddle;

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -400,7 +400,7 @@ export namespace plugins {
     var PositionPlugin : (settings: PositionSettings) => GriddlePlugin;
 }
 
-export const ColumnDefinition : any;
-export const RowDefinition : any;
+export const ColumnDefinition : typeof components.ColumnDefinition;
+export const RowDefinition : typeof components.RowDefinition;
 
 export default Griddle;

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -361,14 +361,14 @@ export namespace utils {
     const rowUtils: PropertyBag<Function>;
 
     interface SortProperties{
-      setSortColumn(sortProperties: ((GriddleSortKey : any) => void)) : any;
+      setSortColumn(sortProperties: ((key : GriddleSortKey) => void)) : void;
       sortProperty: GriddleSortKey;
       columnId: string;
     }
 
     namespace sortUtils {
-      function defaultSort(data: any[], column: string, sortAscending?: boolean) : any;
-      function setSortProperties(sortProperties: SortProperties) : any;
+      function defaultSort(data: any[], column: string, sortAscending?: boolean) : number;
+      function setSortProperties(sortProperties: SortProperties) : () => void;
     }
 }
 


### PR DESCRIPTION
## Griddle major version
1.3
## Changes proposed in this pull request
Remove implicit any
## Why these changes are made
Because we can't force people to use implicit any mode (`"noImplicitAny": false`) with typescript :smile: 