### PR TITLE
Fix missing quote

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -609,7 +609,7 @@ Griddle uses its own Redux store for managing state and all of the components li
 <pre><code><span class="xml">  <span class="hljs-tag">&lt;<span class="hljs-name">Griddle</span> <span class="hljs-attr">data</span>=</span></span><span class="hljs-template-variable">{data}</span><span class="xml"><span class="hljs-tag">&gt;</span>
     <span class="hljs-tag">&lt;<span class="hljs-name">RowDefinition</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-name">ColumnDefinition</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"name"</span> <span class="hljs-attr">title</span>=<span class="hljs-string">"Name"</span> /&gt;</span>
-      <span class="hljs-tag">&lt;<span class="hljs-name">ColumnDefinition</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"company"</span> <span class="hljs-attr">title</span>=<span class="hljs-string">"Company order=</span></span></span><span class="hljs-template-variable">{1}</span><span class="xml"><span class="hljs-tag"><span class="hljs-string"> /&gt;
+      <span class="hljs-tag">&lt;<span class="hljs-name">ColumnDefinition</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"company"</span> <span class="hljs-attr">title</span>=<span class="hljs-string">"Company" order=</span></span></span><span class="hljs-template-variable">{1}</span><span class="xml"><span class="hljs-tag"><span class="hljs-string"> /&gt;
     &lt;/RowDefinition&gt;
   &lt;/Griddle&gt;
 </span></span></span></code></pre>


### PR DESCRIPTION
## Griddle major version
1.0.0

## Changes proposed in this pull request
Fix formatting of the API docs 

## Why these changes are made
Fix formatting
![image](https://user-images.githubusercontent.com/3066423/28115997-69beb9da-6707-11e7-80fe-e4f81d963dca.png)

## Are there tests?
no need