### PR TITLE
Update ColumnChooser

### DIFF
--- a/src/settingsComponentObjects/ColumnChooser.js
+++ b/src/settingsComponentObjects/ColumnChooser.js
@@ -57,6 +57,7 @@ return (
           <input
             type="checkbox"
             name={hiddenColumns[v].id}
+            id={hiddenColumns[v].id}
             onChange={onToggle}
             defaultChecked={false}
           />


### PR DESCRIPTION
## Griddle major version

v1

## Changes proposed in this pull request

Add `id` attribute to the `input` 

## Why these changes are made

To allow for clicking of label to toggle the checkbox

## Are there tests?

No, it is a single HTML attribute