### PR TITLE
Typescript Upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@kadira/storybook": "^2.5.2",
-    "@types/react": "^15.0.17",
+    "@types/react": "^15.0.34",
     "ava": "^0.17.0",
     "babel-cli": "^6.23.0",
     "babel-core": "^6.0.0",
@@ -55,7 +55,7 @@
     "react-dom": "^15.3.2",
     "rimraf": "^2.6.0",
     "ts-loader": "^2.0.2",
-    "typescript": "^2.2.1",
+    "typescript": "^2.4.1",
     "webpack": "^1.14.0",
     "webpack-dev-server": "^1.16.2"
   },

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -84,6 +84,8 @@ export class ColumnDefinition extends React.Component<ColumnDefinitionProps, any
 }
 
 export interface CellProps {
+    griddleKey?: number;
+    columnId?: string;
     value?: any;
     onClick?: React.MouseEventHandler<Element>;
     onMouseEnter?: React.MouseEventHandler<Element>;
@@ -290,6 +292,7 @@ export interface GriddleEvents {
     onNext?: () => void;
     onPrevious?: () => void;
     onGetPage?: (pageNumber: number) => void;
+    setSortProperties?: (sortProperties: utils.SortProperties) => () => void;
 }
 
 export interface GriddleSortKey {
@@ -370,6 +373,7 @@ interface SettingsComponentObject {
 
 export interface GriddlePlugin {
     components?: GriddleComponents,
+    events?: GriddleEvents;
     renderProperties?: GriddleRenderProperties;
     initialState?: PropertyBag<any>,
     reducer?: PropertyBag<Reducer>,

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -286,12 +286,16 @@ export interface GriddleComponents {
     PreviousButtonContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
 }
 
-export interface GriddleEvents {
-    onFilter?: (filterText: string) => void;
+export interface GriddleActions extends PropertyBag<Function> {
     onSort?: (sortProperties: any) => void;
     onNext?: () => void;
     onPrevious?: () => void;
     onGetPage?: (pageNumber: number) => void;
+    setFilter?: (filterText: string) => void;
+}
+
+export interface GriddleEvents extends GriddleActions {
+    onFilter?: (filterText: string) => void;
     setSortProperties?: (sortProperties: utils.SortProperties) => () => void;
 }
 
@@ -397,7 +401,7 @@ export interface GriddleProps<T> {
 declare class Griddle<T> extends React.Component<GriddleProps<T>, any> {
 }
 
-export const actions: PropertyBag<Function>;
+export const actions: GriddleActions;
 
 export const constants: PropertyBag<string>;
 

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -522,7 +522,7 @@ storiesOf('Griddle main', module)
     // We could use this entirely if we wanted and connect and map over visible rows but 
     // Using this + tableBody to take advantange of code that Griddle LocalPlugin already has
     const CustomTableComponent = OriginalComponent =>
-      class CustomTableComponent extends React.Component<{}, void> {
+      class CustomTableComponent extends React.Component<{}> {
         static contextTypes = {
           components: React.PropTypes.object
         }
@@ -1130,7 +1130,7 @@ storiesOf('TableContainer', module)
       </tbody>
     );
 
-    class BaseWithContext extends React.Component<any, void> {
+    class BaseWithContext extends React.Component<any> {
       static childContextTypes = {
         components: PropTypes.object.isRequired
       }
@@ -1350,7 +1350,7 @@ storiesOf('Settings', module)
 
 storiesOf('TypeScript', module)
   .add('GriddleComponent accepts expected types', () => {
-    class Custom extends React.Component<{ value }, void> {
+    class Custom extends React.Component<{ value }> {
       render() {
         return this.props.value;
       }


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

The good news is TypeScript 2.4 found some type ambiguities.

The bad news is that the React type definitions upgrade isn't backwards-compatible (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/17288), so we either have to upgrade or pin an older version of `@types/react`.

So we upgrade. Fixes #686.

## Are there tests?

The compiler is a test.