### PR TITLE
Render Loading component when data is null or undefined

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -63,7 +63,7 @@ export function setPageSize(pageSize) {
   }
 }
 
-export function updateState({ data = [], pageProperties = {}, sortProperties = {} }) {
+export function updateState({ data, pageProperties = {}, sortProperties = {} }) {
   return {
     type: GRIDDLE_UPDATE_STATE,
     newState: { data, pageProperties, sortProperties }

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Loading = ({ className, style }) => (
+  <div style={style} className={className}>
+    Loading…
+  </div>
+);
+
+export default Loading;

--- a/src/components/LoadingContainer.js
+++ b/src/components/LoadingContainer.js
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types';
+import { connect } from '../utils/griddleConnect';
+import compose from 'recompose/compose';
+import mapProps from 'recompose/mapProps';
+import getContext from 'recompose/getContext';
+
+import { classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
+
+const LoadingContainer = compose(
+  getContext({
+    components: PropTypes.object,
+  }),
+  connect(
+    state => ({
+      className: classNamesForComponentSelector(state, 'Loading'),
+      style: stylesForComponentSelector(state, 'Loading'),
+    })
+  ),
+  mapProps((props) => {
+    const { components, ...otherProps } = props;
+    return {
+      Loading: components.Loading,
+      ...otherProps
+    };
+  })
+);
+
+export default LoadingContainer;
+

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,6 +1,8 @@
 import React from 'react';
 
-export const Table = ({ TableHeading, TableBody, NoResults, style, className, visibleRows }) =>  visibleRows > 0 ?
+export const Table = ({ TableHeading, TableBody, Loading, NoResults, style, className, dataLoading, visibleRows }) =>
+  dataLoading ? (Loading && <Loading />) :
+  visibleRows > 0 ?
   (
     <table style={style} className={className}>
       { TableHeading && <TableHeading /> }

--- a/src/components/TableContainer.js
+++ b/src/components/TableContainer.js
@@ -5,7 +5,7 @@ import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 
-import { classNamesForComponentSelector, stylesForComponentSelector, visibleRowCountSelector } from '../selectors/dataSelectors';
+import { classNamesForComponentSelector, stylesForComponentSelector, dataLoadingSelector, visibleRowCountSelector } from '../selectors/dataSelectors';
 
 const ComposedContainerComponent = OriginalComponent => compose(
   getContext(
@@ -16,10 +16,12 @@ const ComposedContainerComponent = OriginalComponent => compose(
   mapProps(props => ({
     TableHeading: props.components.TableHeading,
     TableBody: props.components.TableBody,
+    Loading: props.components.Loading,
     NoResults: props.components.NoResults,
   })),
   connect(
     (state, props) => ({
+      dataLoading: dataLoadingSelector(state),
       visibleRows: visibleRowCountSelector(state),
       className: classNamesForComponentSelector(state, 'Table'),
       style: stylesForComponentSelector(state, 'Table'),

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -30,6 +30,8 @@ import { components as SettingsComponents } from '../settingsComponentObjects';
 import NextButton from './NextButton';
 import NextButtonEnhancer from './NextButtonEnhancer';
 import NextButtonContainer from './NextButtonContainer';
+import Loading from './Loading';
+import LoadingContainer from './LoadingContainer';
 import NoResults from './NoResults';
 import NoResultsContainer from './NoResultsContainer';
 import PreviousButton from './PreviousButton';
@@ -59,6 +61,8 @@ const components = {
   NextButton,
   NextButtonEnhancer,
   NextButtonContainer,
+  Loading,
+  LoadingContainer,
   NoResults,
   NoResultsContainer,
   PageDropdown,

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { createStore, combineReducers, bindActionCreators, applyMiddleware } from 'redux';
+import { createStore, combineReducers, bindActionCreators, applyMiddleware, compose } from 'redux';
 import Immutable from 'immutable';
 import { createProvider } from 'react-redux';
 import React, { Component } from 'react';
@@ -136,10 +136,13 @@ class Griddle extends Component {
       }
     );
 
+    const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
     this.store = createStore(
       reducers,
       initialState,
-      applyMiddleware(..._.compact(_.flatten(plugins.map(p => p.reduxMiddleware))), ...reduxMiddleware) 
+      composeEnhancers(
+        applyMiddleware(..._.compact(_.flatten(plugins.map(p => p.reduxMiddleware))), ...reduxMiddleware)
+      )
     );
 
     this.provider = createProvider(storeKey);

--- a/src/plugins/local/components/TableContainer.js
+++ b/src/plugins/local/components/TableContainer.js
@@ -5,7 +5,7 @@ import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 
-import { classNamesForComponentSelector, stylesForComponentSelector, visibleRowCountSelector } from '../selectors/localSelectors';
+import { classNamesForComponentSelector, stylesForComponentSelector, dataLoadingSelector, visibleRowCountSelector } from '../selectors/localSelectors';
 
 const ComposedContainerComponent = OriginalComponent => compose(
   getContext({
@@ -14,10 +14,12 @@ const ComposedContainerComponent = OriginalComponent => compose(
   mapProps(props => ({
     TableHeading: props.components.TableHeading,
     TableBody: props.components.TableBody,
+    Loading: props.components.Loading,
     NoResults: props.components.NoResults,
   })),
   connect(
     (state, props) => ({
+      dataLoading: dataLoadingSelector(state),
       visibleRows: visibleRowCountSelector(state),
       className: classNamesForComponentSelector(state, 'Table'),
       style: stylesForComponentSelector(state, 'Table'),

--- a/src/plugins/local/selectors/localSelectors.js
+++ b/src/plugins/local/selectors/localSelectors.js
@@ -11,6 +11,8 @@ import * as dataSelectors from '../../../selectors/dataSelectors';
  */
 export const dataSelector = state => state.get('data');
 
+export const dataLoadingSelector = dataSelectors.dataLoadingSelector;
+
 /** Gets the current page from pageProperties
  * @param {Immutable} state - state object
  */

--- a/src/selectors/dataSelectors.js
+++ b/src/selectors/dataSelectors.js
@@ -8,6 +8,8 @@ import MAX_SAFE_INTEGER from 'max-safe-integer'
 /** Gets the full dataset currently tracked by Griddle */
 export const dataSelector = state => state.get('data');
 
+export const dataLoadingSelector = createSelector(dataSelector, data => !data);
+
 /** Gets the page size */
 export const pageSizeSelector = state => state.getIn(['pageProperties', 'pageSize']);
 

--- a/src/utils/dataUtils.js
+++ b/src/utils/dataUtils.js
@@ -27,6 +27,10 @@ function fromJSGreedy(js) {
 }
 
 export function transformData(data, renderProperties) {
+  if (!data) {
+    return {};
+  }
+
   const hasCustomRowId = renderProperties.rowProperties && renderProperties.rowProperties.rowKey;
 
   // Validate that the first item in our data has the custom Griddle key

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -12,7 +12,7 @@ import { createStore } from 'redux';
 import { createSelector } from 'reselect';
 import _ from 'lodash';
 
-import GenericGriddle, { actions, components, selectors, plugins, utils, ColumnDefinition, RowDefinition } from '../src/module';
+import GenericGriddle, { actions, components, selectors, plugins, utils, ColumnDefinition, RowDefinition, GriddleProps } from '../src/module';
 const { connect } = utils;
 const { Cell, Row, Table, TableContainer, TableBody, TableHeading, TableHeadingCell } = components;
 const { SettingsWrapper, SettingsToggle, Settings } = components;
@@ -95,6 +95,33 @@ storiesOf('Griddle main', module)
         </RowDefinition>
       </Griddle>
     )
+  })
+  .add('with local, delayed data', () => {
+    class DeferredGriddle extends React.Component<GriddleProps<FakeData>, { data?: FakeData[] }> {
+      constructor(props) {
+        super(props);
+        this.state = {};
+        this.resetData();
+      }
+
+      resetData = () => {
+        this.setState({ data: null });
+
+        setTimeout(() => {
+          this.setState({ data: this.props.data });
+        }, 2000);
+      }
+
+      render() {
+        return (
+          <div>
+            <p><button onClick={this.resetData}>Reload Data</button></p>
+            <Griddle {...this.props} data={this.state.data} />
+          </div>
+        );
+      }
+    }
+    return <DeferredGriddle data={fakeData} plugins={[LocalPlugin]} />
   })
   .add('with local and legacy (v0) styles', () => {
     return (

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -846,6 +846,40 @@ storiesOf('Plugins', module)
     );
   })
 
+storiesOf('Data Missing', module)
+  .add('base (data=undefined)', () => {
+    return (
+      <Griddle />
+    )
+  })
+  .add('base (data=null)', () => {
+    return (
+      <Griddle data={null} />
+    )
+  })
+  .add('local (data=undefined)', () => {
+    return (
+      <Griddle plugins={[LocalPlugin]} />
+    )
+  })
+  .add('local (data=null)', () => {
+    return (
+      <Griddle data={null} plugins={[LocalPlugin]} />
+    )
+  })
+
+storiesOf('Data Empty', module)
+  .add('base', () => {
+    return (
+      <Griddle data={[]} />
+    )
+  })
+  .add('local', () => {
+    return (
+      <Griddle data={[]} plugins={[LocalPlugin]} />
+    )
+  })
+
 storiesOf('Cell', module)
   .add('base cell', () => {
     const someValue = "hi from storybook"


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

1. Providing `data` of `null`/`undefined` no longer blows up with or without `LocalPlugin`.
2. When `data` is `null`/`undefined` we now render a `Loading` component instead of `NoResults`.

## Why these changes are made

User experience can be made less disruptive if the entire Griddle component doesn't need to be replaced by a loading animation (e.g. if a `Settings` component requires fetching new data).

![griddle-loading](https://user-images.githubusercontent.com/133987/31059521-230a9b4c-a6c9-11e7-90af-3c286cc6208a.gif)

## Are there tests?

Stories!