### PR TITLE
Sort Icon Classes

### DIFF
--- a/src/components/TableHeadingCellContainer.js
+++ b/src/components/TableHeadingCellContainer.js
@@ -6,6 +6,7 @@ import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 
 import { sortPropertyByIdSelector, iconsForComponentSelector, classNamesForComponentSelector, stylesForComponentSelector, customHeadingComponentSelector, cellPropertiesSelector } from '../selectors/dataSelectors';
+import { getSortIconProps } from '../utils/sortUtils';
 import { valueOrResult } from '../utils/valueUtils';
 
 const DefaultTableHeadingCellContent = ({title, icon}) => (
@@ -14,15 +15,6 @@ const DefaultTableHeadingCellContent = ({title, icon}) => (
     { icon && <span>{icon}</span> }
   </span>
 )
-
-function getIcon({sortProperty, sortAscendingIcon, sortDescendingIcon}) {
-  if (sortProperty) {
-    return sortProperty.sortAscending ? sortAscendingIcon : sortDescendingIcon;
-  }
-
-  // return null so we don't render anything if no sortProperty
-  return null;
-}
 
 const EnhancedHeadingCell = OriginalComponent => compose(
   getContext({
@@ -39,10 +31,10 @@ const EnhancedHeadingCell = OriginalComponent => compose(
     })
   ),
   mapProps(props => {
-    const icon = getIcon(props);
+    const iconProps = getSortIconProps(props);
     const title = props.customHeadingComponent ?
-      <props.customHeadingComponent {...props.cellProperties.extraData} {...props} icon={icon} /> :
-      <DefaultTableHeadingCellContent title={props.title} icon={icon} />;
+      <props.customHeadingComponent {...props.cellProperties.extraData} {...props} {...iconProps} /> :
+      <DefaultTableHeadingCellContent title={props.title} {...iconProps} />;
     const className = valueOrResult(props.cellProperties.headerCssClassName, props) || props.className;
     const style = {
       ...(props.cellProperties.sortable === false || { cursor: 'pointer' }),
@@ -52,7 +44,7 @@ const EnhancedHeadingCell = OriginalComponent => compose(
     return {
       ...props.cellProperties.extraData,
       ...props,
-      icon,
+      ...iconProps,
       title,
       style,
       className

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -27,6 +27,8 @@ const EnhancedHeadingCell = OriginalComponent => compose(
       customHeadingComponent: customHeadingComponentSelector(state, props),
       cellProperties: cellPropertiesSelector(state, props),
       className: classNamesForComponentSelector(state, 'TableHeadingCell'),
+      sortAscendingClassName: classNamesForComponentSelector(state, 'TableHeadingCellAscending'),
+      sortDescendingClassName: classNamesForComponentSelector(state, 'TableHeadingCellDescending'),
       style: stylesForComponentSelector(state, 'TableHeadingCell'),
       ...iconsForComponentSelector(state, 'TableHeadingCell'),
     }),

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -7,24 +7,16 @@ import getContext from 'recompose/getContext';
 import withHandlers from 'recompose/withHandlers';
 import { sortPropertyByIdSelector, iconsForComponentSelector, customHeadingComponentSelector, stylesForComponentSelector, classNamesForComponentSelector, cellPropertiesSelector } from '../../../selectors/dataSelectors';
 import { setSortColumn } from '../../../actions';
-import { setSortProperties } from '../../../utils/sortUtils';
+import { getSortIconProps, setSortProperties } from '../../../utils/sortUtils';
 import { valueOrResult } from '../../../utils/valueUtils';
 
-const DefaultTableHeadingCellContent = ({title, icon}) => (
+const DefaultTableHeadingCellContent = ({title, icon, iconClassName}) => (
   <span>
     { title }
-    { icon && <span>{icon}</span> }
+    { icon && <span className={iconClassName}>{icon}</span> }
   </span>
 )
 
-function getIcon({sortProperty, sortAscendingIcon, sortDescendingIcon}) {
-  if (sortProperty) {
-    return sortProperty.sortAscending ? sortAscendingIcon : sortDescendingIcon;
-  }
-
-  // return null so we don't render anything if no sortProperty
-  return null;
-}
 const EnhancedHeadingCell = OriginalComponent => compose(
   getContext({
     events: PropTypes.object,
@@ -48,10 +40,10 @@ const EnhancedHeadingCell = OriginalComponent => compose(
   })),
   //TODO: use with props on change or something more performant here
   mapProps(props => {
-    const icon = getIcon(props);
+    const iconProps = getSortIconProps(props);
     const title = props.customHeadingComponent ?
-      <props.customHeadingComponent {...props.cellProperties.extraData} {...props} icon={icon} /> :
-      <DefaultTableHeadingCellContent title={props.title} icon={icon} />;
+      <props.customHeadingComponent {...props.cellProperties.extraData} {...props} {...iconProps} /> :
+      <DefaultTableHeadingCellContent title={props.title} {...iconProps} />;
     const className = valueOrResult(props.cellProperties.headerCssClassName, props) || props.className;
     const style = {
       ...(props.cellProperties.sortable === false || { cursor: 'pointer' }),
@@ -61,7 +53,7 @@ const EnhancedHeadingCell = OriginalComponent => compose(
     return {
       ...props.cellProperties.extraData,
       ...props,
-      icon,
+      ...iconProps,
       title,
       style,
       className

--- a/src/utils/sortUtils.js
+++ b/src/utils/sortUtils.js
@@ -42,14 +42,17 @@ export function setSortProperties({ setSortColumn, sortProperty, columnId }) {
 
 export function getSortIconProps(props) {
   const { sortProperty, sortAscendingIcon, sortDescendingIcon } = props;
+  const { sortAscendingClassName, sortDescendingClassName } = props;
 
   if (sortProperty) {
     return sortProperty.sortAscending ?
     {
       icon: sortAscendingIcon,
+      iconClassName: sortAscendingClassName,
     } :
     {
       icon: sortDescendingIcon,
+      iconClassName: sortDescendingClassName,
     };
   }
 

--- a/src/utils/sortUtils.js
+++ b/src/utils/sortUtils.js
@@ -39,3 +39,20 @@ export function setSortProperties({ setSortColumn, sortProperty, columnId }) {
     setSortColumn(newSortProperty);
   };
 }
+
+export function getSortIconProps(props) {
+  const { sortProperty, sortAscendingIcon, sortDescendingIcon } = props;
+
+  if (sortProperty) {
+    return sortProperty.sortAscending ?
+    {
+      icon: sortAscendingIcon,
+    } :
+    {
+      icon: sortDescendingIcon,
+    };
+  }
+
+  // return null so we don't render anything if no sortProperty
+  return null;
+}

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -53,7 +53,7 @@ function getRandomFakeData() {
 }
 const GreenLeftSortIconComponent = (props) => (
   <span style={{ color: "#00ff00" }}>
-    {props.icon && <span>{props.icon}</span>}
+    {props.icon && <span className={props.iconClassName}>{props.icon}</span>}
     {props.title}
   </span>
 )
@@ -441,6 +441,10 @@ storiesOf('Griddle main', module)
   .add('with custom heading component', () => {
     return (
       <div>
+        <style type="text/css">{`
+          .griddle-heading-ascending:before { content: '↑'; }
+          .griddle-heading-descending:before { content: '↓'; }
+        `}</style>
         <small>Name should have a green heading component -- sort icon should show up on the left of the title</small>
         <Griddle data={fakeData} plugins={[LocalPlugin]}>
           <RowDefinition>


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

Applies `TableHeadingCellAscending` and `TableHeadingCellDescending` as `className` on the `<span>` that surrounds the sort icon.

Also, extracts a `getSortIconProps` utility function that can be shared between the default and local plugin `TableHeadingCellContainer` implementations.

## Why these changes are made

Fixes #698
cc @moraleslos

## Are there tests?

Story!