### PR TITLE
TypeScript Fix + Pagination with Size Setting

### DIFF
--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -1,24 +1,14 @@
 import React from 'react';
 
-const Pagination = ({ getPrevious,
-  getNext,
-  setPage,
-  maxPages,
-  currentPage,
-  hasNext,
-  hasPrevious,
-  Next=null,
-  Previous=null,
-  PageDropdown=null,
+const Pagination = ({
+  Next,
+  Previous,
+  PageDropdown,
   style,
   className }) => (
     <div style={style} className={className}>
       {Previous && <Previous />}
-      {PageDropdown && <PageDropdown
-        maxPages={maxPages}
-        currentPage={currentPage}
-        setPage={setPage}
-      /> }
+      {PageDropdown && <PageDropdown /> }
       {Next && <Next /> }
     </div>
   );

--- a/src/components/SettingsContainer.js
+++ b/src/components/SettingsContainer.js
@@ -14,7 +14,7 @@ function getSettingsComponentsArrayFromObject(settingsObject, settingsComponents
       var oa = settingsObject[a], ob = settingsObject[b];
       return ((oa && oa.order) || 0) - ((ob && ob.order) || 0);
     })
-    .map(key => (settingsObject[key] && settingsObject[key].component) || (settingsComponents && settingsComponents[key])) : null;
+    .map(key => settingsObject[key] && (settingsObject[key].component || (settingsComponents && settingsComponents[key]))) : null;
 }
 
 const EnhancedSettings = OriginalComponent => compose(

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -4,7 +4,7 @@ interface PropertyBag<T> {
     [propName: string]: T;
 }
 
-type GriddleComponent<T> = (props: T) => string | JSX.Element | React.ComponentClass<T> | React.StatelessComponent<T>
+type GriddleComponent<T> = React.ComponentClass<T> | React.StatelessComponent<T>;
 
 export namespace components {
 

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1197,3 +1197,21 @@ storiesOf('Settings', module)
         }} />
     );
   })
+
+storiesOf('TypeScript', module)
+  .add('GriddleComponent accepts expected types', () => {
+    class Custom extends React.Component<{ value }, void> {
+      render() {
+        return this.props.value;
+      }
+    }
+
+    return (
+      <Griddle data={fakeData} plugins={[LocalPlugin]}>
+        <RowDefinition>
+          <ColumnDefinition id="name" customComponent={({ value }) => <em>{value}</em>} />
+          <ColumnDefinition id="state" customComponent={Custom} />
+        </RowDefinition>
+      </Griddle>
+    );
+  })

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1193,7 +1193,7 @@ storiesOf('Settings', module)
         data={fakeData}
         plugins={[LocalPlugin,PageSizeDropDownInPaginationPlugin(pluginConfig)]}
         settingsComponentObjects={{
-          pageSizeSettings: { order: 0, component: () => null }
+          pageSizeSettings: null
         }} />
     );
   })

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1142,3 +1142,58 @@ storiesOf('Settings', module)
       <Griddle data={fakeData} plugins={[LocalPlugin,PageSizeDropDownPlugin(pluginConfig)]} settingsComponentObjects={{ columnChooser: null }} />
     );
   })
+
+  .add('relocate page size setting near pagination', () => {
+    const pageSizeSettings = ({ pageSizes }) =>
+      compose(
+        connect(
+          (state) => ({
+            pageSize: selectors.pageSizeSelector(state),
+          }),
+          {
+            setPageSize: actions.setPageSize
+          }
+        ),
+        withHandlers({
+          onChange: props => e => {
+            props.setPageSize(+e.target.value);
+          },
+        }),
+      )(({ pageSize, onChange, style }) => {
+      return (
+        <select onChange={onChange} defaultValue={pageSize} style={style}>
+          { pageSizes.map(s => <option key={s}>{s}</option>) }
+        </select>
+      )});
+
+    const PageSizeDropDownInPaginationPlugin = (config) => {
+      const PageSizeSettings = pageSizeSettings(config);
+      return {
+        components: {
+          Pagination: ({ Next, Previous, PageDropdown }) => (
+            <div>
+              <span>
+                Rows Per Page:
+                <PageSizeSettings style={{ marginLeft: '0.5em', marginRight: '1em' }} />
+              </span>
+              {Previous && <Previous />}
+              {PageDropdown && <PageDropdown /> }
+              {Next && <Next /> }
+            </div>
+          ),
+        },
+      };
+    };
+
+    const pluginConfig = {
+      pageSizes: [5, 10, 20, 50],
+    };
+    return (
+      <Griddle
+        data={fakeData}
+        plugins={[LocalPlugin,PageSizeDropDownInPaginationPlugin(pluginConfig)]}
+        settingsComponentObjects={{
+          pageSizeSettings: { order: 0, component: () => null }
+        }} />
+    );
+  })

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1144,54 +1144,25 @@ storiesOf('Settings', module)
   })
 
   .add('relocate page size setting near pagination', () => {
-    const pageSizeSettings = ({ pageSizes }) =>
-      compose(
-        connect(
-          (state) => ({
-            pageSize: selectors.pageSizeSelector(state),
-          }),
-          {
-            setPageSize: actions.setPageSize
-          }
+    const PageSizeSettings = components.SettingsComponents.pageSizeSettings;
+
+    const PageSizeDropDownInPaginationPlugin = {
+      components: {
+        Pagination: ({ Next, Previous, PageDropdown }) => (
+          <div>
+            <PageSizeSettings />
+            {Previous && <Previous />}
+            {PageDropdown && <PageDropdown /> }
+            {Next && <Next /> }
+          </div>
         ),
-        withHandlers({
-          onChange: props => e => {
-            props.setPageSize(+e.target.value);
-          },
-        }),
-      )(({ pageSize, onChange, style }) => {
-      return (
-        <select onChange={onChange} defaultValue={pageSize} style={style}>
-          { pageSizes.map(s => <option key={s}>{s}</option>) }
-        </select>
-      )});
-
-    const PageSizeDropDownInPaginationPlugin = (config) => {
-      const PageSizeSettings = pageSizeSettings(config);
-      return {
-        components: {
-          Pagination: ({ Next, Previous, PageDropdown }) => (
-            <div>
-              <span>
-                Rows Per Page:
-                <PageSizeSettings style={{ marginLeft: '0.5em', marginRight: '1em' }} />
-              </span>
-              {Previous && <Previous />}
-              {PageDropdown && <PageDropdown /> }
-              {Next && <Next /> }
-            </div>
-          ),
-        },
-      };
+      },
     };
 
-    const pluginConfig = {
-      pageSizes: [5, 10, 20, 50],
-    };
     return (
       <Griddle
         data={fakeData}
-        plugins={[LocalPlugin,PageSizeDropDownInPaginationPlugin(pluginConfig)]}
+        plugins={[LocalPlugin,PageSizeDropDownInPaginationPlugin]}
         settingsComponentObjects={{
           pageSizeSettings: null
         }} />


### PR DESCRIPTION
## Griddle major version

1.6

## Changes proposed in this pull request

1. Cleans up obsolete `Pagination` props
2. Adds an example of moving the page size component into `Pagination`
3. Fixes disabling a settings component by clearing its key on `SettingsComponent`
4. Fixes `GriddleComponent<T>` signature, which had apparently never _really_ been tested
   * Discovered with the next commit...
    * But also discovered by compiling an existing app against Griddle 1.6, which includes https://github.com/GriddleGriddle/Griddle/commit/02be19d29b956a000cc9b2b4cc4cd5583f3891db. `ColumnDefinition` had previously been exported without a type, so the types passed to `customComponent` had not been checked.

## Why these changes are made

Who doesn't love more stories? Also, TypeScript should work.

## Are there tests?

Stories!
