### PR TITLE
Fix Middleware in type definition

### DIFF
--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { connect as originalConnect } from 'react-redux';
-import { ActionCreator } from 'redux';
+import { ActionCreator, Middleware } from 'redux';
 
 interface PropertyBag<T> {
     [propName: string]: T;
@@ -393,7 +393,7 @@ interface GriddleInitialState {
 
 export interface GriddlePlugin extends GriddleExtensibility {
     initialState?: GriddleInitialState;
-    reduxMiddleware?: ReactRedux.Middleware[];
+    reduxMiddleware?: Middleware[];
 }
 
 export interface GriddleProps<T> extends GriddlePlugin, GriddleInitialState {


### PR DESCRIPTION
## Griddle major version

1.8.0

## Changes proposed in this pull request

Fixes type definition bug in #726, now (fortunately) checked by #727.

## Why these changes are made

We like green builds and working type definitions.

## Are there tests?

Types!