### PR TITLE
Plugin styleConfig and components.Style

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
-const component = ({Table, Pagination, Filter, SettingsWrapper, className, style}) => (
+const component = ({Table, Pagination, Filter, SettingsWrapper, Style, className, style}) => (
   <div className={className} style={style}>
+    {Style && <Style />}
     <Filter />
     <SettingsWrapper />
     <Table />

--- a/src/components/LayoutContainer.js
+++ b/src/components/LayoutContainer.js
@@ -22,6 +22,7 @@ const EnhancedLayout = OriginalComponent => compose(
     Pagination: props.components.Pagination,
     Filter: props.components.Filter,
     SettingsWrapper: props.components.SettingsWrapper,
+    Style: props.components.Style,
     className: props.className,
     style: props.style,
   }))

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -78,6 +78,7 @@ const components = {
   Settings,
   SettingsContainer,
   SettingsComponents,
+  Style: () => null,
 };
 
 export default components;

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ class Griddle extends Component {
 
     this.selectors = plugins.reduce((combined, plugin) => ({ ...combined, ...plugin.selectors }), {...selectors});
 
-    const mergedStyleConfig = _.merge({}, defaultStyleConfig, styleConfig);
+    const mergedStyleConfig = _.merge({}, defaultStyleConfig, ...plugins.map(p => p.styleConfig), styleConfig);
 
     const pageProperties = Object.assign({}, {
         currentPage: 1,

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -328,6 +328,7 @@ export interface GriddlePlugin {
     reducer?: PropertyBag<Reducer>,
     selectors?: PropertyBag<Selector>,
     settingsComponentObjects?: PropertyBag<SettingsComponentObject>,
+    styleConfig?: GriddleStyleConfig,
 }
 
 export interface GriddleProps<T> {

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -373,6 +373,8 @@ export namespace utils {
 }
 
 export namespace plugins {
+    var LegacyStylePlugin : GriddlePlugin;
+
     var LocalPlugin : GriddlePlugin;
 
     interface PositionSettings {

--- a/src/module.js
+++ b/src/module.js
@@ -7,10 +7,12 @@ import * as selectors from './selectors/dataSelectors';
 import settingsComponentObjects from './settingsComponentObjects';
 import utils from './utils';
 
+import LegacyStylePlugin from './plugins/legacyStyle';
 import LocalPlugin from './plugins/local';
 import PositionPlugin from './plugins/position';
 
 const plugins = {
+  LegacyStylePlugin,
   LocalPlugin,
   PositionPlugin,
 };

--- a/src/plugins/legacyStyle/index.js
+++ b/src/plugins/legacyStyle/index.js
@@ -1,0 +1,102 @@
+import React from 'react';
+
+export default {
+  styleConfig: {
+    classNames: {
+      Layout: 'griddle griddle-container',
+    }
+  },
+  components: {
+    Style: () => (
+      <style type="text/css">
+        {`
+          .griddle-container{
+            border:1px solid #DDD;
+          }
+
+          .griddle .top-section{
+            clear:both;
+            display:table;
+            width:100%;
+          }
+
+          .griddle .griddle-filter{
+            float:left;
+            width:50%;
+            text-align:left;
+            color:#222;
+            min-height:1px;
+          }
+
+          .griddle .griddle-settings-toggle{
+            float:left;
+            width:50%;
+            text-align:right;
+          }
+
+          .griddle .griddle-settings{
+            background-color:#FFF;
+            border:1px solid #DDD;
+            color:#222;
+            padding:10px;
+            margin-bottom:10px;
+          }
+
+          .griddle .griddle-settings .griddle-columns{
+            clear:both;
+            display:table;
+            width:100%;
+            border-bottom:1px solid #EDEDED;
+            margin-bottom:10px;
+          }
+
+          .griddle .griddle-settings .griddle-column-selection{
+            float:left;
+            width:20%;
+          }
+          .griddle table{
+            width:100%;table-layout:fixed;
+          }
+
+          .griddle th{
+            background-color:#EDEDEF;
+            border:0px;
+            border-bottom:1px solid #DDD;
+            color:#222;
+            padding:5px;
+          }
+
+          .griddle td{
+            padding:5px;
+            background-color:#FFF;
+            border-top-color:#DDD;
+            color:#222;
+          }
+
+          .griddle .footer-container{
+            padding:0px;
+            background-color:#EDEDED;
+            border:0px;
+            color:#222;
+          }
+
+          .griddle .griddle-previous, .griddle .griddle-page, .griddle .griddle-next{
+            float:left;
+            width:33%;
+            min-height:1px;
+            margin-top:5px;
+          }
+
+          .griddle .griddle-page{
+            text-align:center;
+          }
+
+          .griddle .griddle-next{
+            text-align:right;
+          }
+
+        `}
+      </style>
+    ),
+  }
+};

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -15,7 +15,7 @@ import GenericGriddle, { actions, components, selectors, plugins, utils, ColumnD
 const { Cell, Row, Table, TableContainer, TableBody, TableHeading, TableHeadingCell } = components;
 const { SettingsWrapper, SettingsToggle, Settings } = components;
 
-const { LocalPlugin, PositionPlugin } = plugins;
+const { LegacyStylePlugin, LocalPlugin, PositionPlugin } = plugins;
 
 import fakeData, { FakeData } from './fakeData';
 import { person, fakeData2, personClass, fakeData3 } from './fakeData2';
@@ -79,6 +79,11 @@ storiesOf('Griddle main', module)
         <RowDefinition>
         </RowDefinition>
       </Griddle>
+    )
+  })
+  .add('with local and legacy (v0) styles', () => {
+    return (
+      <Griddle data={fakeData} plugins={[LocalPlugin, LegacyStylePlugin]} />
     )
   })
   .add('with local and events', () => {

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -591,6 +591,20 @@ storiesOf('Griddle main', module)
 storiesOf('Plugins', module)
   .add('styleConfig', () => {
     const stylePlugin = {
+      components: {
+        Style: () =>
+          <style type="text/css">
+            {`
+              .plugin-layout {
+                border: 5px solid green;
+                padding: 5px;
+              }
+              .plugin-row:nth-child(2n+1) {
+                background-color: #eee;
+              }
+            `}
+          </style>
+      },
       styleConfig: {
         icons: {
           TableHeadingCell: {
@@ -599,7 +613,8 @@ storiesOf('Plugins', module)
           },
         },
         classNames: {
-          Row: 'plugin-row'
+          Layout: 'plugin-layout',
+          Row: 'plugin-row',
         },
         styles: {
           Filter: {
@@ -611,16 +626,8 @@ storiesOf('Plugins', module)
       }
     };
 
-    const css = `
-      .plugin-row:nth-child(2n+1) {
-        background-color: #eee;
-      }
-    `;
     return (
       <div>
-        <style type="text/css">
-          {css}
-        </style>
         <small>Uses styles from plugin unless overridden (filter should be black).</small>
         <Griddle data={fakeData} plugins={[LocalPlugin, stylePlugin]}
           styleConfig={{

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -588,6 +588,49 @@ storiesOf('Griddle main', module)
     );
   })
 
+storiesOf('Plugins', module)
+  .add('styleConfig', () => {
+    const stylePlugin = {
+      styleConfig: {
+        icons: {
+          TableHeadingCell: {
+            sortDescendingIcon: ' (desc)',
+            sortAscendingIcon: ' (asc)'
+          },
+        },
+        classNames: {
+          Row: 'plugin-row'
+        },
+        styles: {
+          Filter: {
+            backgroundColor: 'blue',
+            color: 'white',
+            fontSize: '200%',
+          }
+        }
+      }
+    };
+
+    const css = `
+      .plugin-row:nth-child(2n+1) {
+        background-color: #eee;
+      }
+    `;
+    return (
+      <div>
+        <style type="text/css">
+          {css}
+        </style>
+        <small>Uses styles from plugin unless overridden (filter should be black).</small>
+        <Griddle data={fakeData} plugins={[LocalPlugin, stylePlugin]}
+          styleConfig={{
+            styles: { Filter: { backgroundColor: 'black', fontStyle: 'italic' } }
+          }}
+        />
+      </div>
+    );
+  })
+
 storiesOf('Cell', module)
   .add('base cell', () => {
     const someValue = "hi from storybook"


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

* `styleConfig` from plugins is now merged in between default styles and the `styleConfig` user prop
* The default `Layout` now renders a `Style` component (default renders `null`) that plugins and users can override to inject a stylesheet

## Why these changes are made

* Gives a mechanism for including a new default "theme" via plugin (#661)
* Gives a mechanism for others to contribute themes (#667)

## Are there tests?

Incomplete story - I pulled in the [CSS from v0](https://github.com/GriddleGriddle/Griddle/blob/359f3f1243b857373b8892a0ff93d60797152f60/docs/assets/styles/griddle.css), but don't know v0 well enough to fix it up to look nice.