### PR TITLE
Default sortMethod (plus: initialState from extra props)

### DIFF
--- a/src/components/NextButtonContainer.js
+++ b/src/components/NextButtonContainer.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { hasNextSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+import { textSelector, hasNextSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
 const enhance = OriginalComponent => connect((state, props) => ({
-  text: 'Next', // TODO: Get this from the store
+  text: textSelector(state, { key: 'next' }),
   hasNext: hasNextSelector(state, props),
   className: classNamesForComponentSelector(state, 'NextButton'),
   style: stylesForComponentSelector(state, 'NextButton'),

--- a/src/components/PreviousButtonContainer.js
+++ b/src/components/PreviousButtonContainer.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { hasPreviousSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+import { textSelector, hasPreviousSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
 const enhance = OriginalComponent => connect((state, props) => ({
-  text: 'Previous', // TODO: Get this from the store
+  text: textSelector(state, { key: 'previous' }),
   hasPrevious: hasPreviousSelector(state, props),
   className: classNamesForComponentSelector(state, 'PreviousButton'),
   style: stylesForComponentSelector(state, 'PreviousButton'),

--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,8 @@ class Griddle extends Component {
       {
         enableSettings: true,
         textProperties: {
+          next: 'Next',
+          previous: 'Previous',
           settingsToggle: 'Settings'
         },
       },

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,19 @@ class Griddle extends Component {
   constructor(props) {
     super(props);
 
-    const { plugins=[], data, children:rowPropertiesComponent, events={}, sortProperties={}, styleConfig={}, pageProperties:importedPageProperties, components:userComponents, renderProperties:userRenderProperties={}, settingsComponentObjects:userSettingsComponentObjects } = props;
+    const {
+      plugins=[],
+      data,
+      children:rowPropertiesComponent,
+      events={},
+      sortProperties={},
+      styleConfig={},
+      pageProperties:importedPageProperties,
+      components:userComponents,
+      renderProperties:userRenderProperties={},
+      settingsComponentObjects:userSettingsComponentObjects,
+      ...userInitialState
+    } = props;
 
     const rowProperties = getRowProperties(rowPropertiesComponent);
     const columnProperties = getColumnProperties(rowPropertiesComponent);
@@ -98,19 +110,23 @@ class Griddle extends Component {
     }, ...plugins.map(p => p.renderProperties), userRenderProperties);
 
     // TODO: Make this its own method
-    const initialState = plugins.reduce((combined, plugin) => {
-      return !!plugin.initialState ? { ...combined, ...plugin.initialState } : combined;
-    }, {
-      renderProperties,
-      data,
-      enableSettings: true,
-      pageProperties,
-      sortProperties,
-      textProperties: {
-        settingsToggle: 'Settings'
+    const initialState = _.merge(
+      {
+        enableSettings: true,
+        textProperties: {
+          settingsToggle: 'Settings'
+        },
       },
-      styleConfig: mergedStyleConfig,
-    });
+      ...plugins.map(p => p.initialState),
+      userInitialState,
+      {
+        data,
+        pageProperties,
+        renderProperties,
+        sortProperties,
+        styleConfig: mergedStyleConfig,
+      }
+    );
 
     this.store = createStore(
       reducers,

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -379,6 +379,7 @@ interface GriddleExtensibility {
 
 interface GriddleInitialState {
     enableSettings?: boolean;
+    sortMethod?: (data: any[], column: string, sortAscending?: boolean) => number;
     textProperties?: {
       settingsToggle?: string,
     }

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -59,6 +59,9 @@ export interface ColumnDefinitionProps {
     //Can this column be sorted
     sortable?: boolean,
 
+    //What sort method this column uses
+    sortMethod?: (data: any[], column: string, sortAscending?: boolean) => number;
+
     // TODO: Unused?
     //What sort type this column uses - magic string :shame:
     sortType?: string,
@@ -345,24 +348,10 @@ export interface GriddlePageProperties {
     recordCount?: number;
 }
 
-interface RowRenderProperties {
-    rowKey?: string;
-    childColumnName?: string;
-    cssClassName?: string | ((props: any) => string);
-    props?: {
-        children: components.ColumnDefinition[];
-    };
+interface RowRenderProperties extends components.RowDefinitionProps {
 }
 
-interface ColumnRenderProperties {
-    id: string;
-    title?: string;
-    isMetadata?: boolean;
-    order?: number;
-    sortMethod?: (data: any[], column: string, sortAscending?: boolean) => number;
-    visible?: boolean;
-    customComponent?: GriddleComponent<any>;
-    customHeadingComponent?: GriddleComponent<any>;
+interface ColumnRenderProperties extends components.ColumnDefinitionProps {
 }
 
 export interface GriddleRenderProperties {

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -381,6 +381,8 @@ interface GriddleInitialState {
     enableSettings?: boolean;
     sortMethod?: (data: any[], column: string, sortAscending?: boolean) => number;
     textProperties?: {
+      next?: string,
+      previous?: string,
       settingsToggle?: string,
     }
 

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -367,27 +367,34 @@ interface SettingsComponentObject {
     component?: GriddleComponent<any>;
 }
 
-export interface GriddlePlugin {
+interface GriddleExtensibility {
     components?: GriddleComponents,
     events?: GriddleEvents;
-    renderProperties?: GriddleRenderProperties;
-    initialState?: PropertyBag<any>,
     reducer?: PropertyBag<Reducer>,
+    renderProperties?: GriddleRenderProperties;
     selectors?: PropertyBag<Selector>,
     settingsComponentObjects?: PropertyBag<SettingsComponentObject>,
     styleConfig?: GriddleStyleConfig,
 }
 
-export interface GriddleProps<T> {
+interface GriddleInitialState {
+    enableSettings?: boolean;
+    textProperties?: {
+      settingsToggle?: string,
+    }
+
+    [x: string]: any;
+}
+
+export interface GriddlePlugin extends GriddleExtensibility {
+    initialState?: GriddleInitialState;
+}
+
+export interface GriddleProps<T> extends GriddlePlugin, GriddleInitialState {
     plugins?: GriddlePlugin[];
     data?: T[];
-    events?: GriddleEvents;
     sortProperties?: GriddleSortKey[];
-    styleConfig?: GriddleStyleConfig;
     pageProperties?: GriddlePageProperties;
-    components?: GriddleComponents;
-    renderProperties?: GriddleRenderProperties;
-    settingsComponentObjects?: PropertyBag<SettingsComponentObject>;
 }
 
 declare class Griddle<T> extends React.Component<GriddleProps<T>, any> {

--- a/src/plugins/local/components/NextButtonContainer.js
+++ b/src/plugins/local/components/NextButtonContainer.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { createStructuredSelector } from 'reselect';
 
-import { hasNextSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/localSelectors';
+import { textSelector, hasNextSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/localSelectors';
 import { getNext } from '../../../actions';
 
 const enhance = OriginalComponent => connect(state => ({
+  text: textSelector(state, { key: 'next' }),
   hasNext: hasNextSelector(state),
   className: classNamesForComponentSelector(state, 'NextButton'),
   style: stylesForComponentSelector(state, 'NextButton'),
@@ -13,6 +13,6 @@ const enhance = OriginalComponent => connect(state => ({
   {
     getNext
   }
-)(props => <OriginalComponent {...props} onClick={props.getNext} text="Next" />);
+)(props => <OriginalComponent {...props} onClick={props.getNext} />);
 
 export default enhance;

--- a/src/plugins/local/components/PreviousButtonContainer.js
+++ b/src/plugins/local/components/PreviousButtonContainer.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { createStructuredSelector } from 'reselect';
 
-import { hasPreviousSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/localSelectors';
+import { textSelector, hasPreviousSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/localSelectors';
 import { getPrevious } from '../../../actions';
 
 const enhance = OriginalComponent => connect(state => ({
+  text: textSelector(state, { key: 'previous' }),
   hasPrevious: hasPreviousSelector(state),
   className: classNamesForComponentSelector(state, 'PreviousButton'),
   style: stylesForComponentSelector(state, 'PreviousButton'),
@@ -13,6 +13,6 @@ const enhance = OriginalComponent => connect(state => ({
   {
     getPrevious
   }
-)(props => <OriginalComponent {...props} onClick={props.getPrevious} text="Previous" />);
+)(props => <OriginalComponent {...props} onClick={props.getPrevious} />);
 
 export default enhance;

--- a/src/plugins/local/selectors/localSelectors.js
+++ b/src/plugins/local/selectors/localSelectors.js
@@ -27,6 +27,8 @@ export const filterSelector = state => (state.get('filter') || '');
 
 export const sortPropertiesSelector = state => (state.get('sortProperties'));
 
+export const sortMethodSelector = state => state.get('sortMethod');
+
 export const renderPropertiesSelector = state => (state.get('renderProperties'));
 
 export const metaDataColumnsSelector = dataSelectors.metaDataColumnsSelector;
@@ -105,13 +107,14 @@ export const sortedDataSelector = createSelector(
   filteredDataSelector,
   sortPropertiesSelector,
   renderPropertiesSelector,
-  (filteredData, sortProperties, renderProperties) => {
+  sortMethodSelector,
+  (filteredData, sortProperties, renderProperties, sortMethod = defaultSort) => {
     if (!sortProperties) { return filteredData; }
 
     return sortProperties.reverse().reduce((data, sortColumnOptions) => {
       const columnProperties = renderProperties && renderProperties.get('columnProperties').get(sortColumnOptions.get('id'));
 
-      const sortFunction = (columnProperties && columnProperties.get('sortMethod')) || defaultSort;
+      const sortFunction = (columnProperties && columnProperties.get('sortMethod')) || sortMethod;
 
       return sortFunction(data, sortColumnOptions.get('id'), sortColumnOptions.get('sortAscending'));
     }, filteredData);

--- a/src/plugins/local/selectors/localSelectors.js
+++ b/src/plugins/local/selectors/localSelectors.js
@@ -193,3 +193,4 @@ export const classNamesForComponentSelector = dataSelectors.classNamesForCompone
 
 export const rowPropertiesSelector = dataSelectors.rowPropertiesSelector;
 export const cellPropertiesSelector = dataSelectors.cellPropertiesSelector;
+export const textSelector = dataSelectors.textSelector;

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1214,6 +1214,20 @@ storiesOf('Settings', module)
       <Settings settingsComponents={components} />
     );
   })
+  .add('disable settings', () => {
+    return (
+      <Griddle data={fakeData} plugins={[LocalPlugin]}
+        enableSettings={false}
+        />
+    );
+  })
+  .add('change settings toggle button text', () => {
+    return (
+      <Griddle data={fakeData} plugins={[LocalPlugin]}
+        textProperties={{ settingsToggle: 'Toggle!' }}
+        />
+    );
+  })
   .add('remove built-in settings', () => {
     const plugin = {
       components: {

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1381,6 +1381,12 @@ storiesOf('Settings', module)
           </div>
         ),
       },
+      initialState: {
+        textProperties: {
+          next: '▶',
+          previous: '◀',
+        },
+      },
     };
 
     return (

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -164,6 +164,19 @@ storiesOf('Griddle main', module)
     )
   })
 
+  .add('with custom default sort', () => {
+    return (
+      <div>
+      <small>Sorts all columns by second character</small>
+      <Griddle data={fakeData} plugins={[LocalPlugin]} sortMethod={sortBySecondCharacter}>
+        <RowDefinition>
+          <ColumnDefinition id="name" order={2} />
+          <ColumnDefinition id="state" order={1} />
+        </RowDefinition>
+      </Griddle>
+      </div>
+    );
+  })
   .add('with custom sort on name', () => {
     return (
       <div>


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

- Type cleanup for `RowRenderProperties` and `ColumnRenderProperties`, which currently the same as `RowDefinitionProps` and `ColumnDefinitionProps`.
- Rearranges how `initialState` is initialized to accept/override `initialState` from extra `Griddle` props. Everything still seems to work as expected, but please double-check this.
   * As a bonus, this allows setting `enableSettings` and `textProperties` without a plugin, as demonstrated with new stories.
- Default `sortMethod` from state is used, if it exists.
- Addressed TODO to get Next/Previous label from `textProperties`

## Why these changes are made

`<Griddle sortMethod={...}>` now works as a high-level hook to override all columns' sort behavior. It does not change default behavior (cc #466).

## Are there tests?

Stories!