### PR TITLE
Making typescript definitions comply with strict checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "start": "start-storybook -p 6006",
     "test": "ava",
+    "check-ts": "tsc --strict src/module.d.ts",
     "watch-test": "ava --watch",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -293,7 +293,7 @@ export interface GriddleComponents {
     PreviousButtonContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
 }
 
-export interface GriddleActions extends PropertyBag<Function> {
+export interface GriddleActions extends PropertyBag<Function | undefined> {
     onSort?: (sortProperties: any) => void;
     onNext?: () => void;
     onPrevious?: () => void;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,9 @@
     ],
     "allowJs": true,
     "jsx": "preserve",
-    "noImplicitAny": false,
-    "noImplicitThis": false,
-    "strictNullChecks": false,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
     "types": [],
     "noEmit": true,
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
## Griddle major version
1.8.0

## Changes proposed in this pull request
Type GriddleActions in alignment with strict checking requirements and change typescript config to be strict by default.

## Why these changes are made
Downstream projects should be able to use the library without having to comply to the libraries policies regarding the strictness of the typescript compiler. The definitions provided as of 1.8.0 don't pass checks for strictNullChecks as the optional keys in GriddleActions are all implicitly typed as 'X | undefined' but that isn't explicit in the objects type. If Griddle's typings are as strict as possible then it will compile in any downstream projects regardless of how lenient or strict they decide to set themselves up. Given it's a 1 line fix and no other strictness violations were found I've also turned on the other strict compiler options to catch this in the future.

## Are there tests?
I've added a check-ts task to the package file that checks the file. There's probably a way to pack this into a js test file that I'm not aware of.