### PR TITLE
onSort with *correct* sortProperties

### DIFF
--- a/src/components/TableHeadingCellContainer.js
+++ b/src/components/TableHeadingCellContainer.js
@@ -4,9 +4,11 @@ import { connect } from '../utils/griddleConnect';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
-
+import withHandlers from 'recompose/withHandlers';
 import { sortPropertyByIdSelector, iconsForComponentSelector, classNamesForComponentSelector, stylesForComponentSelector, customHeadingComponentSelector, cellPropertiesSelector } from '../selectors/dataSelectors';
-import { getSortIconProps } from '../utils/sortUtils';
+import { setSortColumn } from '../actions';
+import { combineHandlers } from '../utils/compositionUtils';
+import { getSortIconProps, setSortProperties } from '../utils/sortUtils';
 import { valueOrResult } from '../utils/valueUtils';
 
 const DefaultTableHeadingCellContent = ({title, icon}) => (
@@ -28,8 +30,18 @@ const EnhancedHeadingCell = OriginalComponent => compose(
       className: classNamesForComponentSelector(state, 'TableHeadingCell'),
       style: stylesForComponentSelector(state, 'TableHeadingCell'),
       ...iconsForComponentSelector(state, 'TableHeadingCell'),
+    }),
+    (dispatch, { events: { onSort } }) => ({
+      setSortColumn: combineHandlers([
+        onSort,
+        sp => dispatch(setSortColumn(sp)),
+      ]),
     })
   ),
+  withHandlers(props => ({
+    onClick: props.cellProperties.sortable === false ? (() => () => {}) :
+      props.events.setSortProperties || setSortProperties,
+  })),
   mapProps(props => {
     const iconProps = getSortIconProps(props);
     const title = props.customHeadingComponent ?

--- a/src/components/TableHeadingCellContainer.js
+++ b/src/components/TableHeadingCellContainer.js
@@ -5,16 +5,16 @@ import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 import withHandlers from 'recompose/withHandlers';
-import { sortPropertyByIdSelector, iconsForComponentSelector, classNamesForComponentSelector, stylesForComponentSelector, customHeadingComponentSelector, cellPropertiesSelector } from '../selectors/dataSelectors';
+import { sortPropertyByIdSelector, iconsForComponentSelector, customHeadingComponentSelector, stylesForComponentSelector, classNamesForComponentSelector, cellPropertiesSelector } from '../selectors/dataSelectors';
 import { setSortColumn } from '../actions';
 import { combineHandlers } from '../utils/compositionUtils';
 import { getSortIconProps, setSortProperties } from '../utils/sortUtils';
 import { valueOrResult } from '../utils/valueUtils';
 
-const DefaultTableHeadingCellContent = ({title, icon}) => (
+const DefaultTableHeadingCellContent = ({title, icon, iconClassName}) => (
   <span>
     { title }
-    { icon && <span>{icon}</span> }
+    { icon && <span className={iconClassName}>{icon}</span> }
   </span>
 )
 
@@ -28,6 +28,8 @@ const EnhancedHeadingCell = OriginalComponent => compose(
       customHeadingComponent: customHeadingComponentSelector(state, props),
       cellProperties: cellPropertiesSelector(state, props),
       className: classNamesForComponentSelector(state, 'TableHeadingCell'),
+      sortAscendingClassName: classNamesForComponentSelector(state, 'TableHeadingCellAscending'),
+      sortDescendingClassName: classNamesForComponentSelector(state, 'TableHeadingCellDescending'),
       style: stylesForComponentSelector(state, 'TableHeadingCell'),
       ...iconsForComponentSelector(state, 'TableHeadingCell'),
     }),
@@ -42,6 +44,7 @@ const EnhancedHeadingCell = OriginalComponent => compose(
     onClick: props.cellProperties.sortable === false ? (() => () => {}) :
       props.events.setSortProperties || setSortProperties,
   })),
+  //TODO: use with props on change or something more performant here
   mapProps(props => {
     const iconProps = getSortIconProps(props);
     const title = props.customHeadingComponent ?

--- a/src/components/TableHeadingCellContainer.js
+++ b/src/components/TableHeadingCellContainer.js
@@ -36,7 +36,7 @@ const EnhancedHeadingCell = OriginalComponent => compose(
     (dispatch, { events: { onSort } }) => ({
       setSortColumn: combineHandlers([
         onSort,
-        sp => dispatch(setSortColumn(sp)),
+        compose(dispatch, setSortColumn),
       ]),
     })
   ),

--- a/src/components/TableHeadingCellEnhancer.js
+++ b/src/components/TableHeadingCellEnhancer.js
@@ -1,21 +1,4 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import compose from 'recompose/compose';
-import mapProps from 'recompose/mapProps';
-import getContext from 'recompose/getContext';
-import { combineHandlers } from '../utils/compositionUtils';
-
-const EnhancedHeadingCell = OriginalComponent => compose(
-  getContext({
-    events: PropTypes.object,
-  }),
-  mapProps(({ events: { onSort }, ...props }) => ({
-    ...props,
-    onClick: combineHandlers([
-      () => onSort && onSort(props.sortProperty || { id: props.columnId }),
-      props.onClick,
-    ]),
-  }))
-)(props => <OriginalComponent {...props} />);
+// Obsolete
+const EnhancedHeadingCell = OriginalComponent => OriginalComponent;
 
 export default EnhancedHeadingCell;

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -7,6 +7,7 @@ import getContext from 'recompose/getContext';
 import withHandlers from 'recompose/withHandlers';
 import { sortPropertyByIdSelector, iconsForComponentSelector, customHeadingComponentSelector, stylesForComponentSelector, classNamesForComponentSelector, cellPropertiesSelector } from '../../../selectors/dataSelectors';
 import { setSortColumn } from '../../../actions';
+import { combineHandlers } from '../../../utils/compositionUtils';
 import { getSortIconProps, setSortProperties } from '../../../utils/sortUtils';
 import { valueOrResult } from '../../../utils/valueUtils';
 
@@ -32,9 +33,12 @@ const EnhancedHeadingCell = OriginalComponent => compose(
       style: stylesForComponentSelector(state, 'TableHeadingCell'),
       ...iconsForComponentSelector(state, 'TableHeadingCell'),
     }),
-    {
-      setSortColumn
-    }
+    (dispatch, { events: { onSort } }) => ({
+      setSortColumn: combineHandlers([
+        onSort,
+        sp => dispatch(setSortColumn(sp)),
+      ]),
+    })
   ),
   withHandlers(props => ({
     onClick: props.cellProperties.sortable === false ? (() => () => {}) :

--- a/src/plugins/local/components/TableHeadingCellContainer.js
+++ b/src/plugins/local/components/TableHeadingCellContainer.js
@@ -36,7 +36,7 @@ const EnhancedHeadingCell = OriginalComponent => compose(
     (dispatch, { events: { onSort } }) => ({
       setSortColumn: combineHandlers([
         onSort,
-        sp => dispatch(setSortColumn(sp)),
+        compose(dispatch, setSortColumn),
       ]),
     })
   ),

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1548,7 +1548,7 @@ storiesOf('TypeScript', module)
   .add('GriddleComponent accepts expected types', () => {
     class Custom extends React.Component<{ value }> {
       render() {
-        return this.props.value;
+        return <strong>{this.props.value}</strong>;
       }
     }
 


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

`onSort` is now fired just before the new `sortProperties` are dispatched.

This essentially renders `TableHeadingCell` obsolete, but deleting it is a potentially breaking change.

### Idea
What if events were fired from a Redux middleware instead of click handlers?

## Why these changes are made

Close #716; #717 was insufficient.

## Are there tests?

Existing story now demonstrates expected behavior.

It seems like a new React version changed behavior when `render()` returns a string, so the TS story has been adjusted.