### PR TITLE
Add "griddleConnect" to help avoid store conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lodash": "^4.17.4",
     "max-safe-integer": "^1.0.0",
     "prop-types": "^15.5.8",
-    "react-redux": "^5.0.2",
+    "react-redux": "^5.0.6",
     "react-redux-custom-store": "^1.0.0",
     "recompose": "^0.21.2",
     "redux": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "max-safe-integer": "^1.0.0",
     "prop-types": "^15.5.8",
     "react-redux": "^5.0.6",
-    "react-redux-custom-store": "^1.0.0",
     "recompose": "^0.21.2",
     "redux": "^3.5.2",
     "reselect": "^2.5.3"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "max-safe-integer": "^1.0.0",
     "prop-types": "^15.5.8",
     "react-redux": "^5.0.2",
+    "react-redux-custom-store": "^1.0.0",
     "recompose": "^0.21.2",
     "redux": "^3.5.2",
     "reselect": "^2.5.3"

--- a/src/components/CellContainer.js
+++ b/src/components/CellContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import getContext from 'recompose/getContext';
 import mapProps from 'recompose/mapProps';
 import compose from 'recompose/compose';

--- a/src/components/CellContainer.js
+++ b/src/components/CellContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import getContext from 'recompose/getContext';
 import mapProps from 'recompose/mapProps';
 import compose from 'recompose/compose';

--- a/src/components/FilterContainer.js
+++ b/src/components/FilterContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 
 import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 import { setFilter } from '../actions';

--- a/src/components/FilterContainer.js
+++ b/src/components/FilterContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 
 import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 import { setFilter } from '../actions';

--- a/src/components/LayoutContainer.js
+++ b/src/components/LayoutContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import getContext from 'recompose/getContext';
 import mapProps from 'recompose/mapProps';
 import compose from 'recompose/compose';
@@ -9,7 +9,7 @@ import { classNamesForComponentSelector, stylesForComponentSelector } from '../s
 
 const EnhancedLayout = OriginalComponent => compose(
   getContext({
-    components: PropTypes.object
+    components: PropTypes.object,
   }),
   connect(
     (state, props) => ({
@@ -25,7 +25,7 @@ const EnhancedLayout = OriginalComponent => compose(
     Style: props.components.Style,
     className: props.className,
     style: props.style,
-  }))
+  })),
 )(props => (
   <OriginalComponent
     {...props}

--- a/src/components/LayoutContainer.js
+++ b/src/components/LayoutContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import getContext from 'recompose/getContext';
 import mapProps from 'recompose/mapProps';
 import compose from 'recompose/compose';

--- a/src/components/NextButtonContainer.js
+++ b/src/components/NextButtonContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 
 import { hasNextSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 

--- a/src/components/NextButtonContainer.js
+++ b/src/components/NextButtonContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 
 import { hasNextSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 

--- a/src/components/NoResultsContainer.js
+++ b/src/components/NoResultsContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/NoResultsContainer.js
+++ b/src/components/NoResultsContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/PageDropdownContainer.js
+++ b/src/components/PageDropdownContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/PageDropdownContainer.js
+++ b/src/components/PageDropdownContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/PaginationContainer.js
+++ b/src/components/PaginationContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/PaginationContainer.js
+++ b/src/components/PaginationContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/PreviousButtonContainer.js
+++ b/src/components/PreviousButtonContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import { hasPreviousSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
 const enhance = OriginalComponent => connect((state, props) => ({

--- a/src/components/PreviousButtonContainer.js
+++ b/src/components/PreviousButtonContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import { hasPreviousSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
 const enhance = OriginalComponent => connect((state, props) => ({

--- a/src/components/RowContainer.js
+++ b/src/components/RowContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/RowContainer.js
+++ b/src/components/RowContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/SettingsContainer.js
+++ b/src/components/SettingsContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/SettingsContainer.js
+++ b/src/components/SettingsContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/SettingsToggleContainer.js
+++ b/src/components/SettingsToggleContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import { textSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 import { toggleSettings as toggleSettingsAction } from '../actions';

--- a/src/components/SettingsToggleContainer.js
+++ b/src/components/SettingsToggleContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import compose from 'recompose/compose';
 import { textSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 import { toggleSettings as toggleSettingsAction } from '../actions';

--- a/src/components/SettingsWrapperContainer.js
+++ b/src/components/SettingsWrapperContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/SettingsWrapperContainer.js
+++ b/src/components/SettingsWrapperContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/TableBodyContainer.js
+++ b/src/components/TableBodyContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/TableBodyContainer.js
+++ b/src/components/TableBodyContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/TableContainer.js
+++ b/src/components/TableContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/TableContainer.js
+++ b/src/components/TableContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/TableHeadingCellContainer.js
+++ b/src/components/TableHeadingCellContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/TableHeadingCellContainer.js
+++ b/src/components/TableHeadingCellContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/TableHeadingContainer.js
+++ b/src/components/TableHeadingContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from './griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/TableHeadingContainer.js
+++ b/src/components/TableHeadingContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from './griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/components/griddleConnect.js
+++ b/src/components/griddleConnect.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux-custom-store';
+import getContext from 'recompose/getContext';
+
+
+const griddleConnect = (...connectOptions) => OriginalComponent => class extends React.Component {
+  static contextTypes = {
+    storeName: PropTypes.string,
+  }
+
+  render() {
+    console.log(this.context.storeName)
+    const ConnectedComponent = connect(...connectOptions)(OriginalComponent, this.context.storeName);
+
+    return <ConnectedComponent {...this.props}/>
+  }
+}
+
+export { griddleConnect as connect }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { createStore, combineReducers, bindActionCreators } from 'redux';
 import Immutable from 'immutable';
-import { createProvider, connect } from 'react-redux-custom-store';
+import { createProvider } from 'react-redux';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { createStore, combineReducers, bindActionCreators } from 'redux';
 import Immutable from 'immutable';
-import { connect, Provider } from 'react-redux';
+import { createProvider, connect } from 'react-redux-custom-store';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
@@ -60,12 +60,25 @@ class Griddle extends Component {
     settingsComponentObjects: PropTypes.object,
     events: PropTypes.object,
     selectors: PropTypes.object,
+    storeName: PropTypes.string,
   }
 
   constructor(props) {
     super(props);
 
-    const { plugins=[], data, children:rowPropertiesComponent, events={}, sortProperties={}, styleConfig={}, pageProperties:importedPageProperties, components:userComponents, renderProperties:userRenderProperties={}, settingsComponentObjects:userSettingsComponentObjects } = props;
+    const {
+      plugins=[],
+      data,
+      children:rowPropertiesComponent,
+      events={},
+      sortProperties={},
+      styleConfig={},
+      pageProperties:importedPageProperties,
+      components:userComponents,
+      renderProperties:userRenderProperties={},
+      settingsComponentObjects:userSettingsComponentObjects,
+      storeName = 'store',
+    } = props;
 
     const rowProperties = getRowProperties(rowPropertiesComponent);
     const columnProperties = getColumnProperties(rowPropertiesComponent);
@@ -116,6 +129,8 @@ class Griddle extends Component {
       reducers,
       initialState
     );
+
+    this.provider = createProvider(storeName);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -124,20 +139,25 @@ class Griddle extends Component {
     this.store.dispatch(actions.updateState({ data, pageProperties, sortProperties }));
   }
 
+  getStoreName = () => {
+    return this.props.storeName || 'store';
+  }
+
   getChildContext() {
     return {
       components: this.components,
       settingsComponentObjects: this.settingsComponentObjects,
       events: this.events,
       selectors: this.selectors,
+      storeName: this.getStoreName(),
     };
   }
 
   render() {
     return (
-      <Provider store={this.store}>
+      <this.provider store={this.store}>
         <this.components.Layout />
-      </Provider>
+      </this.provider>
     )
 
   }

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ class Griddle extends Component {
     settingsComponentObjects: PropTypes.object,
     events: PropTypes.object,
     selectors: PropTypes.object,
-    storeName: PropTypes.string,
+    storeKey: PropTypes.string,
   }
 
   constructor(props) {
@@ -77,7 +77,7 @@ class Griddle extends Component {
       components:userComponents,
       renderProperties:userRenderProperties={},
       settingsComponentObjects:userSettingsComponentObjects,
-      storeName = 'store',
+      storeKey = 'store',
     } = props;
 
     const rowProperties = getRowProperties(rowPropertiesComponent);
@@ -130,7 +130,7 @@ class Griddle extends Component {
       initialState
     );
 
-    this.provider = createProvider(storeName);
+    this.provider = createProvider(storeKey);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -139,8 +139,8 @@ class Griddle extends Component {
     this.store.dispatch(actions.updateState({ data, pageProperties, sortProperties }));
   }
 
-  getStoreName = () => {
-    return this.props.storeName || 'store';
+  getStoreKey = () => {
+    return this.props.storeKey || 'store';
   }
 
   getChildContext() {
@@ -149,7 +149,7 @@ class Griddle extends Component {
       settingsComponentObjects: this.settingsComponentObjects,
       events: this.events,
       selectors: this.selectors,
-      storeName: this.getStoreName(),
+      storeKey: this.getStoreKey(),
     };
   }
 

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -399,6 +399,7 @@ export interface GriddleProps<T> {
     components?: GriddleComponents;
     renderProperties?: GriddleRenderProperties;
     settingsComponentObjects?: PropertyBag<SettingsComponentObject>;
+    storeName?: string;
 }
 
 declare class Griddle<T> extends React.Component<GriddleProps<T>, any> {

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -399,7 +399,7 @@ export interface GriddleProps<T> {
     components?: GriddleComponents;
     renderProperties?: GriddleRenderProperties;
     settingsComponentObjects?: PropertyBag<SettingsComponentObject>;
-    storeName?: string;
+    storeKey?: string;
 }
 
 declare class Griddle<T> extends React.Component<GriddleProps<T>, any> {

--- a/src/plugins/local/components/NextButtonContainer.js
+++ b/src/plugins/local/components/NextButtonContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from '../../../components/griddleConnect';
+import { connect } from '../../../utils/griddleConnect';
 import { createStructuredSelector } from 'reselect';
 
 import { hasNextSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/localSelectors';

--- a/src/plugins/local/components/NextButtonContainer.js
+++ b/src/plugins/local/components/NextButtonContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../../../components/griddleConnect';
 import { createStructuredSelector } from 'reselect';
 
 import { hasNextSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/localSelectors';

--- a/src/plugins/local/components/PageDropdownContainer.js
+++ b/src/plugins/local/components/PageDropdownContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from '../../../components/griddleConnect';
+import { connect } from '../../../utils/griddleConnect';
 import { createStructuredSelector } from 'reselect';
 
 import { currentPageSelector, maxPageSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/localSelectors';

--- a/src/plugins/local/components/PageDropdownContainer.js
+++ b/src/plugins/local/components/PageDropdownContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../../../components/griddleConnect';
 import { createStructuredSelector } from 'reselect';
 
 import { currentPageSelector, maxPageSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/localSelectors';

--- a/src/plugins/local/components/PreviousButtonContainer.js
+++ b/src/plugins/local/components/PreviousButtonContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../../../components/griddleConnect';
 import { createStructuredSelector } from 'reselect';
 
 import { hasPreviousSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/localSelectors';

--- a/src/plugins/local/components/PreviousButtonContainer.js
+++ b/src/plugins/local/components/PreviousButtonContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from '../../../components/griddleConnect';
+import { connect } from '../../../utils/griddleConnect';
 import { createStructuredSelector } from 'reselect';
 
 import { hasPreviousSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/localSelectors';

--- a/src/plugins/local/components/RowContainer.js
+++ b/src/plugins/local/components/RowContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from '../../../components/griddleConnect';
+import { connect } from '../../../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/plugins/local/components/RowContainer.js
+++ b/src/plugins/local/components/RowContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from '../../../components/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/plugins/local/components/TableBodyContainer.js
+++ b/src/plugins/local/components/TableBodyContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from '../../../components/griddleConnect';
+import { connect } from '../../../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/plugins/local/components/TableBodyContainer.js
+++ b/src/plugins/local/components/TableBodyContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from '../../../components/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/plugins/local/components/TableContainer.js
+++ b/src/plugins/local/components/TableContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from '../../../components/griddleConnect';
+import { connect } from '../../../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/plugins/local/components/TableContainer.js
+++ b/src/plugins/local/components/TableContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from '../../../components/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from '../../../components/griddleConnect';
+import { connect } from '../../../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from '../../../components/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/plugins/local/components/TableHeadingContainer.js
+++ b/src/plugins/local/components/TableHeadingContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from '../../../components/griddleConnect';
+import { connect } from '../../../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/plugins/local/components/TableHeadingContainer.js
+++ b/src/plugins/local/components/TableHeadingContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from '../../../components/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/plugins/position/components/SpacerRow.js
+++ b/src/plugins/position/components/SpacerRow.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from '../../../components/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/plugins/position/components/SpacerRow.js
+++ b/src/plugins/position/components/SpacerRow.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from '../../../components/griddleConnect';
+import { connect } from '../../../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/plugins/position/components/TableEnhancer.js
+++ b/src/plugins/position/components/TableEnhancer.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from '../../../components/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/plugins/position/components/TableEnhancer.js
+++ b/src/plugins/position/components/TableEnhancer.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from '../../../components/griddleConnect';
+import { connect } from '../../../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';

--- a/src/settingsComponentObjects/ColumnChooser.js
+++ b/src/settingsComponentObjects/ColumnChooser.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from '../components/griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import withHandlers from 'recompose/withHandlers';
 

--- a/src/settingsComponentObjects/ColumnChooser.js
+++ b/src/settingsComponentObjects/ColumnChooser.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../components/griddleConnect';
 import compose from 'recompose/compose';
 import withHandlers from 'recompose/withHandlers';
 

--- a/src/settingsComponentObjects/PageSizeSettings.js
+++ b/src/settingsComponentObjects/PageSizeSettings.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from '../components/griddleConnect';
+import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import withState from 'recompose/withState';
 import withHandlers from 'recompose/withHandlers';

--- a/src/settingsComponentObjects/PageSizeSettings.js
+++ b/src/settingsComponentObjects/PageSizeSettings.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../components/griddleConnect';
 import compose from 'recompose/compose';
 import withState from 'recompose/withState';
 import withHandlers from 'recompose/withHandlers';

--- a/src/utils/__tests__/griddleConnectTest.js
+++ b/src/utils/__tests__/griddleConnectTest.js
@@ -1,0 +1,26 @@
+import test from 'ava';
+
+import { mergeConnectParametersWithOptions } from '../griddleConnect';
+
+test('makes options the fourth parameter even if connectOptions contains only one parameter', assert => {
+  const mapStateToProps = (state, props) => {};
+  const connectParams = [mapStateToProps];
+
+  const output = mergeConnectParametersWithOptions(connectParams, { 'test': 'hi' });
+  assert.deepEqual(
+    output,
+    [mapStateToProps, undefined, undefined, { 'test': 'hi' }]
+  );
+});
+
+test('merges with existing options', assert => {
+  const mapStateToProps = (state, props) => {};
+  const action = () => { };
+  const connectParams = [mapStateToProps, { someAction: action }, undefined, { 'one': 'two'}];
+
+  const output = mergeConnectParametersWithOptions(connectParams, { 'test': 'hi' });
+  assert.deepEqual(
+    output,
+    [mapStateToProps, { someAction: action }, undefined, { 'test': 'hi', 'one': 'two' }]
+  );
+})

--- a/src/utils/griddleConnect.js
+++ b/src/utils/griddleConnect.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 
 /// This method appends options onto existing connect parameters
-const mergeConnectParametersWithOptions = (originalConnect, newOptions) => {
+export const mergeConnectParametersWithOptions = (originalConnect, newOptions) => {
   const [mapStateFromProps, mapDispatchFromProps, mergeProps, options] = originalConnect;
 
   return [

--- a/src/utils/griddleConnect.js
+++ b/src/utils/griddleConnect.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux-custom-store';
-import getContext from 'recompose/getContext';
-
 
 const griddleConnect = (...connectOptions) => OriginalComponent => class extends React.Component {
   static contextTypes = {
@@ -10,7 +8,6 @@ const griddleConnect = (...connectOptions) => OriginalComponent => class extends
   }
 
   render() {
-    console.log(this.context.storeName)
     const ConnectedComponent = connect(...connectOptions)(OriginalComponent, this.context.storeName);
 
     return <ConnectedComponent {...this.props}/>

--- a/src/utils/griddleConnect.js
+++ b/src/utils/griddleConnect.js
@@ -1,14 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux-custom-store';
+import { connect } from 'react-redux';
+
+
+/// This method appends options onto existing connect parameters
+const mergeConnectParametersWithOptions = (originalConnect, newOptions) => {
+  const [mapStateFromProps, mapDispatchFromProps, mergeProps, options] = originalConnect;
+
+  return [
+    mapStateFromProps,
+    mapDispatchFromProps,
+    mergeProps,
+    { ...options, ...newOptions }
+  ];
+}
 
 const griddleConnect = (...connectOptions) => OriginalComponent => class extends React.Component {
   static contextTypes = {
-    storeName: PropTypes.string,
+    storeKey: PropTypes.string,
   }
 
   render() {
-    const ConnectedComponent = connect(...connectOptions)(OriginalComponent, this.context.storeName);
+    const newOptions = mergeConnectParametersWithOptions(connectOptions, { storeKey: this.context.storeKey })
+    const ConnectedComponent = connect(...newOptions)(OriginalComponent);
 
     return <ConnectedComponent {...this.props}/>
   }

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -718,7 +718,7 @@ storiesOf('Griddle main', module)
     // basically the demo redux stuff
     const countSelector = (state) => state.count;
 
-    const CountComponent = (props) => console.log('PROPS', props) || (
+    const CountComponent = (props) => (
       <div>
         {props.count}
         <button type="button" onClick={props.increment}>
@@ -751,7 +751,6 @@ storiesOf('Griddle main', module)
 
     class Other extends React.Component {
       render() {
-        console.log('OTHER', this.props)
         return (
           <ConnectedComponent
             {...this.props}
@@ -784,7 +783,7 @@ storiesOf('Griddle main', module)
         <Provider store={testStore}>
           <div>
             <h2>This</h2>
-            <Griddle data={fakeData} plugins={[LocalPlugin]} storeName="griddleStore">
+            <Griddle data={fakeData} plugins={[LocalPlugin]} storeKey="griddleStore">
               <RowDefinition>
                 <ColumnDefinition id="name" />
                 <ColumnDefinition id="state" />

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -7,8 +7,7 @@ import getContext from 'recompose/getContext';
 import withContext from 'recompose/withContext';
 import withHandlers from 'recompose/withHandlers';
 import withState from 'recompose/withState';
-import { Provider } from 'react-redux';
-import { connect } from 'react-redux-custom-store';
+import { Provider, connect } from 'react-redux';
 import { createStore } from 'redux';
 import { createSelector } from 'reselect';
 import _ from 'lodash';
@@ -749,40 +748,10 @@ storiesOf('Griddle main', module)
       })
     )(CountComponent);
 
-    class Other extends React.Component {
-      render() {
-        return (
-          <ConnectedComponent
-            {...this.props}
-            store={testStore}
-          />
-        );
-      }
-    }
-
-    class ProvidedComponent extends React.Component { 
-      render() {
-
-        return (
-          <div>
-            <Other />
-            <Griddle data={fakeData} plugins={[LocalPlugin]}>
-              <RowDefinition>
-                <ColumnDefinition id="name" />
-                <ColumnDefinition id="state" />
-                <ColumnDefinition id="customCount" customComponent={Other}/>
-              </RowDefinition>
-            </Griddle>
-          </div>
-        )
-      }
-    }
-
     return (
       <div>
         <Provider store={testStore}>
           <div>
-            <h2>This</h2>
             <Griddle data={fakeData} plugins={[LocalPlugin]} storeKey="griddleStore">
               <RowDefinition>
                 <ColumnDefinition id="name" />
@@ -791,8 +760,8 @@ storiesOf('Griddle main', module)
               </RowDefinition>
             </Griddle>
 
-            <h2>Should look like this...</h2>
-            <ProvidedComponent />
+          Component outside of Griddle that's sharing state
+          <ConnectedComponent />
           </div>
         </Provider>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3258,9 +3258,13 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.0.0, hoist-non-react-statics@^1.0.3, hoist-non-react-statics@^1.2.0:
+hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.0.0, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+
+hoist-non-react-statics@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.2.2.tgz#c0eca5a7d5a28c5ada3107eb763b01da6bfa81fb"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3986,7 +3990,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -5032,6 +5036,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 prop-types@^15.5.8:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
@@ -5200,15 +5211,16 @@ react-redux-custom-store@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-redux-custom-store/-/react-redux-custom-store-1.0.0.tgz#dcbf177c73aca546533aff94c65c98d98ce9ba15"
 
-react-redux@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.2.tgz#3d9878f5f71c6fafcd45de1fbb162ea31f389814"
+react-redux@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.6.tgz#23ed3a4f986359d68b5212eaaa681e60d6574946"
   dependencies:
-    hoist-non-react-statics "^1.0.3"
+    hoist-non-react-statics "^2.2.1"
     invariant "^2.0.0"
     lodash "^4.2.0"
     lodash-es "^4.2.0"
     loose-envify "^1.1.0"
+    prop-types "^15.5.10"
 
 react-simple-di@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,9 +99,9 @@
     webpack-dev-middleware "^1.6.0"
     webpack-hot-middleware "^2.13.2"
 
-"@types/react@^15.0.17":
-  version "15.0.23"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.23.tgz#f3facbef5290610f54242f00308759d3a3c27346"
+"@types/react@^15.0.34":
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.6.1.tgz#497f7228762da4432e335957cb34fe9b40f150ae"
 
 abab@^1.0.3:
   version "1.0.3"
@@ -2907,19 +2907,7 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.8.tgz#02f1b6e0ea0d46c24e0b51a2d24df069563a5ad6"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
-fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -5208,6 +5196,10 @@ react-modal@^1.2.0, react-modal@^1.2.1:
     exenv "1.2.0"
     lodash.assign "^4.2.0"
 
+react-redux-custom-store@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-redux-custom-store/-/react-redux-custom-store-1.0.0.tgz#dcbf177c73aca546533aff94c65c98d98ce9ba15"
+
 react-redux@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.2.tgz#3d9878f5f71c6fafcd45de1fbb162ea31f389814"
@@ -6095,9 +6087,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.2.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
+typescript@^2.4.1:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
 
 ua-parser-js@^0.7.9:
   version "0.7.12"


### PR DESCRIPTION
## Griddle major version
1

## Changes proposed in this pull request
This adds a griddle specific connect and storeName prop that all of the container components in Griddle can use (it will be on the module as well when this PR is more finalized).

## Why these changes are made
The thinking here is that it would be nice to use Griddle inside of apps that also are using redux and not have store conflicts with custom components, etc.

## Are there tests?
story for now