### PR TITLE
onSort event argument

### DIFF
--- a/src/components/TableHeadingCellEnhancer.js
+++ b/src/components/TableHeadingCellEnhancer.js
@@ -11,7 +11,10 @@ const EnhancedHeadingCell = OriginalComponent => compose(
   }),
   mapProps(({ events: { onSort }, ...props }) => ({
     ...props,
-    onClick: combineHandlers([() => onSort && onSort({ id: props.columnId }), props.onClick]),
+    onClick: combineHandlers([
+      () => onSort && onSort(props.sortProperty || { id: props.columnId }),
+      props.onClick,
+    ]),
   }))
 )(props => <OriginalComponent {...props} />);
 

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -90,11 +90,11 @@ storiesOf('Griddle main', module)
 
     // don't do things this way - fine for example storybook
     const events = {
-      onFilter: () => console.log('onFilter'),
-      onSort: () => console.log('onSort'),
+      onFilter: filter => console.log('onFilter', filter),
+      onSort: sortProperties => console.log('onSort', sortProperties),
       onNext: () => console.log('onNext'),
       onPrevious: () => console.log('onPrevious'),
-      onGetPage: () => console.log('onGetPage')
+      onGetPage: pageNumber => console.log('onGetPage', pageNumber),
     }
 
     return (


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

Pass full `sortProperty` to `events.onSort`, if available.

Note that the initial call only includes `id`, not `sortAscending`. Easy enough to hard-code that to `true`, as in [`setSortProperties`](https://github.com/GriddleGriddle/Griddle/blob/1d7b763215c016fa73d700deec98d5edc56fcbe7/src/utils/sortUtils.js#L30), but it _may_ be useful to be able to identify if this was the initial sort?

## Why these changes are made

It is right and good, and also closes #716 (cc @jariwalabhavesh)

## Are there tests?

`/shrug`