### PR TITLE
fix of long initialization

### DIFF
--- a/src/utils/dataUtils.js
+++ b/src/utils/dataUtils.js
@@ -44,12 +44,12 @@ export function transformData(data, renderProperties) {
     const keyedData = map.has('griddleKey') ? map : map.set('griddleKey', key);
 
     // return list and lookup with the new stuff from this iteration
+    lookup[key] = index;
+    list.push(keyedData);
+
     return {
-      list: [...list, keyedData],
-      lookup: {
-        ...lookup,
-        [key]: index
-      },
+      list,
+      lookup,
     };
   }, {
     list: [],


### PR DESCRIPTION
## Griddle major version 
1.5.0

## Changes proposed in this pull request
We got performance issue with `transformData`.
After a half day of researching I fixed the problem and now it runs 50x times faster!
The problem was in `concat` method — it works slow on 10k+ rows.

## Are there tests?
No new tests were added