### PR TITLE
Add Storybook to build + fix connect type definition

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,6 +10,10 @@ const include = path.resolve(__dirname, '../');
 // to "React Create App". This only has babel loader to load JavaScript.
 
 module.exports = {
+  entry: './stories/index.tsx',
+  output: {
+    filename: include + '/dist/examples/storybook.js'
+  },
   plugins: [
     // your custom plugins
   ],

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,3 +1,4 @@
+const failPlugin = require('webpack-fail-plugin');
 const path = require("path");
 const include = path.resolve(__dirname, '../');
 
@@ -15,7 +16,7 @@ module.exports = {
     filename: include + '/dist/examples/storybook.js'
   },
   plugins: [
-    // your custom plugins
+    failPlugin
   ],
   resolve: {
     // Add `.ts` and `.tsx` as a resolvable extension.

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ install:
   - 'npm install'
 script:
   - npm run build
+  - npm run build-examples
   - npm test

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "ts-loader": "^2.0.2",
     "typescript": "^2.4.1",
     "webpack": "^1.14.0",
-    "webpack-dev-server": "^1.16.2"
+    "webpack-dev-server": "^1.16.2",
+    "webpack-fail-plugin": "^1.0.6"
   },
   "dependencies": {
     "immutable": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build-storybook": "build-storybook",
     "build": "npm run clean-dist && npm run build-modules && npm run build-umd && npm run build-ts",
     "clean-dist": "rimraf dist",
+    "build-examples": "webpack --config .storybook/webpack.config.js",
     "build-ts": "cp src/module.d.ts dist/module/",
     "build-umd": "webpack --config webpack.config.js",
     "build-modules": "cross-env BABEL_ENV=build babel src --out-dir dist/module ",

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -419,15 +419,7 @@ export namespace utils {
     const dataUtils: PropertyBag<Function>;
     const rowUtils: PropertyBag<Function>;
 
-    // TODO: Not a fan of this but was trying to avoid 
-    // wholesale copying the 11 or so types out of definitely-typed's connect
-    // not immediately seeing how to say for this thing, just reference their types
-    function connect(
-        mapStateToProps?: ReactRedux.MapStateToPropsParam<any, any>,
-        mapDispatchToProps?: ReactRedux.MapDispatchToPropsParam<any, any>,
-        mergeProps?: ReactRedux.MergeProps<any, any, any, any>,
-        options?: ReactRedux.Options
-    ) : ReactRedux.InferableComponentEnhancerWithProps<any, any>;
+    export const connect : typeof ReactRedux.connect;
 
     interface SortProperties{
       setSortColumn(sortProperties: ((key : GriddleSortKey) => void)) : void;

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactRedux from 'react-redux';
+import { connect as originalConnect } from 'react-redux';
 import { ActionCreator } from 'redux';
 
 interface PropertyBag<T> {
@@ -420,7 +420,7 @@ export namespace utils {
     const dataUtils: PropertyBag<Function>;
     const rowUtils: PropertyBag<Function>;
 
-    export const connect : typeof ReactRedux.connect;
+    const connect : typeof originalConnect;
 
     interface SortProperties{
       setSortColumn(sortProperties: ((key : GriddleSortKey) => void)) : void;

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as ReactRedux from 'react-redux';
+import { ActionCreator } from 'redux';
 
 interface PropertyBag<T> {
     [propName: string]: T;
@@ -293,7 +294,7 @@ export interface GriddleComponents {
     PreviousButtonContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
 }
 
-export interface GriddleActions extends PropertyBag<Function> {
+export interface GriddleActions extends PropertyBag<ActionCreator<any>> {
     onSort?: (sortProperties: any) => void;
     onNext?: () => void;
     onPrevious?: () => void;

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -7,12 +7,13 @@ import getContext from 'recompose/getContext';
 import withContext from 'recompose/withContext';
 import withHandlers from 'recompose/withHandlers';
 import withState from 'recompose/withState';
-import { Provider, connect } from 'react-redux';
+import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import { createSelector } from 'reselect';
 import _ from 'lodash';
 
 import GenericGriddle, { actions, components, selectors, plugins, utils, ColumnDefinition, RowDefinition } from '../src/module';
+const { connect } = utils;
 const { Cell, Row, Table, TableContainer, TableBody, TableHeading, TableHeadingCell } = components;
 const { SettingsWrapper, SettingsToggle, Settings } = components;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 var LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 var webpack = require('webpack');
+const failPlugin = require('webpack-fail-plugin');
 
 module.exports = {
   devtool: 'source-map',
@@ -29,6 +30,7 @@ module.exports = {
     ]
   },
   plugins: [
+    failPlugin,
     new LodashModuleReplacementPlugin,
     new webpack.optimize.OccurrenceOrderPlugin,
     new webpack.optimize.UglifyJsPlugin


### PR DESCRIPTION
## Griddle major version

1.8

## Changes proposed in this pull request

* [x] Make build fail if TypeScript Storybook won't build.
    * Not sure if there's really any value to targeting `dist/examples/storybook.js` rather than throwing the output away.
    * It seems like `build-storybook` should have been sufficient, but it doesn't recognize JSX. So we're going with a straight webpack for now.
* [ ] Fix type definition for new `connect` - I didn't have a chance to test #722, but it's not happy

## Why these changes are made

1. The build should break if types are broken.
2. The types should not be broken.

## Are there tests?

Kind of?