### PR TITLE
Export connect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ class Griddle extends Component {
       components:userComponents,
       renderProperties:userRenderProperties={},
       settingsComponentObjects:userSettingsComponentObjects,
-      storeKey = 'store',
+      storeKey = Griddle.storeKey || 'store',
       reduxMiddleware = [],
       listeners = {},
       ...userInitialState
@@ -162,7 +162,7 @@ class Griddle extends Component {
   }
 
   getStoreKey = () => {
-    return this.props.storeKey || 'store';
+    return this.props.storeKey || Griddle.storeKey || 'store';
   }
 
   getChildContext() {
@@ -185,5 +185,7 @@ class Griddle extends Component {
 
   }
 }
+
+Griddle.storeKey = 'store';
 
 export default Griddle;

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -417,6 +417,8 @@ export const selectors: PropertyBag<Selector>;
 
 export const settingsComponentObjects: PropertyBag<SettingsComponentObject>;
 
+export const connect : typeof originalConnect;
+
 export namespace utils {
     const columnUtils: PropertyBag<Function>;
     const compositionUtils: PropertyBag<Function>;

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -407,6 +407,7 @@ export interface GriddleProps<T> extends GriddlePlugin, GriddleInitialState {
 }
 
 declare class Griddle<T> extends React.Component<GriddleProps<T>, any> {
+  static storeKey: string;
 }
 
 export const actions: GriddleActions;

--- a/src/module.js
+++ b/src/module.js
@@ -20,6 +20,8 @@ const plugins = {
 const ColumnDefinition = components.ColumnDefinition;
 const RowDefinition = components.RowDefinition;
 
+const connect = utils.connect;
+
 export default Griddle;
 export {
   actions,
@@ -31,4 +33,5 @@ export {
   plugins,
   ColumnDefinition,
   RowDefinition,
+  connect,
 };

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -12,8 +12,7 @@ import { createStore } from 'redux';
 import { createSelector } from 'reselect';
 import _ from 'lodash';
 
-import GenericGriddle, { actions, components, selectors, plugins, utils, ColumnDefinition, RowDefinition, GriddleProps } from '../src/module';
-const { connect } = utils;
+import GenericGriddle, { connect, actions, components, selectors, plugins, utils, ColumnDefinition, RowDefinition, GriddleProps } from '../src/module';
 const { Cell, Row, Table, TableContainer, TableBody, TableHeading, TableHeadingCell } = components;
 const { SettingsWrapper, SettingsToggle, Settings } = components;
 

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -7,7 +7,7 @@ import getContext from 'recompose/getContext';
 import withContext from 'recompose/withContext';
 import withHandlers from 'recompose/withHandlers';
 import withState from 'recompose/withState';
-import { Provider } from 'react-redux';
+import { Provider, connect as reduxConnect } from 'react-redux';
 import { createStore } from 'redux';
 import { createSelector } from 'reselect';
 import _ from 'lodash';
@@ -753,24 +753,20 @@ storiesOf('Griddle main', module)
     );
   })
 
-  .add('with child of another redux container', () => {
+  .add('with custom storeKey and child connected to another Redux store', () => {
     // basically the demo redux stuff
     const countSelector = (state) => state.count;
 
     const CountComponent = (props) => (
       <div>
-        {props.count}
-        <button type="button" onClick={props.increment}>
-          +
-        </button>
-        <button type="button" onClick={props.decrement}>
-          -
-        </button>
+        <button type="button" onClick={props.increment}>+</button>
+        <input value={props.count} readOnly style={{ width: '2em', textAlign: 'center' }} />
+        <button type="button" onClick={props.decrement}>−</button>
       </div>
     )
 
     // should get count from other store
-    const ConnectedComponent = connect(
+    const ConnectedComponent = reduxConnect(
       state => ({
         count: countSelector(state)
       }),
@@ -800,8 +796,8 @@ storiesOf('Griddle main', module)
               </RowDefinition>
             </Griddle>
 
-          Component outside of Griddle that's sharing state
-          <ConnectedComponent />
+            Component outside of Griddle that's sharing state
+            <ConnectedComponent />
           </div>
         </Provider>
       </div>


### PR DESCRIPTION
## Griddle major version

1.8+

## Changes proposed in this pull request

1. Export `connect` directly, so it's more of a drop-in replacement for `react-redux`, i.e.

   ```diff
   -import { connect } from 'react-redux';
   +import { connect } from 'griddle-react';
   ```

2. Add static `storeKey` property, so default can be changed once app-wide

3. The `storeKey` story's `ConnectedComponent` was incorrectly using Griddle's `connect`; now it doesn't, and the demo works. (Bonus: demo's slightly prettier.)
   ![image](https://user-images.githubusercontent.com/133987/31413092-5b046954-addd-11e7-9de8-18dcd8b27341.png)


## Why these changes are made

I'm actually using this functionality now across an app, and it's a bit tedious.
