### PR TITLE
Add redux middleware to Griddle props to be passed to the store upon …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { createStore, combineReducers, bindActionCreators } from 'redux';
+import { createStore, combineReducers, bindActionCreators, applyMiddleware } from 'redux';
 import Immutable from 'immutable';
 import { createProvider } from 'react-redux';
 import React, { Component } from 'react';
@@ -78,6 +78,7 @@ class Griddle extends Component {
       renderProperties:userRenderProperties={},
       settingsComponentObjects:userSettingsComponentObjects,
       storeKey = 'store',
+      reduxMiddleware = [],
       ...userInitialState
     } = props;
 
@@ -134,7 +135,8 @@ class Griddle extends Component {
 
     this.store = createStore(
       reducers,
-      initialState
+      initialState,
+      applyMiddleware(...reduxMiddleware)
     );
 
     this.provider = createProvider(storeKey);

--- a/src/index.js
+++ b/src/index.js
@@ -136,7 +136,7 @@ class Griddle extends Component {
     this.store = createStore(
       reducers,
       initialState,
-      applyMiddleware(...reduxMiddleware)
+      applyMiddleware(..._.compact(plugins.map(p => p.reduxMiddleware)), ...reduxMiddleware) 
     );
 
     this.provider = createProvider(storeKey);

--- a/src/index.js
+++ b/src/index.js
@@ -136,7 +136,7 @@ class Griddle extends Component {
     this.store = createStore(
       reducers,
       initialState,
-      applyMiddleware(..._.compact(plugins.map(p => p.reduxMiddleware)), ...reduxMiddleware) 
+      applyMiddleware(..._.compact(_.flatten(plugins.map(p => p.reduxMiddleware))), ...reduxMiddleware) 
     );
 
     this.provider = createProvider(storeKey);

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -392,11 +392,11 @@ interface GriddleInitialState {
 
 export interface GriddlePlugin extends GriddleExtensibility {
     initialState?: GriddleInitialState;
+    reduxMiddleware?: ReactRedux.Middleware[];
 }
 
 export interface GriddleProps<T> extends GriddlePlugin, GriddleInitialState {
     plugins?: GriddlePlugin[];
-    reduxMiddleware?: ReactRedux.Middleware[];
     data?: T[];
     sortProperties?: GriddleSortKey[];
     pageProperties?: GriddlePageProperties;

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -396,6 +396,7 @@ export interface GriddlePlugin extends GriddleExtensibility {
 
 export interface GriddleProps<T> extends GriddlePlugin, GriddleInitialState {
     plugins?: GriddlePlugin[];
+    reduxMiddleware?: ReactRedux.Middleware[];
     data?: T[];
     sortProperties?: GriddleSortKey[];
     pageProperties?: GriddlePageProperties;


### PR DESCRIPTION
…creation.

## Griddle major version
1.8.0

## Changes proposed in this pull request
Adding a prop to top level Griddle component which passes in user supplied redux middleware which is then applied during redux store creation using applyMiddleware

## Why these changes are made
Running into cases where it would be really great to be able to apply redux middleware and there isn't an easy way to do that right now

## Are there tests?
No