### PR TITLE
Implement ColumnDefinition extraData

### DIFF
--- a/src/components/CellContainer.js
+++ b/src/components/CellContainer.js
@@ -57,12 +57,10 @@ const ComposedCellContainer = OriginalComponent => compose(
       <props.customComponent {...props} /> :
       props.value
   })})
-)(({ value, style, className }) => (
+)(props =>
   <OriginalComponent
-    value={value}
-    style={style}
-    className={className}
+    {...props}
   />
-))
+);
 
 export default ComposedCellContainer;

--- a/src/components/CellContainer.js
+++ b/src/components/CellContainer.js
@@ -50,11 +50,12 @@ const ComposedCellContainer = OriginalComponent => compose(
   }),
   mapProps(props => {
     return ({
+    ...props.cellProperties.extraData,
     ...props,
     className: valueOrResult(props.cellProperties.cssClassName, props) || props.className,
     style: getCellStyles(props.cellProperties, props.style),
     value: props.customComponent ?
-      <props.customComponent {...props} /> :
+      <props.customComponent {...props.cellProperties.extraData} {...props} /> :
       props.value
   })})
 )(props =>

--- a/src/components/TableHeadingCellContainer.js
+++ b/src/components/TableHeadingCellContainer.js
@@ -41,7 +41,7 @@ const EnhancedHeadingCell = OriginalComponent => compose(
   mapProps(props => {
     const icon = getIcon(props);
     const title = props.customHeadingComponent ?
-      <props.customHeadingComponent {...props} icon={icon} /> :
+      <props.customHeadingComponent {...props.cellProperties.extraData} {...props} icon={icon} /> :
       <DefaultTableHeadingCellContent title={props.title} icon={icon} />;
     const className = valueOrResult(props.cellProperties.headerCssClassName, props) || props.className;
     const style = {
@@ -50,6 +50,7 @@ const EnhancedHeadingCell = OriginalComponent => compose(
     };
 
     return {
+      ...props.cellProperties.extraData,
       ...props,
       icon,
       title,

--- a/src/components/TableHeadingCellContainer.js
+++ b/src/components/TableHeadingCellContainer.js
@@ -57,10 +57,10 @@ const EnhancedHeadingCell = OriginalComponent => compose(
       className
     };
   })
-)((props) => {
-  return (
-    <OriginalComponent {...props} />
-  );
-});
+)(props =>
+  <OriginalComponent
+    {...props}
+  />
+);
 
 export default EnhancedHeadingCell;

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -48,10 +48,10 @@ export interface ColumnDefinitionProps {
     title?: string,
 
     //The component that should be rendered instead of the standard column data. This component will still be rendered inside of a TD element.
-    customComponent?: GriddleComponent<CellProps>,
+    customComponent?: GriddleComponent<CellProps & any>,
 
     //The component that should be used instead of the normal title
-    customHeadingComponent?: GriddleComponent<TableHeadingCellProps>,
+    customHeadingComponent?: GriddleComponent<TableHeadingCellProps & any>,
 
     //Can this column be sorted
     sortable?: boolean,
@@ -60,7 +60,6 @@ export interface ColumnDefinitionProps {
     //What sort type this column uses - magic string :shame:
     sortType?: string,
 
-    // TODO: Unused?
     //Any extra data that should be passed to each instance of this column
     extraData?: any,
 

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -25,7 +25,7 @@ function getIcon({sortProperty, sortAscendingIcon, sortDescendingIcon}) {
   // return null so we don't render anything if no sortProperty
   return null;
 }
-const EnhancedHeadingCell = (OriginalComponent => compose(
+const EnhancedHeadingCell = OriginalComponent => compose(
   getContext({
     events: PropTypes.object,
   }),
@@ -66,10 +66,10 @@ const EnhancedHeadingCell = (OriginalComponent => compose(
       className
     };
   })
-)((props) => (
+)(props =>
   <OriginalComponent
     {...props}
-    onClick={props.onClick} />
-)));
+  />
+);
 
 export default EnhancedHeadingCell;

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -50,7 +50,7 @@ const EnhancedHeadingCell = OriginalComponent => compose(
   mapProps(props => {
     const icon = getIcon(props);
     const title = props.customHeadingComponent ?
-      <props.customHeadingComponent {...props} icon={icon} /> :
+      <props.customHeadingComponent {...props.cellProperties.extraData} {...props} icon={icon} /> :
       <DefaultTableHeadingCellContent title={props.title} icon={icon} />;
     const className = valueOrResult(props.cellProperties.headerCssClassName, props) || props.className;
     const style = {
@@ -59,6 +59,7 @@ const EnhancedHeadingCell = OriginalComponent => compose(
     };
 
     return {
+      ...props.cellProperties.extraData,
       ...props,
       icon,
       title,

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -345,6 +345,35 @@ storiesOf('Griddle main', module)
   .add('with controlled griddle component with no results', () => {
     return <Griddle data={[]} />
   })
+  .add('with extraData', () => {
+    const customHeadingComponent =
+      ({ title, extra }) =>
+        <span>{title} {extra && <em> {extra}</em>}</span>;
+
+    const customComponent =
+      ({ value, extra }) =>
+        <span>{value} {extra && <em> {extra}</em>}</span>;
+
+    const components = {
+      Cell: ({value, extra}) =>
+        <td>{value} {extra && <strong> {extra}</strong>}</td>,
+      TableHeadingCell: ({title, extra}) =>
+        <th>{title} {extra && <strong> {extra}</strong>}</th>,
+    };
+
+    return (
+      <div>
+        <small><em>extra</em> from <code>custom(Heading)Component</code>; <strong>extra</strong> from <code>(TableHeading)Cell</code></small>
+        <Griddle data={fakeData} plugins={[LocalPlugin]} components={components}>
+          <RowDefinition rowKey="name">
+            <ColumnDefinition id="name" order={2} extraData={{extra: 'extra'}}
+              customHeadingComponent={customHeadingComponent} customComponent={customComponent} />
+            <ColumnDefinition id="state" order={1} />
+          </RowDefinition>
+        </Griddle>
+      </div>
+    )
+  })
   .add('with custom griddle key', () => {
     return (
       <div>


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

Expand `ColumnDefinition` `extraData` into `props` for `TableHeadingCell`, `Cell`, `customHeadingComponent` and `customComponent`.

The [v0 implementation of `globalData`](https://github.com/GriddleGriddle/Griddle/pull/302) passed `globalData` through directly; it's trivial to switch this implementation to pass through an `extraData` prop, if that would be preferred.

## Why these changes are made

Closes #674 

## Are there tests?

Story!