### PR TITLE
Pass down TableBody style and className

### DIFF
--- a/src/components/TableBodyContainer.js
+++ b/src/components/TableBodyContainer.js
@@ -24,10 +24,12 @@ const ComposedTableBodyContainer = OriginalComponent => compose(
       ...otherProps,
     };
   }),
-)(({Row, visibleRowIds }) => (
+)(({Row, visibleRowIds, style, className}) => (
   <OriginalComponent
     rowIds={visibleRowIds}
     Row={Row}
+    style={style}
+    className={className}
   />
 ));
 


### PR DESCRIPTION
## Griddle major version
1.5.0

## Changes proposed in this pull request
className and style are fetched from the store but never passed down to the original component.

## Why these changes are made
If a user wants to keep the original TableBody container but wants to override the style or className.

## Are there tests?
No