### PR TITLE
TypeScript: Rewrite GriddleComponents + (Row/Cell Events Example)

### DIFF
--- a/src/components/Cell.js
+++ b/src/components/Cell.js
@@ -1,11 +1,11 @@
 import React from 'react';
 
-const Cell = ({ value, onMouseEnter, onClick, className, style, onMouseLeave }) => (
+const Cell = ({ value, onClick, onMouseEnter, onMouseLeave, style, className }) => (
   <td
-    style={style}
     onClick={onClick}
     onMouseEnter={onMouseEnter}
     onMouseLeave={onMouseLeave}
+    style={style}
     className={className}
   >
     {value}

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,8 +1,11 @@
 import React from 'react';
 
-const Row = ({Cell, griddleKey, columnIds, style, className}) => (
+const Row = ({ Cell, griddleKey, columnIds, onClick, onMouseEnter, onMouseLeave, style, className }) => (
   <tr
     key={griddleKey}
+    onClick={onClick}
+    onMouseEnter={onMouseEnter}
+    onMouseLeave={onMouseLeave}
     style={style}
     className={className}
   >

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -85,9 +85,9 @@ export class ColumnDefinition extends React.Component<ColumnDefinitionProps, any
 
 export interface CellProps {
     value?: any;
-    onClick?: Function;
-    onMouseEnter?: Function;
-    onMouseLeave?: Function;
+    onClick?: React.MouseEventHandler<Element>;
+    onMouseEnter?: React.MouseEventHandler<Element>;
+    onMouseLeave?: React.MouseEventHandler<Element>;
     className?: string;
     style?: React.CSSProperties;
 }
@@ -99,9 +99,9 @@ export interface RowProps {
     Cell?: any;
     griddleKey?: string;
     columnIds?: number[];
-    onClick?: Function;
-    onMouseEnter?: Function;
-    onMouseLeave?: Function;
+    onClick?: React.MouseEventHandler<Element>;
+    onMouseEnter?: React.MouseEventHandler<Element>;
+    onMouseLeave?: React.MouseEventHandler<Element>;
     className?: string;
     style?: React.CSSProperties;
 }
@@ -141,9 +141,9 @@ class TableHeading extends React.Component<TableHeadingProps, any> {
 export interface TableHeadingCellProps {
     title?: string;
     columnId?: number;
-    onClick?: Function;
-    onMouseEnter?: Function;
-    onMouseLeave?: Function;
+    onClick?: React.MouseEventHandler<Element>;
+    onMouseEnter?: React.MouseEventHandler<Element>;
+    onMouseLeave?: React.MouseEventHandler<Element>;
     icon?: any;
     className?: string;
     style?: React.CSSProperties;
@@ -169,7 +169,7 @@ class SettingsWrapper extends React.Component<SettingsWrapperProps, any> {
 const SettingsWrapperContainer: (OriginalComponent: any) => any;
 
 export interface SettingsToggleProps {
-    onClick?: Function;
+    onClick?: React.MouseEventHandler<Element>;
     text?: any;
     className?: string;
     style?: React.CSSProperties;

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -196,45 +196,92 @@ const SettingsComponents: PropertyBag<GriddleComponent<any>>;
 } // namespace components
 
 export interface GriddleComponents {
-    Cell?: any;
-    CellContainer?: any;
-    ColumnDefinition?: any;
-    Row?: any;
-    RowContainer?: any;
-    RowDefinition?: any;
-    Table?: any;
-    TableBody?: any;
-    TableBodyContainer?: any;
-    TableHeading?: any;
-    TableHeadingContainer?: any;
-    TableHeadingCell?: any;
-    TableHeadingCellContainer?: any;
-    TableHeadingCellEnhancer?: any;
-    TableContainer?: any;
-    Layout?: any;
-    LayoutContainer?: any;
-    NextButton?: any;
-    NextButtonEnhancer?: any;
-    NextButtonContainer?: any;
-    NoResults?: any;
-    NoResultsContainer?: any;
-    PageDropdown?: any;
-    PageDropdownContainer?: any;
-    Pagination?: any;
-    PaginationContainer?: any;
-    PreviousButton?: any;
-    PreviousButtonEnhancer?: any;
-    PreviousButtonContainer?: any;
-    Filter?: any;
-    FilterEnhancer?: any;
-    FilterContainer?: any;
-    SettingsToggle?: any;
-    SettingsToggleContainer?: any;
-    SettingsWrapper?: any;
-    SettingsWrapperContainer?: any;
-    Settings?: any;
-    SettingsContainer?: any;
+    Layout?: GriddleComponent<any>;
+    LayoutEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    LayoutContainer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    LayoutContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+
+    Style?: GriddleComponent<any>;
+    StyleEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    StyleContainer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    StyleContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+
+    Filter?: GriddleComponent<any>;
+    FilterEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    FilterContainer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    FilterContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+
+    SettingsWrapper?: GriddleComponent<components.SettingsWrapperProps>;
+    SettingsWrapperEnhancer?: (OriginalComponent: GriddleComponent<components.SettingsWrapperProps>) => GriddleComponent<components.SettingsWrapperProps>;
+    SettingsWrapperContainer?: (OriginalComponent: GriddleComponent<components.SettingsWrapperProps>) => GriddleComponent<components.SettingsWrapperProps>;
+    SettingsWrapperContainerEnhancer?: (OriginalComponent: GriddleComponent<components.SettingsWrapperProps>) => GriddleComponent<components.SettingsWrapperProps>;
+
+    SettingsToggle?: GriddleComponent<components.SettingsToggleProps>;
+    SettingsToggleEnhancer?: (OriginalComponent: GriddleComponent<components.SettingsToggleProps>) => GriddleComponent<components.SettingsToggleProps>;
+    SettingsToggleContainer?: (OriginalComponent: GriddleComponent<components.SettingsToggleProps>) => GriddleComponent<components.SettingsToggleProps>;
+    SettingsToggleContainerEnhancer?: (OriginalComponent: GriddleComponent<components.SettingsToggleProps>) => GriddleComponent<components.SettingsToggleProps>;
+
+    Settings?: GriddleComponent<components.SettingsProps>;
+    SettingsEnhancer?: (OriginalComponent: GriddleComponent<components.SettingsProps>) => GriddleComponent<components.SettingsProps>;
+    SettingsContainer?: (OriginalComponent: GriddleComponent<components.SettingsProps>) => GriddleComponent<components.SettingsProps>;
+    SettingsContainerEnhancer?: (OriginalComponent: GriddleComponent<components.SettingsProps>) => GriddleComponent<components.SettingsProps>;
+
     SettingsComponents?: PropertyBag<GriddleComponent<any>>;
+
+    Table?: GriddleComponent<components.TableProps>;
+    TableEnhancer?: (OriginalComponent: GriddleComponent<components.TableProps>) => GriddleComponent<components.TableProps>;
+    TableContainer?: (OriginalComponent: GriddleComponent<components.TableProps>) => GriddleComponent<components.TableProps>;
+    TableContainerEnhancer?: (OriginalComponent: GriddleComponent<components.TableProps>) => GriddleComponent<components.TableProps>;
+
+    TableHeading?: GriddleComponent<components.TableHeadingProps>;
+    TableHeadingEnhancer?: (OriginalComponent: GriddleComponent<components.TableHeadingProps>) => GriddleComponent<components.TableHeadingProps>;
+    TableHeadingContainer?: (OriginalComponent: GriddleComponent<components.TableHeadingProps>) => GriddleComponent<components.TableHeadingProps>;
+    TableHeadingContainerEnhancer?: (OriginalComponent: GriddleComponent<components.TableHeadingProps>) => GriddleComponent<components.TableHeadingProps>;
+
+    TableHeadingCell?: GriddleComponent<components.TableHeadingCellProps>;
+    TableHeadingCellEnhancer?: (OriginalComponent: GriddleComponent<components.TableHeadingCellProps>) => GriddleComponent<components.TableHeadingCellProps>;
+    TableHeadingCellContainer?: (OriginalComponent: GriddleComponent<components.TableHeadingCellProps>) => GriddleComponent<components.TableHeadingCellProps>;
+    TableHeadingCellContainerEnhancer?: (OriginalComponent: GriddleComponent<components.TableHeadingCellProps>) => GriddleComponent<components.TableHeadingCellProps>;
+
+    TableBody?: GriddleComponent<components.TableBodyProps>;
+    TableBodyEnhancer?: (OriginalComponent: GriddleComponent<components.TableBodyProps>) => GriddleComponent<components.TableBodyProps>;
+    TableBodyContainer?: (OriginalComponent: GriddleComponent<components.TableBodyProps>) => GriddleComponent<components.TableBodyProps>;
+    TableBodyContainerEnhancer?: (OriginalComponent: GriddleComponent<components.TableBodyProps>) => GriddleComponent<components.TableBodyProps>;
+
+    Row?: GriddleComponent<components.RowProps>;
+    RowEnhancer?: (OriginalComponent: GriddleComponent<components.RowProps>) => GriddleComponent<components.RowProps>;
+    RowContainer?: (OriginalComponent: GriddleComponent<components.RowProps>) => GriddleComponent<components.RowProps>;
+    RowContainerEnhancer?: (OriginalComponent: GriddleComponent<components.RowProps>) => GriddleComponent<components.RowProps>;
+
+    Cell?: GriddleComponent<components.CellProps>;
+    CellEnhancer?: (OriginalComponent: GriddleComponent<components.CellProps>) => GriddleComponent<components.CellProps>;
+    CellContainer?: (OriginalComponent: GriddleComponent<components.CellProps>) => GriddleComponent<components.CellProps>;
+    CellContainerEnhancer?: (OriginalComponent: GriddleComponent<components.CellProps>) => GriddleComponent<components.CellProps>;
+
+    NoResults?: GriddleComponent<any>;
+    NoResultsEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    NoResultsContainer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    NoResultsContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+
+    Pagination?: GriddleComponent<any>;
+    PaginationEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    PaginationContainer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    PaginationContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+
+    NextButton?: GriddleComponent<any>;
+    NextButtonEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    NextButtonContainer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    NextButtonContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+
+    PageDropDown?: GriddleComponent<any>;
+    PageDropDownEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    PageDropDownContainer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    PageDropDownContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+
+    PreviousButton?: GriddleComponent<any>;
+    PreviousButtonEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    PreviousButtonContainer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    PreviousButtonContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
 }
 
 export interface GriddleEvents {

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -104,6 +104,25 @@ storiesOf('Griddle main', module)
       </Griddle>
     )
   })
+  .add('with Cell events', () => {
+    return (
+      <Griddle
+        data={fakeData}
+        plugins={[LocalPlugin]}
+        components={{
+          CellEnhancer: OriginalComponent =>
+            props => (
+              <OriginalComponent
+                {...props}
+                onClick={() => console.log(`Click ${props.value}`)}
+                onMouseEnter={() => console.log(`MouseEnter ${props.value}`)}
+                onMouseLeave={() => console.log(`MouseLeave ${props.value}`)}
+                />
+            ),
+        }}
+        />
+    );
+  })
   .add('with local and sort set', () => {
     const sortProperties = [
       { id: 'name', sortAscending: true }

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -104,12 +104,21 @@ storiesOf('Griddle main', module)
       </Griddle>
     )
   })
-  .add('with Cell events', () => {
+  .add('with Row & Cell events', () => {
     return (
       <Griddle
         data={fakeData}
         plugins={[LocalPlugin]}
         components={{
+          RowEnhancer: OriginalComponent =>
+            props => (
+              <OriginalComponent
+                {...props}
+                onClick={() => console.log(`Click Row ${props.griddleKey}`)}
+                onMouseEnter={() => console.log(`MouseEnter Row ${props.griddleKey}`)}
+                onMouseLeave={() => console.log(`MouseLeave Row ${props.griddleKey}`)}
+                />
+            ),
           CellEnhancer: OriginalComponent =>
             props => (
               <OriginalComponent
@@ -119,6 +128,11 @@ storiesOf('Griddle main', module)
                 onMouseLeave={() => console.log(`MouseLeave ${props.value}`)}
                 />
             ),
+        }}
+        styleConfig={{
+          styles: {
+            Table: { borderCollapse: 'collapse' }, // To prevent Row enter/leave between cells
+          },
         }}
         />
     );


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

- Closes #678 with a story that demonstrates providing `Row` and `Cell` with event handlers, via enhancers
- Replaces naive `GriddleComponents` (type of `Griddle.components` and `GriddlePlugin.components`) with a more complete definition:
  - `Enhancer`, `Container` and `ContainerEnhancer` companions are now included for all components 
  - `RowDefinition` and `ColumnDefinition` have been removed
- Adds types to mouse event handlers

## Why these changes are made

Types are neat. Examples are neat, too.

## Are there tests?

Stories!