### PR TITLE
Store listeners proposal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,24 @@ class Griddle extends Component {
     );
 
     this.provider = createProvider(storeKey);
+
+    this.listeners = plugins.reduce((combined, plugin) => ({...combined, ...plugin.listeners}), {});
+
+    const observeStore = (store, onChange, otherArgs) => {
+      let oldState;
+    
+      const handleChange = () => {
+        const newState = store.getState();
+        onChange({oldState, newState, ...otherArgs});
+          oldState = newState;
+      }
+    
+      return store.subscribe(handleChange);
+    }
+
+    _.forIn(this.listeners, (value, key) => {
+      observeStore(this.store, value, {events: this.events, selectors: this.selectors});
+    });
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -363,6 +363,7 @@ export interface GriddleRenderProperties {
 
 type Reducer = (state: any, action?: any) => void;
 type Selector = (state: any, props?: any) => any;
+type Listener = (prevState: any, nextState: any, otherArgs?: any) => any;
 
 interface SettingsComponentObject {
     order: number;
@@ -377,6 +378,7 @@ interface GriddleExtensibility {
     selectors?: PropertyBag<Selector>,
     settingsComponentObjects?: PropertyBag<SettingsComponentObject>,
     styleConfig?: GriddleStyleConfig,
+    listeners?: PropertyBag<Listener>,
 }
 
 interface GriddleInitialState {

--- a/src/utils/listenerUtils.js
+++ b/src/utils/listenerUtils.js
@@ -1,0 +1,46 @@
+export const StoreListener = class StoreListener {
+    constructor(store) {
+        this.store = store;
+        this.unsubscribers = {};
+    }
+
+    removeListener = (name) => {
+        if (this.unsubscribers.hasOwnProperty(name)) {
+            this.unsubscribers[name]();
+            delete this.unsubscribers[name];
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    // Adds a listener to the store.
+    // Will attempt to remove an existing listener if the name
+    // matches that of an existing listener.
+    // If no name is provided this is an anonymous lister, it
+    // is not registered in the list of unsubscribe functions,
+    // returns the unsubscribe function so it can still be handled
+    // manually if desired.
+    addListener = (listener, name, otherArgs) => {
+        // attempt to unsubscribe an existing listener if the new 
+        // listener name matches
+        // if no name is provided, do nothing
+        name && this.removeListener(name);
+        const unsubscribe = (() => {
+            let oldState;
+            return this.store.subscribe(() => {
+                const newState = this.store.getState();
+                listener(oldState, newState, {...otherArgs});
+                oldState = newState;
+            });
+        })();
+        // if name was provided, add the unsubscribe
+        // otherwise this is an "anonymous" listener
+        name && (this.unsubscribers[name] = unsubscribe);
+        return unsubscribe;
+    }
+
+    hasListener = (name) => {
+        return this.unsubscribers.hasOwnProperty(name);
+    }
+};

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -781,6 +781,21 @@ storiesOf('Griddle main', module)
       </div>
     );
   })
+
+  .add('with custom store listener (check the console!)', () => {
+    const paginationListener = (prevState, nextState) => {
+      const page = nextState.getIn(['pageProperties', 'currentPage']);
+      page % 2 ? console.log("pageProperties->currentPage is odd!") : console.log("pageProperties->currentPage is even!");
+    };
+    return (
+      <Griddle data={fakeData} plugins={[LocalPlugin]} listeners={{anExternalListener: paginationListener}}>
+        <RowDefinition>
+          <ColumnDefinition id="name" order={2} customHeadingComponent={GreenLeftSortIconComponent} width={300} />
+          <ColumnDefinition id="state" order={1} width={400} />
+        </RowDefinition>
+      </Griddle>
+    );
+  })
 storiesOf('Plugins', module)
   .add('styleConfig', () => {
     const stylePlugin = {


### PR DESCRIPTION
## Griddle major version
1.8.0

## Changes proposed in this pull request
Adding the ability to have listeners on the store independent of the "visual" part of Griddle. I am envisioning these to be used for running callbacks from the outside world, for example those provided on the "events" object.

## Why these changes are made
Instead of having an event callback passed down to the component that would trigger it, for example on the pagination buttons, a listener function can subscribe to the store and trigger the "onNext" event when the pagination state has changed in the store. This would make for a better separation of concerns between how the state is changed and what has changed. 

I am running into use cases where I want to be listening on the change of a particular plugin's store subset to run an externally provided call-back but would have to hook into UI events in several places to make this work. It would be great if there was just a single place to keep this sort of behaviour.

And of course it's not required to make all events use this design, this is just supplementary.

This is also not a ready-to-merge PR, I have a question: right now I am only getting listeners from plugins, do we want to allow listeners to be passed in as props on <Griddle /> as well? And in that case, will have to update typescript stuff too.
 
## Are there tests?
No