### PR TITLE
Add connect to utils out

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,6 +3,7 @@ import * as compositionUtils from './compositionUtils';
 import * as dataUtils from './dataUtils';
 import * as rowUtils from './rowUtils';
 import * as sortUtils from './sortUtils';
+import { connect } from './griddleConnect';
 
 export default {
   columnUtils,
@@ -10,4 +11,5 @@ export default {
   dataUtils,
   rowUtils,
   sortUtils,
+  connect,
 };


### PR DESCRIPTION
## Griddle major version
1

## Changes proposed in this pull request
Add the Griddle connect to something that can be used outside of Griddle.

## Why these changes are made
When making custom components, it's useful to still be able to easily connect to Griddle's store.

## Are there tests?
Not really but the previous PR utilizes connect directly and I am running one of my projects against a local copy of Griddle with this change (using Griddle's connect)