### PR TITLE
Change all containers in base components to use context for selectors

### DIFF
--- a/src/components/CellContainer.js
+++ b/src/components/CellContainer.js
@@ -5,13 +5,13 @@ import getContext from 'recompose/getContext';
 import mapProps from 'recompose/mapProps';
 import compose from 'recompose/compose';
 
-import {
-  customComponentSelector,
-  cellValueSelector,
-  cellPropertiesSelector,
-  classNamesForComponentSelector,
-  stylesForComponentSelector
-} from '../selectors/dataSelectors';
+//import {
+//  customComponentSelector,
+//  cellValueSelector,
+//  cellPropertiesSelector,
+//  classNamesForComponentSelector,
+//  stylesForComponentSelector
+//} from '../selectors/dataSelectors';
 import { valueOrResult } from '../utils/valueUtils';
 
 function hasWidthOrStyles(cellProperties) {
@@ -41,11 +41,11 @@ const ComposedCellContainer = OriginalComponent => compose(
   }),
   connect((state, props) => {
     return {
-      value: cellValueSelector(state, props),
-      customComponent: customComponentSelector(state, props),
-      cellProperties: cellPropertiesSelector(state, props),
-      className: classNamesForComponentSelector(state, 'Cell'),
-      style: stylesForComponentSelector(state, 'Cell'),
+      value: props.selectors.cellValueSelector(state, props),
+      customComponent: props.selectors.customComponentSelector(state, props),
+      cellProperties: props.selectors.cellPropertiesSelector(state, props),
+      className: props.selectors.classNamesForComponentSelector(state, 'Cell'),
+      style: props.selectors.stylesForComponentSelector(state, 'Cell'),
     };
   }),
   mapProps(props => {

--- a/src/components/FilterContainer.js
+++ b/src/components/FilterContainer.js
@@ -1,13 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import compose from 'recompose/compose';
+import getContext from 'recompose/getContext';
 import { connect } from '../utils/griddleConnect';
 
-import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+//import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 import { setFilter } from '../actions';
 
-const EnhancedFilter = OriginalComponent => connect((state, props) => ({
-  className: classNamesForComponentSelector(state, 'Filter'),
-  style: stylesForComponentSelector(state, 'Filter'),
-}), { setFilter })(props => <OriginalComponent {...props} />);
+const EnhancedFilter = OriginalComponent => compose(
+  getContext({
+    selectors: PropTypes.object
+  }),
+  connect(
+    (state, props) => ({
+      className: props.selectors.classNamesForComponentSelector(state, 'Filter'),
+      style: props.selectors.stylesForComponentSelector(state, 'Filter'),
+    }), 
+    { setFilter }
+  )
+)(props => <OriginalComponent {...props} />);
 
 export default EnhancedFilter;

--- a/src/components/LayoutContainer.js
+++ b/src/components/LayoutContainer.js
@@ -5,16 +5,17 @@ import getContext from 'recompose/getContext';
 import mapProps from 'recompose/mapProps';
 import compose from 'recompose/compose';
 
-import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+//import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
 const EnhancedLayout = OriginalComponent => compose(
   getContext({
     components: PropTypes.object,
+    selectors: PropTypes.object
   }),
   connect(
     (state, props) => ({
-      className: classNamesForComponentSelector(state, 'Layout'),
-      style: stylesForComponentSelector(state, 'Layout'),
+      className: props.selectors.classNamesForComponentSelector(state, 'Layout'),
+      style: props.selectors.stylesForComponentSelector(state, 'Layout'),
     })
   ),
   mapProps( props => ({

--- a/src/components/NextButtonContainer.js
+++ b/src/components/NextButtonContainer.js
@@ -1,13 +1,21 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import compose from 'recompose/compose';
+import getContext from 'recompose/getContext';
 import { connect } from '../utils/griddleConnect';
 
-import { textSelector, hasNextSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+//import { textSelector, hasNextSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
-const enhance = OriginalComponent => connect((state, props) => ({
-  text: textSelector(state, { key: 'next' }),
-  hasNext: hasNextSelector(state, props),
-  className: classNamesForComponentSelector(state, 'NextButton'),
-  style: stylesForComponentSelector(state, 'NextButton'),
-}))((props) => <OriginalComponent {...props} />);
+const enhance = OriginalComponent => compose(
+  getContext({
+    selectors: PropTypes.object
+  }),
+  connect((state, props) => ({
+    text: props.selectors.textSelector(state, { key: 'next' }),
+    hasNext: props.selectors.hasNextSelector(state, props),
+    className: props.selectors.classNamesForComponentSelector(state, 'NextButton'),
+    style: props.selectors.stylesForComponentSelector(state, 'NextButton'),
+  }))
+)((props) => <OriginalComponent {...props} />);
 
 export default enhance;

--- a/src/components/NoResultsContainer.js
+++ b/src/components/NoResultsContainer.js
@@ -5,16 +5,17 @@ import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 
-import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+//import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
 const NoResultsContainer = OriginalComponent => compose(
   getContext({
     components: PropTypes.object,
+    selectors: PropTypes.object
   }),
   connect(
-    state => ({
-      className: classNamesForComponentSelector(state, 'NoResults'),
-      style: stylesForComponentSelector(state, 'NoResults'),
+    (state, props) => ({
+      className: props.selectors.classNamesForComponentSelector(state, 'NoResults'),
+      style: props.selectors.stylesForComponentSelector(state, 'NoResults'),
     })
   ),
   mapProps((props) => {

--- a/src/components/PageDropdownContainer.js
+++ b/src/components/PageDropdownContainer.js
@@ -4,18 +4,21 @@ import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
-import { currentPageSelector, maxPageSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+//import { currentPageSelector, maxPageSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
 const enhance = OriginalComponent => compose(
   getContext({
     events: PropTypes.object,
+    selectors: PropTypes.object
   }),
-  connect((state, props) => ({
-    maxPages: maxPageSelector(state, props),
-    currentPage: currentPageSelector(state, props),
-    className: classNamesForComponentSelector(state, 'PageDropdown'),
-    style: stylesForComponentSelector(state, 'PageDropdown'),
-  })),
+  connect(
+    (state, props) => ({
+      maxPages: props.selectors.maxPageSelector(state, props),
+      currentPage: props.selectors.currentPageSelector(state, props),
+      className: props.selectors.classNamesForComponentSelector(state, 'PageDropdown'),
+      style: props.selectors.stylesForComponentSelector(state, 'PageDropdown'),
+    })
+  ),
   mapProps(({ events: { onGetPage: setPage }, ...props }) => ({
     ...props,
     setPage,

--- a/src/components/PaginationContainer.js
+++ b/src/components/PaginationContainer.js
@@ -5,16 +5,17 @@ import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 
-import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+//import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
 const EnhancedPaginationContainer = OriginalComponent => compose(
   getContext({
     components: PropTypes.object,
+    selectors: PropTypes.object
   }),
   connect(
     (state, props) => ({
-      className: classNamesForComponentSelector(state, 'Pagination'),
-      style: stylesForComponentSelector(state, 'Pagination'),
+      className: props.selectors.classNamesForComponentSelector(state, 'Pagination'),
+      style: props.selectors.stylesForComponentSelector(state, 'Pagination'),
     })
   ),
   mapProps((props) => {

--- a/src/components/PreviousButtonContainer.js
+++ b/src/components/PreviousButtonContainer.js
@@ -1,12 +1,22 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import compose from 'recompose/compose';
+import getContext from 'recompose/getContext';
 import { connect } from '../utils/griddleConnect';
-import { textSelector, hasPreviousSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+//import { textSelector, hasPreviousSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
-const enhance = OriginalComponent => connect((state, props) => ({
-  text: textSelector(state, { key: 'previous' }),
-  hasPrevious: hasPreviousSelector(state, props),
-  className: classNamesForComponentSelector(state, 'PreviousButton'),
-  style: stylesForComponentSelector(state, 'PreviousButton'),
-}))((props) => <OriginalComponent {...props} />);
+const enhance = OriginalComponent => compose(
+  getContext({
+    selectors: PropTypes.object
+  }),
+  connect(
+    (state, props) => ({
+      text: props.selectors.textSelector(state, { key: 'previous' }),
+      hasPrevious: props.selectors.hasPreviousSelector(state, props),
+      className: props.selectors.classNamesForComponentSelector(state, 'PreviousButton'),
+      style: props.selectors.stylesForComponentSelector(state, 'PreviousButton'),
+    })
+  )
+)((props) => <OriginalComponent {...props} />);
 
 export default enhance;

--- a/src/components/RowContainer.js
+++ b/src/components/RowContainer.js
@@ -5,26 +5,29 @@ import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 
-import {
-  columnIdsSelector,
-  rowDataSelector,
-  rowPropertiesSelector,
-  classNamesForComponentSelector,
-  stylesForComponentSelector,
-} from '../selectors/dataSelectors';
+//import {
+//  columnIdsSelector,
+//  rowDataSelector,
+//  rowPropertiesSelector,
+//  classNamesForComponentSelector,
+//  stylesForComponentSelector,
+//} from '../selectors/dataSelectors';
 import { valueOrResult } from '../utils/valueUtils';
 
 const ComposedRowContainer = OriginalComponent => compose(
   getContext({
     components: PropTypes.object,
+    selectors: PropTypes.object
   }),
-  connect((state, props) => ({
-    columnIds: columnIdsSelector(state),
-    rowProperties: rowPropertiesSelector(state),
-    rowData: rowDataSelector(state, props),
-    className: classNamesForComponentSelector(state, 'Row'),
-    style: stylesForComponentSelector(state, 'Row'),
-  })),
+  connect(
+    (state, props) => ({
+      columnIds: props.selectors.columnIdsSelector(state),
+      rowProperties: props.selectors.rowPropertiesSelector(state),
+      rowData: props.selectors.rowDataSelector(state, props),
+      className: props.selectors.classNamesForComponentSelector(state, 'Row'),
+      style: props.selectors.stylesForComponentSelector(state, 'Row'),
+    })
+  ),
   mapProps(props => {
     const { components, rowProperties, className, ...otherProps } = props;
     return {
@@ -35,7 +38,7 @@ const ComposedRowContainer = OriginalComponent => compose(
   }),
 )(props => (
   <OriginalComponent
-    {...props}
+  {...props}
   />
 ));
 

--- a/src/components/SettingsContainer.js
+++ b/src/components/SettingsContainer.js
@@ -5,7 +5,7 @@ import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 
-import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+//import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
 function getSettingsComponentsArrayFromObject(settingsObject, settingsComponents) {
   //TODO: determine if we need to make this faster
@@ -20,12 +20,13 @@ function getSettingsComponentsArrayFromObject(settingsObject, settingsComponents
 const EnhancedSettings = OriginalComponent => compose(
   getContext({
     components: PropTypes.object,
+    selectors: PropTypes.object,
     settingsComponentObjects: PropTypes.object
   }),
   connect(
     (state, props) => ({
-      className: classNamesForComponentSelector(state, 'Settings'),
-      style: stylesForComponentSelector(state, 'Settings'),
+      className: props.selectors.classNamesForComponentSelector(state, 'Settings'),
+      style: props.selectors.stylesForComponentSelector(state, 'Settings'),
     })
   ),
   mapProps(props => {

--- a/src/components/SettingsToggleContainer.js
+++ b/src/components/SettingsToggleContainer.js
@@ -1,14 +1,19 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
+import getContext from 'recompose/getContext';
 import { textSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 import { toggleSettings as toggleSettingsAction } from '../actions';
 
 const enhancedSettingsToggle = OriginalComponent => compose(
+  getContext({
+    selectors: PropTypes.object
+  }),
   connect((state, props) => ({
-    text: textSelector(state, { key: 'settingsToggle' }),
-    className: classNamesForComponentSelector(state, 'SettingsToggle'),
-    style: stylesForComponentSelector(state, 'SettingsToggle'),
+    text: props.selectors.textSelector(state, { key: 'settingsToggle' }),
+    className: props.selectors.classNamesForComponentSelector(state, 'SettingsToggle'),
+    style: props.selectors.stylesForComponentSelector(state, 'SettingsToggle'),
   }),
     {
       toggleSettings: toggleSettingsAction

--- a/src/components/SettingsWrapperContainer.js
+++ b/src/components/SettingsWrapperContainer.js
@@ -10,17 +10,24 @@ import { isSettingsEnabledSelector, isSettingsVisibleSelector, classNamesForComp
 const EnhancedSettingsWrapper = OriginalComponent => compose(
   getContext({
     components: PropTypes.object,
+    selectors: PropTypes.object,
   }),
-  mapProps(props => ({
-    Settings: props.components.Settings,
-    SettingsToggle: props.components.SettingsToggle
-  })),
-  connect((state, props) => ({
-    isEnabled: isSettingsEnabledSelector(state),
-    isVisible: isSettingsVisibleSelector(state),
-    className: classNamesForComponentSelector(state, 'SettingsWrapper'),
-    style: stylesForComponentSelector(state, 'SettingsWrapper'),
-  }))
+  connect(
+    (state, props) => ({
+      isEnabled: props.selectors.isSettingsEnabledSelector(state),
+      isVisible: props.selectors.isSettingsVisibleSelector(state),
+      className: props.selectors.classNamesForComponentSelector(state, 'SettingsWrapper'),
+      style: props.selectors.stylesForComponentSelector(state, 'SettingsWrapper'),
+    })
+  ),
+  mapProps(props => {
+    const { components, ...otherProps } = props;
+    return {
+      Settings: components.Settings,
+      SettingsToggle: components.SettingsToggle,
+      ...otherProps
+    }
+  })
 )(props => (
   <OriginalComponent {...props} />
 ));

--- a/src/components/TableBodyContainer.js
+++ b/src/components/TableBodyContainer.js
@@ -5,20 +5,22 @@ import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 
-import { visibleRowIdsSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+//import { visibleRowIdsSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
 const ComposedTableBodyContainer = OriginalComponent => compose(
   getContext({
     components: PropTypes.object,
     selectors: PropTypes.object,
   }),
-  connect((state, props) => ({
-    visibleRowIds: visibleRowIdsSelector(state),
-    className: classNamesForComponentSelector(state, 'TableBody'),
-    style: stylesForComponentSelector(state, 'TableBody'),
-  })),
+  connect(
+    (state, props) => ({
+      visibleRowIds: props.selectors.visibleRowIdsSelector(state),
+      className: props.selectors.classNamesForComponentSelector(state, 'TableBody'),
+      style: props.selectors.stylesForComponentSelector(state, 'TableBody'),
+    })
+  ),
   mapProps(props => {
-    const { components, ...otherProps } = props;
+    const { components, selectors, ...otherProps } = props;
     return {
       Row:  props.components.Row,
       ...otherProps,
@@ -26,10 +28,10 @@ const ComposedTableBodyContainer = OriginalComponent => compose(
   }),
 )(({Row, visibleRowIds, style, className}) => (
   <OriginalComponent
-    rowIds={visibleRowIds}
-    Row={Row}
-    style={style}
-    className={className}
+  rowIds={visibleRowIds}
+  Row={Row}
+  style={style}
+  className={className}
   />
 ));
 

--- a/src/components/TableContainer.js
+++ b/src/components/TableContainer.js
@@ -8,23 +8,27 @@ import getContext from 'recompose/getContext';
 import { classNamesForComponentSelector, stylesForComponentSelector, visibleRowCountSelector } from '../selectors/dataSelectors';
 
 const ComposedContainerComponent = OriginalComponent => compose(
-  getContext(
-  {
-    components: PropTypes.object
+  getContext({
+    components: PropTypes.object,
+    selectors: PropTypes.object
   }),
-  //TODO: Should we use withHandlers here instead? I realize that's not 100% the intent of that method
-  mapProps(props => ({
-    TableHeading: props.components.TableHeading,
-    TableBody: props.components.TableBody,
-    NoResults: props.components.NoResults,
-  })),
   connect(
     (state, props) => ({
-      visibleRows: visibleRowCountSelector(state),
-      className: classNamesForComponentSelector(state, 'Table'),
-      style: stylesForComponentSelector(state, 'Table'),
+      visibleRows: props.selectors.visibleRowCountSelector(state),
+      className: props.selectors.classNamesForComponentSelector(state, 'Table'),
+      style: props.selectors.stylesForComponentSelector(state, 'Table')
     })
   ),
+  //TODO: Should we use withHandlers here instead? I realize that's not 100% the intent of that method
+  mapProps(props => {
+    const { components, ...otherProps } = props;
+    return {
+      TableHeading: components.TableHeading,
+      TableBody: components.TableBody,
+      NoResults: components.NoResults,
+      ...otherProps
+    }
+  })
 )(props => <OriginalComponent {...props} />);
 
 export default ComposedContainerComponent;

--- a/src/components/TableHeadingCellContainer.js
+++ b/src/components/TableHeadingCellContainer.js
@@ -5,7 +5,7 @@ import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 
-import { sortPropertyByIdSelector, iconsForComponentSelector, classNamesForComponentSelector, stylesForComponentSelector, customHeadingComponentSelector, cellPropertiesSelector } from '../selectors/dataSelectors';
+//import { sortPropertyByIdSelector, iconsForComponentSelector, classNamesForComponentSelector, stylesForComponentSelector, customHeadingComponentSelector, cellPropertiesSelector } from '../selectors/dataSelectors';
 import { getSortIconProps } from '../utils/sortUtils';
 import { valueOrResult } from '../utils/valueUtils';
 
@@ -22,12 +22,12 @@ const EnhancedHeadingCell = OriginalComponent => compose(
   }),
   connect(
     (state, props) => ({
-      sortProperty: sortPropertyByIdSelector(state, props),
-      customHeadingComponent: customHeadingComponentSelector(state, props),
-      cellProperties: cellPropertiesSelector(state, props),
-      className: classNamesForComponentSelector(state, 'TableHeadingCell'),
-      style: stylesForComponentSelector(state, 'TableHeadingCell'),
-      ...iconsForComponentSelector(state, 'TableHeadingCell'),
+      sortProperty: props.selectors.sortPropertyByIdSelector(state, props),
+      customHeadingComponent: props.selectors.customHeadingComponentSelector(state, props),
+      cellProperties: props.selectors.cellPropertiesSelector(state, props),
+      className: props.selectors.classNamesForComponentSelector(state, 'TableHeadingCell'),
+      style: props.selectors.stylesForComponentSelector(state, 'TableHeadingCell'),
+      ...props.selectors.iconsForComponentSelector(state, 'TableHeadingCell'),
     })
   ),
   mapProps(props => {

--- a/src/components/TableHeadingContainer.js
+++ b/src/components/TableHeadingContainer.js
@@ -5,7 +5,7 @@ import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 
-import { columnTitlesSelector, columnIdsSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+//import { columnTitlesSelector, columnIdsSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
 const ComposedContainerComponent = OriginalComponent => compose(
   getContext({
@@ -13,10 +13,10 @@ const ComposedContainerComponent = OriginalComponent => compose(
     selectors: PropTypes.object,
   }),
   connect((state, props) => ({
-    columnTitles: columnTitlesSelector(state),
-    columnIds: columnIdsSelector(state),
-    className: classNamesForComponentSelector(state, 'TableHeading'),
-    style: stylesForComponentSelector(state, 'TableHeading'),
+    columnTitles: props.selectors.columnTitlesSelector(state),
+    columnIds: props.selectors.columnIdsSelector(state),
+    className: props.selectors.classNamesForComponentSelector(state, 'TableHeading'),
+    style: props.selectors.stylesForComponentSelector(state, 'TableHeading'),
   })),
   mapProps(props => {
     const { components, ...otherProps } = props;


### PR DESCRIPTION
## Griddle major version
1.9.0

## Changes proposed in this pull request
Convert all references to dataSelectors file in components to the context.selectors

## Why these changes are made
This allows plugins to override selectors in the base components without having to wholesale copy them. Would this potentially be a dangerous change from a consumers of Griddle perspective?

## Are there tests?
No