### PR TITLE
v0: fix React.createClass and PropTypes for react 16

### DIFF
--- a/build/Griddle.js
+++ b/build/Griddle.js
@@ -81,44 +81,44 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 	var React = __webpack_require__(2);
-	var GridTable = __webpack_require__(3);
-	var GridFilter = __webpack_require__(175);
-	var GridPagination = __webpack_require__(176);
-	var GridSettings = __webpack_require__(177);
-	var GridNoData = __webpack_require__(183);
-	var GridRow = __webpack_require__(184);
-	var GridRowContainer = __webpack_require__(166);
-	var CustomRowComponentContainer = __webpack_require__(204);
-	var CustomPaginationContainer = __webpack_require__(205);
-	var CustomFilterContainer = __webpack_require__(206);
-	var ColumnProperties = __webpack_require__(5);
-	var RowProperties = __webpack_require__(173);
-	var deep = __webpack_require__(185);
+	var PropTypes = __webpack_require__(3);
+	var createReactClass = __webpack_require__(13);
+	var GridTable = __webpack_require__(16);
+	var GridFilter = __webpack_require__(188);
+	var GridPagination = __webpack_require__(189);
+	var GridSettings = __webpack_require__(190);
+	var GridNoData = __webpack_require__(196);
+	var GridRow = __webpack_require__(197);
+	var GridRowContainer = __webpack_require__(179);
+	var CustomRowComponentContainer = __webpack_require__(217);
+	var CustomPaginationContainer = __webpack_require__(218);
+	var CustomFilterContainer = __webpack_require__(219);
+	var ColumnProperties = __webpack_require__(18);
+	var RowProperties = __webpack_require__(186);
+	var deep = __webpack_require__(198);
 
-	var drop = __webpack_require__(207);
-	var dropRight = __webpack_require__(209);
-	var find = __webpack_require__(130);
-	var first = __webpack_require__(210);
-	var forEach = __webpack_require__(186);
-	var initial = __webpack_require__(211);
-	var intersection = __webpack_require__(212);
-	var isArray = __webpack_require__(71);
-	var isEmpty = __webpack_require__(215);
-	var isNull = __webpack_require__(216);
-	var isUndefined = __webpack_require__(217);
-	var omit = __webpack_require__(218);
-	var map = __webpack_require__(6);
-	var extend = __webpack_require__(161);
-	var _filter = __webpack_require__(128);
+	var drop = __webpack_require__(220);
+	var dropRight = __webpack_require__(222);
+	var find = __webpack_require__(143);
+	var first = __webpack_require__(223);
+	var forEach = __webpack_require__(199);
+	var initial = __webpack_require__(224);
+	var intersection = __webpack_require__(225);
+	var isArray = __webpack_require__(84);
+	var isEmpty = __webpack_require__(228);
+	var isNull = __webpack_require__(229);
+	var isUndefined = __webpack_require__(230);
+	var omit = __webpack_require__(231);
+	var map = __webpack_require__(19);
+	var extend = __webpack_require__(174);
+	var _filter = __webpack_require__(141);
 
-	var _orderBy = __webpack_require__(246);
-	var _property = __webpack_require__(119);
-	var _get = __webpack_require__(104);
-	var _some = __webpack_require__(247);
+	var _orderBy = __webpack_require__(259);
+	var _property = __webpack_require__(132);
+	var _get = __webpack_require__(117);
+	var _some = __webpack_require__(260);
 
-	var Griddle = React.createClass({
-	    displayName: 'Griddle',
-
+	var Griddle = createReactClass({
 	    statics: {
 	        GridTable: GridTable,
 	        GridFilter: GridFilter,
@@ -224,11 +224,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	        };
 	    },
 	    propTypes: {
-	        isMultipleSelection: React.PropTypes.bool,
-	        selectedRowIds: React.PropTypes.oneOfType([React.PropTypes.arrayOf(React.PropTypes.number), React.PropTypes.arrayOf(React.PropTypes.string)]),
-	        uniqueIdentifier: React.PropTypes.string,
-	        onSelectionChange: React.PropTypes.func,
-	        columnFilterFunc: React.PropTypes.func
+	        isMultipleSelection: PropTypes.bool,
+	        selectedRowIds: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.number), PropTypes.arrayOf(PropTypes.string)]),
+	        uniqueIdentifier: PropTypes.string,
+	        onSelectionChange: PropTypes.func,
+	        columnFilterFunc: PropTypes.func
 	    },
 	    defaultFilter: function defaultFilter(results, filter) {
 	        var that = this;
@@ -1030,20 +1030,2139 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 3 */
 /***/ function(module, exports, __webpack_require__) {
 
+	/* WEBPACK VAR INJECTION */(function(process) {/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+
+	if (process.env.NODE_ENV !== 'production') {
+	  var REACT_ELEMENT_TYPE = (typeof Symbol === 'function' &&
+	    Symbol.for &&
+	    Symbol.for('react.element')) ||
+	    0xeac7;
+
+	  var isValidElement = function(object) {
+	    return typeof object === 'object' &&
+	      object !== null &&
+	      object.$$typeof === REACT_ELEMENT_TYPE;
+	  };
+
+	  // By explicitly using `prop-types` you are opting into new development behavior.
+	  // http://fb.me/prop-types-in-prod
+	  var throwOnDirectAccess = true;
+	  module.exports = __webpack_require__(5)(isValidElement, throwOnDirectAccess);
+	} else {
+	  // By explicitly using `prop-types` you are opting into new production behavior.
+	  // http://fb.me/prop-types-in-prod
+	  module.exports = __webpack_require__(12)();
+	}
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(4)))
+
+/***/ },
+/* 4 */
+/***/ function(module, exports) {
+
+	// shim for using process in browser
+	var process = module.exports = {};
+
+	// cached from whatever global is present so that test runners that stub it
+	// don't break things.  But we need to wrap it in a try catch in case it is
+	// wrapped in strict mode code which doesn't define any globals.  It's inside a
+	// function because try/catches deoptimize in certain engines.
+
+	var cachedSetTimeout;
+	var cachedClearTimeout;
+
+	function defaultSetTimout() {
+	    throw new Error('setTimeout has not been defined');
+	}
+	function defaultClearTimeout () {
+	    throw new Error('clearTimeout has not been defined');
+	}
+	(function () {
+	    try {
+	        if (typeof setTimeout === 'function') {
+	            cachedSetTimeout = setTimeout;
+	        } else {
+	            cachedSetTimeout = defaultSetTimout;
+	        }
+	    } catch (e) {
+	        cachedSetTimeout = defaultSetTimout;
+	    }
+	    try {
+	        if (typeof clearTimeout === 'function') {
+	            cachedClearTimeout = clearTimeout;
+	        } else {
+	            cachedClearTimeout = defaultClearTimeout;
+	        }
+	    } catch (e) {
+	        cachedClearTimeout = defaultClearTimeout;
+	    }
+	} ())
+	function runTimeout(fun) {
+	    if (cachedSetTimeout === setTimeout) {
+	        //normal enviroments in sane situations
+	        return setTimeout(fun, 0);
+	    }
+	    // if setTimeout wasn't available but was latter defined
+	    if ((cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) && setTimeout) {
+	        cachedSetTimeout = setTimeout;
+	        return setTimeout(fun, 0);
+	    }
+	    try {
+	        // when when somebody has screwed with setTimeout but no I.E. maddness
+	        return cachedSetTimeout(fun, 0);
+	    } catch(e){
+	        try {
+	            // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
+	            return cachedSetTimeout.call(null, fun, 0);
+	        } catch(e){
+	            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
+	            return cachedSetTimeout.call(this, fun, 0);
+	        }
+	    }
+
+
+	}
+	function runClearTimeout(marker) {
+	    if (cachedClearTimeout === clearTimeout) {
+	        //normal enviroments in sane situations
+	        return clearTimeout(marker);
+	    }
+	    // if clearTimeout wasn't available but was latter defined
+	    if ((cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) && clearTimeout) {
+	        cachedClearTimeout = clearTimeout;
+	        return clearTimeout(marker);
+	    }
+	    try {
+	        // when when somebody has screwed with setTimeout but no I.E. maddness
+	        return cachedClearTimeout(marker);
+	    } catch (e){
+	        try {
+	            // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
+	            return cachedClearTimeout.call(null, marker);
+	        } catch (e){
+	            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
+	            // Some versions of I.E. have different rules for clearTimeout vs setTimeout
+	            return cachedClearTimeout.call(this, marker);
+	        }
+	    }
+
+
+
+	}
+	var queue = [];
+	var draining = false;
+	var currentQueue;
+	var queueIndex = -1;
+
+	function cleanUpNextTick() {
+	    if (!draining || !currentQueue) {
+	        return;
+	    }
+	    draining = false;
+	    if (currentQueue.length) {
+	        queue = currentQueue.concat(queue);
+	    } else {
+	        queueIndex = -1;
+	    }
+	    if (queue.length) {
+	        drainQueue();
+	    }
+	}
+
+	function drainQueue() {
+	    if (draining) {
+	        return;
+	    }
+	    var timeout = runTimeout(cleanUpNextTick);
+	    draining = true;
+
+	    var len = queue.length;
+	    while(len) {
+	        currentQueue = queue;
+	        queue = [];
+	        while (++queueIndex < len) {
+	            if (currentQueue) {
+	                currentQueue[queueIndex].run();
+	            }
+	        }
+	        queueIndex = -1;
+	        len = queue.length;
+	    }
+	    currentQueue = null;
+	    draining = false;
+	    runClearTimeout(timeout);
+	}
+
+	process.nextTick = function (fun) {
+	    var args = new Array(arguments.length - 1);
+	    if (arguments.length > 1) {
+	        for (var i = 1; i < arguments.length; i++) {
+	            args[i - 1] = arguments[i];
+	        }
+	    }
+	    queue.push(new Item(fun, args));
+	    if (queue.length === 1 && !draining) {
+	        runTimeout(drainQueue);
+	    }
+	};
+
+	// v8 likes predictible objects
+	function Item(fun, array) {
+	    this.fun = fun;
+	    this.array = array;
+	}
+	Item.prototype.run = function () {
+	    this.fun.apply(null, this.array);
+	};
+	process.title = 'browser';
+	process.browser = true;
+	process.env = {};
+	process.argv = [];
+	process.version = ''; // empty string to avoid regexp issues
+	process.versions = {};
+
+	function noop() {}
+
+	process.on = noop;
+	process.addListener = noop;
+	process.once = noop;
+	process.off = noop;
+	process.removeListener = noop;
+	process.removeAllListeners = noop;
+	process.emit = noop;
+	process.prependListener = noop;
+	process.prependOnceListener = noop;
+
+	process.listeners = function (name) { return [] }
+
+	process.binding = function (name) {
+	    throw new Error('process.binding is not supported');
+	};
+
+	process.cwd = function () { return '/' };
+	process.chdir = function (dir) {
+	    throw new Error('process.chdir is not supported');
+	};
+	process.umask = function() { return 0; };
+
+
+/***/ },
+/* 5 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(process) {/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+
+	'use strict';
+
+	var emptyFunction = __webpack_require__(6);
+	var invariant = __webpack_require__(7);
+	var warning = __webpack_require__(8);
+	var assign = __webpack_require__(9);
+
+	var ReactPropTypesSecret = __webpack_require__(10);
+	var checkPropTypes = __webpack_require__(11);
+
+	module.exports = function(isValidElement, throwOnDirectAccess) {
+	  /* global Symbol */
+	  var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+	  var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
+
+	  /**
+	   * Returns the iterator method function contained on the iterable object.
+	   *
+	   * Be sure to invoke the function with the iterable as context:
+	   *
+	   *     var iteratorFn = getIteratorFn(myIterable);
+	   *     if (iteratorFn) {
+	   *       var iterator = iteratorFn.call(myIterable);
+	   *       ...
+	   *     }
+	   *
+	   * @param {?object} maybeIterable
+	   * @return {?function}
+	   */
+	  function getIteratorFn(maybeIterable) {
+	    var iteratorFn = maybeIterable && (ITERATOR_SYMBOL && maybeIterable[ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL]);
+	    if (typeof iteratorFn === 'function') {
+	      return iteratorFn;
+	    }
+	  }
+
+	  /**
+	   * Collection of methods that allow declaration and validation of props that are
+	   * supplied to React components. Example usage:
+	   *
+	   *   var Props = require('ReactPropTypes');
+	   *   var MyArticle = React.createClass({
+	   *     propTypes: {
+	   *       // An optional string prop named "description".
+	   *       description: Props.string,
+	   *
+	   *       // A required enum prop named "category".
+	   *       category: Props.oneOf(['News','Photos']).isRequired,
+	   *
+	   *       // A prop named "dialog" that requires an instance of Dialog.
+	   *       dialog: Props.instanceOf(Dialog).isRequired
+	   *     },
+	   *     render: function() { ... }
+	   *   });
+	   *
+	   * A more formal specification of how these methods are used:
+	   *
+	   *   type := array|bool|func|object|number|string|oneOf([...])|instanceOf(...)
+	   *   decl := ReactPropTypes.{type}(.isRequired)?
+	   *
+	   * Each and every declaration produces a function with the same signature. This
+	   * allows the creation of custom validation functions. For example:
+	   *
+	   *  var MyLink = React.createClass({
+	   *    propTypes: {
+	   *      // An optional string or URI prop named "href".
+	   *      href: function(props, propName, componentName) {
+	   *        var propValue = props[propName];
+	   *        if (propValue != null && typeof propValue !== 'string' &&
+	   *            !(propValue instanceof URI)) {
+	   *          return new Error(
+	   *            'Expected a string or an URI for ' + propName + ' in ' +
+	   *            componentName
+	   *          );
+	   *        }
+	   *      }
+	   *    },
+	   *    render: function() {...}
+	   *  });
+	   *
+	   * @internal
+	   */
+
+	  var ANONYMOUS = '<<anonymous>>';
+
+	  // Important!
+	  // Keep this list in sync with production version in `./factoryWithThrowingShims.js`.
+	  var ReactPropTypes = {
+	    array: createPrimitiveTypeChecker('array'),
+	    bool: createPrimitiveTypeChecker('boolean'),
+	    func: createPrimitiveTypeChecker('function'),
+	    number: createPrimitiveTypeChecker('number'),
+	    object: createPrimitiveTypeChecker('object'),
+	    string: createPrimitiveTypeChecker('string'),
+	    symbol: createPrimitiveTypeChecker('symbol'),
+
+	    any: createAnyTypeChecker(),
+	    arrayOf: createArrayOfTypeChecker,
+	    element: createElementTypeChecker(),
+	    instanceOf: createInstanceTypeChecker,
+	    node: createNodeChecker(),
+	    objectOf: createObjectOfTypeChecker,
+	    oneOf: createEnumTypeChecker,
+	    oneOfType: createUnionTypeChecker,
+	    shape: createShapeTypeChecker,
+	    exact: createStrictShapeTypeChecker,
+	  };
+
+	  /**
+	   * inlined Object.is polyfill to avoid requiring consumers ship their own
+	   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+	   */
+	  /*eslint-disable no-self-compare*/
+	  function is(x, y) {
+	    // SameValue algorithm
+	    if (x === y) {
+	      // Steps 1-5, 7-10
+	      // Steps 6.b-6.e: +0 != -0
+	      return x !== 0 || 1 / x === 1 / y;
+	    } else {
+	      // Step 6.a: NaN == NaN
+	      return x !== x && y !== y;
+	    }
+	  }
+	  /*eslint-enable no-self-compare*/
+
+	  /**
+	   * We use an Error-like object for backward compatibility as people may call
+	   * PropTypes directly and inspect their output. However, we don't use real
+	   * Errors anymore. We don't inspect their stack anyway, and creating them
+	   * is prohibitively expensive if they are created too often, such as what
+	   * happens in oneOfType() for any type before the one that matched.
+	   */
+	  function PropTypeError(message) {
+	    this.message = message;
+	    this.stack = '';
+	  }
+	  // Make `instanceof Error` still work for returned errors.
+	  PropTypeError.prototype = Error.prototype;
+
+	  function createChainableTypeChecker(validate) {
+	    if (process.env.NODE_ENV !== 'production') {
+	      var manualPropTypeCallCache = {};
+	      var manualPropTypeWarningCount = 0;
+	    }
+	    function checkType(isRequired, props, propName, componentName, location, propFullName, secret) {
+	      componentName = componentName || ANONYMOUS;
+	      propFullName = propFullName || propName;
+
+	      if (secret !== ReactPropTypesSecret) {
+	        if (throwOnDirectAccess) {
+	          // New behavior only for users of `prop-types` package
+	          invariant(
+	            false,
+	            'Calling PropTypes validators directly is not supported by the `prop-types` package. ' +
+	            'Use `PropTypes.checkPropTypes()` to call them. ' +
+	            'Read more at http://fb.me/use-check-prop-types'
+	          );
+	        } else if (process.env.NODE_ENV !== 'production' && typeof console !== 'undefined') {
+	          // Old behavior for people using React.PropTypes
+	          var cacheKey = componentName + ':' + propName;
+	          if (
+	            !manualPropTypeCallCache[cacheKey] &&
+	            // Avoid spamming the console because they are often not actionable except for lib authors
+	            manualPropTypeWarningCount < 3
+	          ) {
+	            warning(
+	              false,
+	              'You are manually calling a React.PropTypes validation ' +
+	              'function for the `%s` prop on `%s`. This is deprecated ' +
+	              'and will throw in the standalone `prop-types` package. ' +
+	              'You may be seeing this warning due to a third-party PropTypes ' +
+	              'library. See https://fb.me/react-warning-dont-call-proptypes ' + 'for details.',
+	              propFullName,
+	              componentName
+	            );
+	            manualPropTypeCallCache[cacheKey] = true;
+	            manualPropTypeWarningCount++;
+	          }
+	        }
+	      }
+	      if (props[propName] == null) {
+	        if (isRequired) {
+	          if (props[propName] === null) {
+	            return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required ' + ('in `' + componentName + '`, but its value is `null`.'));
+	          }
+	          return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required in ' + ('`' + componentName + '`, but its value is `undefined`.'));
+	        }
+	        return null;
+	      } else {
+	        return validate(props, propName, componentName, location, propFullName);
+	      }
+	    }
+
+	    var chainedCheckType = checkType.bind(null, false);
+	    chainedCheckType.isRequired = checkType.bind(null, true);
+
+	    return chainedCheckType;
+	  }
+
+	  function createPrimitiveTypeChecker(expectedType) {
+	    function validate(props, propName, componentName, location, propFullName, secret) {
+	      var propValue = props[propName];
+	      var propType = getPropType(propValue);
+	      if (propType !== expectedType) {
+	        // `propValue` being instance of, say, date/regexp, pass the 'object'
+	        // check, but we can offer a more precise error message here rather than
+	        // 'of type `object`'.
+	        var preciseType = getPreciseType(propValue);
+
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + preciseType + '` supplied to `' + componentName + '`, expected ') + ('`' + expectedType + '`.'));
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createAnyTypeChecker() {
+	    return createChainableTypeChecker(emptyFunction.thatReturnsNull);
+	  }
+
+	  function createArrayOfTypeChecker(typeChecker) {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      if (typeof typeChecker !== 'function') {
+	        return new PropTypeError('Property `' + propFullName + '` of component `' + componentName + '` has invalid PropType notation inside arrayOf.');
+	      }
+	      var propValue = props[propName];
+	      if (!Array.isArray(propValue)) {
+	        var propType = getPropType(propValue);
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an array.'));
+	      }
+	      for (var i = 0; i < propValue.length; i++) {
+	        var error = typeChecker(propValue, i, componentName, location, propFullName + '[' + i + ']', ReactPropTypesSecret);
+	        if (error instanceof Error) {
+	          return error;
+	        }
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createElementTypeChecker() {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      var propValue = props[propName];
+	      if (!isValidElement(propValue)) {
+	        var propType = getPropType(propValue);
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected a single ReactElement.'));
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createInstanceTypeChecker(expectedClass) {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      if (!(props[propName] instanceof expectedClass)) {
+	        var expectedClassName = expectedClass.name || ANONYMOUS;
+	        var actualClassName = getClassName(props[propName]);
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + actualClassName + '` supplied to `' + componentName + '`, expected ') + ('instance of `' + expectedClassName + '`.'));
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createEnumTypeChecker(expectedValues) {
+	    if (!Array.isArray(expectedValues)) {
+	      process.env.NODE_ENV !== 'production' ? warning(false, 'Invalid argument supplied to oneOf, expected an instance of array.') : void 0;
+	      return emptyFunction.thatReturnsNull;
+	    }
+
+	    function validate(props, propName, componentName, location, propFullName) {
+	      var propValue = props[propName];
+	      for (var i = 0; i < expectedValues.length; i++) {
+	        if (is(propValue, expectedValues[i])) {
+	          return null;
+	        }
+	      }
+
+	      var valuesString = JSON.stringify(expectedValues);
+	      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of value `' + propValue + '` ' + ('supplied to `' + componentName + '`, expected one of ' + valuesString + '.'));
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createObjectOfTypeChecker(typeChecker) {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      if (typeof typeChecker !== 'function') {
+	        return new PropTypeError('Property `' + propFullName + '` of component `' + componentName + '` has invalid PropType notation inside objectOf.');
+	      }
+	      var propValue = props[propName];
+	      var propType = getPropType(propValue);
+	      if (propType !== 'object') {
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an object.'));
+	      }
+	      for (var key in propValue) {
+	        if (propValue.hasOwnProperty(key)) {
+	          var error = typeChecker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);
+	          if (error instanceof Error) {
+	            return error;
+	          }
+	        }
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createUnionTypeChecker(arrayOfTypeCheckers) {
+	    if (!Array.isArray(arrayOfTypeCheckers)) {
+	      process.env.NODE_ENV !== 'production' ? warning(false, 'Invalid argument supplied to oneOfType, expected an instance of array.') : void 0;
+	      return emptyFunction.thatReturnsNull;
+	    }
+
+	    for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
+	      var checker = arrayOfTypeCheckers[i];
+	      if (typeof checker !== 'function') {
+	        warning(
+	          false,
+	          'Invalid argument supplied to oneOfType. Expected an array of check functions, but ' +
+	          'received %s at index %s.',
+	          getPostfixForTypeWarning(checker),
+	          i
+	        );
+	        return emptyFunction.thatReturnsNull;
+	      }
+	    }
+
+	    function validate(props, propName, componentName, location, propFullName) {
+	      for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
+	        var checker = arrayOfTypeCheckers[i];
+	        if (checker(props, propName, componentName, location, propFullName, ReactPropTypesSecret) == null) {
+	          return null;
+	        }
+	      }
+
+	      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`.'));
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createNodeChecker() {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      if (!isNode(props[propName])) {
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`, expected a ReactNode.'));
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createShapeTypeChecker(shapeTypes) {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      var propValue = props[propName];
+	      var propType = getPropType(propValue);
+	      if (propType !== 'object') {
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
+	      }
+	      for (var key in shapeTypes) {
+	        var checker = shapeTypes[key];
+	        if (!checker) {
+	          continue;
+	        }
+	        var error = checker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);
+	        if (error) {
+	          return error;
+	        }
+	      }
+	      return null;
+	    }
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function createStrictShapeTypeChecker(shapeTypes) {
+	    function validate(props, propName, componentName, location, propFullName) {
+	      var propValue = props[propName];
+	      var propType = getPropType(propValue);
+	      if (propType !== 'object') {
+	        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
+	      }
+	      // We need to check all keys in case some are required but missing from
+	      // props.
+	      var allKeys = assign({}, props[propName], shapeTypes);
+	      for (var key in allKeys) {
+	        var checker = shapeTypes[key];
+	        if (!checker) {
+	          return new PropTypeError(
+	            'Invalid ' + location + ' `' + propFullName + '` key `' + key + '` supplied to `' + componentName + '`.' +
+	            '\nBad object: ' + JSON.stringify(props[propName], null, '  ') +
+	            '\nValid keys: ' +  JSON.stringify(Object.keys(shapeTypes), null, '  ')
+	          );
+	        }
+	        var error = checker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);
+	        if (error) {
+	          return error;
+	        }
+	      }
+	      return null;
+	    }
+
+	    return createChainableTypeChecker(validate);
+	  }
+
+	  function isNode(propValue) {
+	    switch (typeof propValue) {
+	      case 'number':
+	      case 'string':
+	      case 'undefined':
+	        return true;
+	      case 'boolean':
+	        return !propValue;
+	      case 'object':
+	        if (Array.isArray(propValue)) {
+	          return propValue.every(isNode);
+	        }
+	        if (propValue === null || isValidElement(propValue)) {
+	          return true;
+	        }
+
+	        var iteratorFn = getIteratorFn(propValue);
+	        if (iteratorFn) {
+	          var iterator = iteratorFn.call(propValue);
+	          var step;
+	          if (iteratorFn !== propValue.entries) {
+	            while (!(step = iterator.next()).done) {
+	              if (!isNode(step.value)) {
+	                return false;
+	              }
+	            }
+	          } else {
+	            // Iterator will provide entry [k,v] tuples rather than values.
+	            while (!(step = iterator.next()).done) {
+	              var entry = step.value;
+	              if (entry) {
+	                if (!isNode(entry[1])) {
+	                  return false;
+	                }
+	              }
+	            }
+	          }
+	        } else {
+	          return false;
+	        }
+
+	        return true;
+	      default:
+	        return false;
+	    }
+	  }
+
+	  function isSymbol(propType, propValue) {
+	    // Native Symbol.
+	    if (propType === 'symbol') {
+	      return true;
+	    }
+
+	    // 19.4.3.5 Symbol.prototype[@@toStringTag] === 'Symbol'
+	    if (propValue['@@toStringTag'] === 'Symbol') {
+	      return true;
+	    }
+
+	    // Fallback for non-spec compliant Symbols which are polyfilled.
+	    if (typeof Symbol === 'function' && propValue instanceof Symbol) {
+	      return true;
+	    }
+
+	    return false;
+	  }
+
+	  // Equivalent of `typeof` but with special handling for array and regexp.
+	  function getPropType(propValue) {
+	    var propType = typeof propValue;
+	    if (Array.isArray(propValue)) {
+	      return 'array';
+	    }
+	    if (propValue instanceof RegExp) {
+	      // Old webkits (at least until Android 4.0) return 'function' rather than
+	      // 'object' for typeof a RegExp. We'll normalize this here so that /bla/
+	      // passes PropTypes.object.
+	      return 'object';
+	    }
+	    if (isSymbol(propType, propValue)) {
+	      return 'symbol';
+	    }
+	    return propType;
+	  }
+
+	  // This handles more types than `getPropType`. Only used for error messages.
+	  // See `createPrimitiveTypeChecker`.
+	  function getPreciseType(propValue) {
+	    if (typeof propValue === 'undefined' || propValue === null) {
+	      return '' + propValue;
+	    }
+	    var propType = getPropType(propValue);
+	    if (propType === 'object') {
+	      if (propValue instanceof Date) {
+	        return 'date';
+	      } else if (propValue instanceof RegExp) {
+	        return 'regexp';
+	      }
+	    }
+	    return propType;
+	  }
+
+	  // Returns a string that is postfixed to a warning about an invalid type.
+	  // For example, "undefined" or "of type array"
+	  function getPostfixForTypeWarning(value) {
+	    var type = getPreciseType(value);
+	    switch (type) {
+	      case 'array':
+	      case 'object':
+	        return 'an ' + type;
+	      case 'boolean':
+	      case 'date':
+	      case 'regexp':
+	        return 'a ' + type;
+	      default:
+	        return type;
+	    }
+	  }
+
+	  // Returns class name of the object, if any.
+	  function getClassName(propValue) {
+	    if (!propValue.constructor || !propValue.constructor.name) {
+	      return ANONYMOUS;
+	    }
+	    return propValue.constructor.name;
+	  }
+
+	  ReactPropTypes.checkPropTypes = checkPropTypes;
+	  ReactPropTypes.PropTypes = ReactPropTypes;
+
+	  return ReactPropTypes;
+	};
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(4)))
+
+/***/ },
+/* 6 */
+/***/ function(module, exports) {
+
+	"use strict";
+
+	/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 *
+	 * 
+	 */
+
+	function makeEmptyFunction(arg) {
+	  return function () {
+	    return arg;
+	  };
+	}
+
+	/**
+	 * This function accepts and discards inputs; it has no side effects. This is
+	 * primarily useful idiomatically for overridable function endpoints which
+	 * always need to be callable, since JS lacks a null-call idiom ala Cocoa.
+	 */
+	var emptyFunction = function emptyFunction() {};
+
+	emptyFunction.thatReturns = makeEmptyFunction;
+	emptyFunction.thatReturnsFalse = makeEmptyFunction(false);
+	emptyFunction.thatReturnsTrue = makeEmptyFunction(true);
+	emptyFunction.thatReturnsNull = makeEmptyFunction(null);
+	emptyFunction.thatReturnsThis = function () {
+	  return this;
+	};
+	emptyFunction.thatReturnsArgument = function (arg) {
+	  return arg;
+	};
+
+	module.exports = emptyFunction;
+
+/***/ },
+/* 7 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(process) {/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 *
+	 */
+
+	'use strict';
+
+	/**
+	 * Use invariant() to assert state which your program assumes to be true.
+	 *
+	 * Provide sprintf-style format (only %s is supported) and arguments
+	 * to provide information about what broke and what you were
+	 * expecting.
+	 *
+	 * The invariant message will be stripped in production, but the invariant
+	 * will remain to ensure logic does not differ in production.
+	 */
+
+	var validateFormat = function validateFormat(format) {};
+
+	if (process.env.NODE_ENV !== 'production') {
+	  validateFormat = function validateFormat(format) {
+	    if (format === undefined) {
+	      throw new Error('invariant requires an error message argument');
+	    }
+	  };
+	}
+
+	function invariant(condition, format, a, b, c, d, e, f) {
+	  validateFormat(format);
+
+	  if (!condition) {
+	    var error;
+	    if (format === undefined) {
+	      error = new Error('Minified exception occurred; use the non-minified dev environment ' + 'for the full error message and additional helpful warnings.');
+	    } else {
+	      var args = [a, b, c, d, e, f];
+	      var argIndex = 0;
+	      error = new Error(format.replace(/%s/g, function () {
+	        return args[argIndex++];
+	      }));
+	      error.name = 'Invariant Violation';
+	    }
+
+	    error.framesToPop = 1; // we don't care about invariant's own frame
+	    throw error;
+	  }
+	}
+
+	module.exports = invariant;
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(4)))
+
+/***/ },
+/* 8 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(process) {/**
+	 * Copyright (c) 2014-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 *
+	 */
+
+	'use strict';
+
+	var emptyFunction = __webpack_require__(6);
+
+	/**
+	 * Similar to invariant but only logs a warning if the condition is not met.
+	 * This can be used to log issues in development environments in critical
+	 * paths. Removing the logging code for production environments will keep the
+	 * same logic and follow the same code paths.
+	 */
+
+	var warning = emptyFunction;
+
+	if (process.env.NODE_ENV !== 'production') {
+	  var printWarning = function printWarning(format) {
+	    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+	      args[_key - 1] = arguments[_key];
+	    }
+
+	    var argIndex = 0;
+	    var message = 'Warning: ' + format.replace(/%s/g, function () {
+	      return args[argIndex++];
+	    });
+	    if (typeof console !== 'undefined') {
+	      console.error(message);
+	    }
+	    try {
+	      // --- Welcome to debugging React ---
+	      // This error was thrown as a convenience so that you can use this stack
+	      // to find the callsite that caused this warning to fire.
+	      throw new Error(message);
+	    } catch (x) {}
+	  };
+
+	  warning = function warning(condition, format) {
+	    if (format === undefined) {
+	      throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
+	    }
+
+	    if (format.indexOf('Failed Composite propType: ') === 0) {
+	      return; // Ignore CompositeComponent proptype check.
+	    }
+
+	    if (!condition) {
+	      for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+	        args[_key2 - 2] = arguments[_key2];
+	      }
+
+	      printWarning.apply(undefined, [format].concat(args));
+	    }
+	  };
+	}
+
+	module.exports = warning;
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(4)))
+
+/***/ },
+/* 9 */
+/***/ function(module, exports) {
+
+	/*
+	object-assign
+	(c) Sindre Sorhus
+	@license MIT
+	*/
+
+	'use strict';
+	/* eslint-disable no-unused-vars */
+	var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+	var hasOwnProperty = Object.prototype.hasOwnProperty;
+	var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+	function toObject(val) {
+		if (val === null || val === undefined) {
+			throw new TypeError('Object.assign cannot be called with null or undefined');
+		}
+
+		return Object(val);
+	}
+
+	function shouldUseNative() {
+		try {
+			if (!Object.assign) {
+				return false;
+			}
+
+			// Detect buggy property enumeration order in older V8 versions.
+
+			// https://bugs.chromium.org/p/v8/issues/detail?id=4118
+			var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
+			test1[5] = 'de';
+			if (Object.getOwnPropertyNames(test1)[0] === '5') {
+				return false;
+			}
+
+			// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+			var test2 = {};
+			for (var i = 0; i < 10; i++) {
+				test2['_' + String.fromCharCode(i)] = i;
+			}
+			var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
+				return test2[n];
+			});
+			if (order2.join('') !== '0123456789') {
+				return false;
+			}
+
+			// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+			var test3 = {};
+			'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
+				test3[letter] = letter;
+			});
+			if (Object.keys(Object.assign({}, test3)).join('') !==
+					'abcdefghijklmnopqrst') {
+				return false;
+			}
+
+			return true;
+		} catch (err) {
+			// We don't expect any of the above to throw, but better to be safe.
+			return false;
+		}
+	}
+
+	module.exports = shouldUseNative() ? Object.assign : function (target, source) {
+		var from;
+		var to = toObject(target);
+		var symbols;
+
+		for (var s = 1; s < arguments.length; s++) {
+			from = Object(arguments[s]);
+
+			for (var key in from) {
+				if (hasOwnProperty.call(from, key)) {
+					to[key] = from[key];
+				}
+			}
+
+			if (getOwnPropertySymbols) {
+				symbols = getOwnPropertySymbols(from);
+				for (var i = 0; i < symbols.length; i++) {
+					if (propIsEnumerable.call(from, symbols[i])) {
+						to[symbols[i]] = from[symbols[i]];
+					}
+				}
+			}
+		}
+
+		return to;
+	};
+
+
+/***/ },
+/* 10 */
+/***/ function(module, exports) {
+
+	/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+
+	'use strict';
+
+	var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
+
+	module.exports = ReactPropTypesSecret;
+
+
+/***/ },
+/* 11 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(process) {/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+
+	'use strict';
+
+	if (process.env.NODE_ENV !== 'production') {
+	  var invariant = __webpack_require__(7);
+	  var warning = __webpack_require__(8);
+	  var ReactPropTypesSecret = __webpack_require__(10);
+	  var loggedTypeFailures = {};
+	}
+
+	/**
+	 * Assert that the values match with the type specs.
+	 * Error messages are memorized and will only be shown once.
+	 *
+	 * @param {object} typeSpecs Map of name to a ReactPropType
+	 * @param {object} values Runtime values that need to be type-checked
+	 * @param {string} location e.g. "prop", "context", "child context"
+	 * @param {string} componentName Name of the component for error messages.
+	 * @param {?Function} getStack Returns the component stack.
+	 * @private
+	 */
+	function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
+	  if (process.env.NODE_ENV !== 'production') {
+	    for (var typeSpecName in typeSpecs) {
+	      if (typeSpecs.hasOwnProperty(typeSpecName)) {
+	        var error;
+	        // Prop type validation may throw. In case they do, we don't want to
+	        // fail the render phase where it didn't fail before. So we log it.
+	        // After these have been cleaned up, we'll let them throw.
+	        try {
+	          // This is intentionally an invariant that gets caught. It's the same
+	          // behavior as without this statement except with a better message.
+	          invariant(typeof typeSpecs[typeSpecName] === 'function', '%s: %s type `%s` is invalid; it must be a function, usually from ' + 'the `prop-types` package, but received `%s`.', componentName || 'React class', location, typeSpecName, typeof typeSpecs[typeSpecName]);
+	          error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
+	        } catch (ex) {
+	          error = ex;
+	        }
+	        warning(!error || error instanceof Error, '%s: type specification of %s `%s` is invalid; the type checker ' + 'function must return `null` or an `Error` but returned a %s. ' + 'You may have forgotten to pass an argument to the type checker ' + 'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' + 'shape all require an argument).', componentName || 'React class', location, typeSpecName, typeof error);
+	        if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+	          // Only monitor this failure once because there tends to be a lot of the
+	          // same error.
+	          loggedTypeFailures[error.message] = true;
+
+	          var stack = getStack ? getStack() : '';
+
+	          warning(false, 'Failed %s type: %s%s', location, error.message, stack != null ? stack : '');
+	        }
+	      }
+	    }
+	  }
+	}
+
+	module.exports = checkPropTypes;
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(4)))
+
+/***/ },
+/* 12 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+
+	'use strict';
+
+	var emptyFunction = __webpack_require__(6);
+	var invariant = __webpack_require__(7);
+	var ReactPropTypesSecret = __webpack_require__(10);
+
+	module.exports = function() {
+	  function shim(props, propName, componentName, location, propFullName, secret) {
+	    if (secret === ReactPropTypesSecret) {
+	      // It is still safe when called from React.
+	      return;
+	    }
+	    invariant(
+	      false,
+	      'Calling PropTypes validators directly is not supported by the `prop-types` package. ' +
+	      'Use PropTypes.checkPropTypes() to call them. ' +
+	      'Read more at http://fb.me/use-check-prop-types'
+	    );
+	  };
+	  shim.isRequired = shim;
+	  function getShim() {
+	    return shim;
+	  };
+	  // Important!
+	  // Keep this list in sync with production version in `./factoryWithTypeCheckers.js`.
+	  var ReactPropTypes = {
+	    array: shim,
+	    bool: shim,
+	    func: shim,
+	    number: shim,
+	    object: shim,
+	    string: shim,
+	    symbol: shim,
+
+	    any: shim,
+	    arrayOf: getShim,
+	    element: shim,
+	    instanceOf: getShim,
+	    node: shim,
+	    objectOf: getShim,
+	    oneOf: getShim,
+	    oneOfType: getShim,
+	    shape: getShim,
+	    exact: getShim
+	  };
+
+	  ReactPropTypes.checkPropTypes = emptyFunction;
+	  ReactPropTypes.PropTypes = ReactPropTypes;
+
+	  return ReactPropTypes;
+	};
+
+
+/***/ },
+/* 13 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 *
+	 */
+
+	'use strict';
+
+	var React = __webpack_require__(2);
+	var factory = __webpack_require__(14);
+
+	if (typeof React === 'undefined') {
+	  throw Error(
+	    'create-react-class could not find the React object. If you are using script tags, ' +
+	      'make sure that React is being loaded before create-react-class.'
+	  );
+	}
+
+	// Hack to grab NoopUpdateQueue from isomorphic React
+	var ReactNoopUpdateQueue = new React.Component().updater;
+
+	module.exports = factory(
+	  React.Component,
+	  React.isValidElement,
+	  ReactNoopUpdateQueue
+	);
+
+
+/***/ },
+/* 14 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(process) {/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 *
+	 */
+
+	'use strict';
+
+	var _assign = __webpack_require__(9);
+
+	var emptyObject = __webpack_require__(15);
+	var _invariant = __webpack_require__(7);
+
+	if (process.env.NODE_ENV !== 'production') {
+	  var warning = __webpack_require__(8);
+	}
+
+	var MIXINS_KEY = 'mixins';
+
+	// Helper function to allow the creation of anonymous functions which do not
+	// have .name set to the name of the variable being assigned to.
+	function identity(fn) {
+	  return fn;
+	}
+
+	var ReactPropTypeLocationNames;
+	if (process.env.NODE_ENV !== 'production') {
+	  ReactPropTypeLocationNames = {
+	    prop: 'prop',
+	    context: 'context',
+	    childContext: 'child context'
+	  };
+	} else {
+	  ReactPropTypeLocationNames = {};
+	}
+
+	function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
+	  /**
+	   * Policies that describe methods in `ReactClassInterface`.
+	   */
+
+	  var injectedMixins = [];
+
+	  /**
+	   * Composite components are higher-level components that compose other composite
+	   * or host components.
+	   *
+	   * To create a new type of `ReactClass`, pass a specification of
+	   * your new class to `React.createClass`. The only requirement of your class
+	   * specification is that you implement a `render` method.
+	   *
+	   *   var MyComponent = React.createClass({
+	   *     render: function() {
+	   *       return <div>Hello World</div>;
+	   *     }
+	   *   });
+	   *
+	   * The class specification supports a specific protocol of methods that have
+	   * special meaning (e.g. `render`). See `ReactClassInterface` for
+	   * more the comprehensive protocol. Any other properties and methods in the
+	   * class specification will be available on the prototype.
+	   *
+	   * @interface ReactClassInterface
+	   * @internal
+	   */
+	  var ReactClassInterface = {
+	    /**
+	     * An array of Mixin objects to include when defining your component.
+	     *
+	     * @type {array}
+	     * @optional
+	     */
+	    mixins: 'DEFINE_MANY',
+
+	    /**
+	     * An object containing properties and methods that should be defined on
+	     * the component's constructor instead of its prototype (static methods).
+	     *
+	     * @type {object}
+	     * @optional
+	     */
+	    statics: 'DEFINE_MANY',
+
+	    /**
+	     * Definition of prop types for this component.
+	     *
+	     * @type {object}
+	     * @optional
+	     */
+	    propTypes: 'DEFINE_MANY',
+
+	    /**
+	     * Definition of context types for this component.
+	     *
+	     * @type {object}
+	     * @optional
+	     */
+	    contextTypes: 'DEFINE_MANY',
+
+	    /**
+	     * Definition of context types this component sets for its children.
+	     *
+	     * @type {object}
+	     * @optional
+	     */
+	    childContextTypes: 'DEFINE_MANY',
+
+	    // ==== Definition methods ====
+
+	    /**
+	     * Invoked when the component is mounted. Values in the mapping will be set on
+	     * `this.props` if that prop is not specified (i.e. using an `in` check).
+	     *
+	     * This method is invoked before `getInitialState` and therefore cannot rely
+	     * on `this.state` or use `this.setState`.
+	     *
+	     * @return {object}
+	     * @optional
+	     */
+	    getDefaultProps: 'DEFINE_MANY_MERGED',
+
+	    /**
+	     * Invoked once before the component is mounted. The return value will be used
+	     * as the initial value of `this.state`.
+	     *
+	     *   getInitialState: function() {
+	     *     return {
+	     *       isOn: false,
+	     *       fooBaz: new BazFoo()
+	     *     }
+	     *   }
+	     *
+	     * @return {object}
+	     * @optional
+	     */
+	    getInitialState: 'DEFINE_MANY_MERGED',
+
+	    /**
+	     * @return {object}
+	     * @optional
+	     */
+	    getChildContext: 'DEFINE_MANY_MERGED',
+
+	    /**
+	     * Uses props from `this.props` and state from `this.state` to render the
+	     * structure of the component.
+	     *
+	     * No guarantees are made about when or how often this method is invoked, so
+	     * it must not have side effects.
+	     *
+	     *   render: function() {
+	     *     var name = this.props.name;
+	     *     return <div>Hello, {name}!</div>;
+	     *   }
+	     *
+	     * @return {ReactComponent}
+	     * @required
+	     */
+	    render: 'DEFINE_ONCE',
+
+	    // ==== Delegate methods ====
+
+	    /**
+	     * Invoked when the component is initially created and about to be mounted.
+	     * This may have side effects, but any external subscriptions or data created
+	     * by this method must be cleaned up in `componentWillUnmount`.
+	     *
+	     * @optional
+	     */
+	    componentWillMount: 'DEFINE_MANY',
+
+	    /**
+	     * Invoked when the component has been mounted and has a DOM representation.
+	     * However, there is no guarantee that the DOM node is in the document.
+	     *
+	     * Use this as an opportunity to operate on the DOM when the component has
+	     * been mounted (initialized and rendered) for the first time.
+	     *
+	     * @param {DOMElement} rootNode DOM element representing the component.
+	     * @optional
+	     */
+	    componentDidMount: 'DEFINE_MANY',
+
+	    /**
+	     * Invoked before the component receives new props.
+	     *
+	     * Use this as an opportunity to react to a prop transition by updating the
+	     * state using `this.setState`. Current props are accessed via `this.props`.
+	     *
+	     *   componentWillReceiveProps: function(nextProps, nextContext) {
+	     *     this.setState({
+	     *       likesIncreasing: nextProps.likeCount > this.props.likeCount
+	     *     });
+	     *   }
+	     *
+	     * NOTE: There is no equivalent `componentWillReceiveState`. An incoming prop
+	     * transition may cause a state change, but the opposite is not true. If you
+	     * need it, you are probably looking for `componentWillUpdate`.
+	     *
+	     * @param {object} nextProps
+	     * @optional
+	     */
+	    componentWillReceiveProps: 'DEFINE_MANY',
+
+	    /**
+	     * Invoked while deciding if the component should be updated as a result of
+	     * receiving new props, state and/or context.
+	     *
+	     * Use this as an opportunity to `return false` when you're certain that the
+	     * transition to the new props/state/context will not require a component
+	     * update.
+	     *
+	     *   shouldComponentUpdate: function(nextProps, nextState, nextContext) {
+	     *     return !equal(nextProps, this.props) ||
+	     *       !equal(nextState, this.state) ||
+	     *       !equal(nextContext, this.context);
+	     *   }
+	     *
+	     * @param {object} nextProps
+	     * @param {?object} nextState
+	     * @param {?object} nextContext
+	     * @return {boolean} True if the component should update.
+	     * @optional
+	     */
+	    shouldComponentUpdate: 'DEFINE_ONCE',
+
+	    /**
+	     * Invoked when the component is about to update due to a transition from
+	     * `this.props`, `this.state` and `this.context` to `nextProps`, `nextState`
+	     * and `nextContext`.
+	     *
+	     * Use this as an opportunity to perform preparation before an update occurs.
+	     *
+	     * NOTE: You **cannot** use `this.setState()` in this method.
+	     *
+	     * @param {object} nextProps
+	     * @param {?object} nextState
+	     * @param {?object} nextContext
+	     * @param {ReactReconcileTransaction} transaction
+	     * @optional
+	     */
+	    componentWillUpdate: 'DEFINE_MANY',
+
+	    /**
+	     * Invoked when the component's DOM representation has been updated.
+	     *
+	     * Use this as an opportunity to operate on the DOM when the component has
+	     * been updated.
+	     *
+	     * @param {object} prevProps
+	     * @param {?object} prevState
+	     * @param {?object} prevContext
+	     * @param {DOMElement} rootNode DOM element representing the component.
+	     * @optional
+	     */
+	    componentDidUpdate: 'DEFINE_MANY',
+
+	    /**
+	     * Invoked when the component is about to be removed from its parent and have
+	     * its DOM representation destroyed.
+	     *
+	     * Use this as an opportunity to deallocate any external resources.
+	     *
+	     * NOTE: There is no `componentDidUnmount` since your component will have been
+	     * destroyed by that point.
+	     *
+	     * @optional
+	     */
+	    componentWillUnmount: 'DEFINE_MANY',
+
+	    // ==== Advanced methods ====
+
+	    /**
+	     * Updates the component's currently mounted DOM representation.
+	     *
+	     * By default, this implements React's rendering and reconciliation algorithm.
+	     * Sophisticated clients may wish to override this.
+	     *
+	     * @param {ReactReconcileTransaction} transaction
+	     * @internal
+	     * @overridable
+	     */
+	    updateComponent: 'OVERRIDE_BASE'
+	  };
+
+	  /**
+	   * Mapping from class specification keys to special processing functions.
+	   *
+	   * Although these are declared like instance properties in the specification
+	   * when defining classes using `React.createClass`, they are actually static
+	   * and are accessible on the constructor instead of the prototype. Despite
+	   * being static, they must be defined outside of the "statics" key under
+	   * which all other static methods are defined.
+	   */
+	  var RESERVED_SPEC_KEYS = {
+	    displayName: function(Constructor, displayName) {
+	      Constructor.displayName = displayName;
+	    },
+	    mixins: function(Constructor, mixins) {
+	      if (mixins) {
+	        for (var i = 0; i < mixins.length; i++) {
+	          mixSpecIntoComponent(Constructor, mixins[i]);
+	        }
+	      }
+	    },
+	    childContextTypes: function(Constructor, childContextTypes) {
+	      if (process.env.NODE_ENV !== 'production') {
+	        validateTypeDef(Constructor, childContextTypes, 'childContext');
+	      }
+	      Constructor.childContextTypes = _assign(
+	        {},
+	        Constructor.childContextTypes,
+	        childContextTypes
+	      );
+	    },
+	    contextTypes: function(Constructor, contextTypes) {
+	      if (process.env.NODE_ENV !== 'production') {
+	        validateTypeDef(Constructor, contextTypes, 'context');
+	      }
+	      Constructor.contextTypes = _assign(
+	        {},
+	        Constructor.contextTypes,
+	        contextTypes
+	      );
+	    },
+	    /**
+	     * Special case getDefaultProps which should move into statics but requires
+	     * automatic merging.
+	     */
+	    getDefaultProps: function(Constructor, getDefaultProps) {
+	      if (Constructor.getDefaultProps) {
+	        Constructor.getDefaultProps = createMergedResultFunction(
+	          Constructor.getDefaultProps,
+	          getDefaultProps
+	        );
+	      } else {
+	        Constructor.getDefaultProps = getDefaultProps;
+	      }
+	    },
+	    propTypes: function(Constructor, propTypes) {
+	      if (process.env.NODE_ENV !== 'production') {
+	        validateTypeDef(Constructor, propTypes, 'prop');
+	      }
+	      Constructor.propTypes = _assign({}, Constructor.propTypes, propTypes);
+	    },
+	    statics: function(Constructor, statics) {
+	      mixStaticSpecIntoComponent(Constructor, statics);
+	    },
+	    autobind: function() {}
+	  };
+
+	  function validateTypeDef(Constructor, typeDef, location) {
+	    for (var propName in typeDef) {
+	      if (typeDef.hasOwnProperty(propName)) {
+	        // use a warning instead of an _invariant so components
+	        // don't show up in prod but only in __DEV__
+	        if (process.env.NODE_ENV !== 'production') {
+	          warning(
+	            typeof typeDef[propName] === 'function',
+	            '%s: %s type `%s` is invalid; it must be a function, usually from ' +
+	              'React.PropTypes.',
+	            Constructor.displayName || 'ReactClass',
+	            ReactPropTypeLocationNames[location],
+	            propName
+	          );
+	        }
+	      }
+	    }
+	  }
+
+	  function validateMethodOverride(isAlreadyDefined, name) {
+	    var specPolicy = ReactClassInterface.hasOwnProperty(name)
+	      ? ReactClassInterface[name]
+	      : null;
+
+	    // Disallow overriding of base class methods unless explicitly allowed.
+	    if (ReactClassMixin.hasOwnProperty(name)) {
+	      _invariant(
+	        specPolicy === 'OVERRIDE_BASE',
+	        'ReactClassInterface: You are attempting to override ' +
+	          '`%s` from your class specification. Ensure that your method names ' +
+	          'do not overlap with React methods.',
+	        name
+	      );
+	    }
+
+	    // Disallow defining methods more than once unless explicitly allowed.
+	    if (isAlreadyDefined) {
+	      _invariant(
+	        specPolicy === 'DEFINE_MANY' || specPolicy === 'DEFINE_MANY_MERGED',
+	        'ReactClassInterface: You are attempting to define ' +
+	          '`%s` on your component more than once. This conflict may be due ' +
+	          'to a mixin.',
+	        name
+	      );
+	    }
+	  }
+
+	  /**
+	   * Mixin helper which handles policy validation and reserved
+	   * specification keys when building React classes.
+	   */
+	  function mixSpecIntoComponent(Constructor, spec) {
+	    if (!spec) {
+	      if (process.env.NODE_ENV !== 'production') {
+	        var typeofSpec = typeof spec;
+	        var isMixinValid = typeofSpec === 'object' && spec !== null;
+
+	        if (process.env.NODE_ENV !== 'production') {
+	          warning(
+	            isMixinValid,
+	            "%s: You're attempting to include a mixin that is either null " +
+	              'or not an object. Check the mixins included by the component, ' +
+	              'as well as any mixins they include themselves. ' +
+	              'Expected object but got %s.',
+	            Constructor.displayName || 'ReactClass',
+	            spec === null ? null : typeofSpec
+	          );
+	        }
+	      }
+
+	      return;
+	    }
+
+	    _invariant(
+	      typeof spec !== 'function',
+	      "ReactClass: You're attempting to " +
+	        'use a component class or function as a mixin. Instead, just use a ' +
+	        'regular object.'
+	    );
+	    _invariant(
+	      !isValidElement(spec),
+	      "ReactClass: You're attempting to " +
+	        'use a component as a mixin. Instead, just use a regular object.'
+	    );
+
+	    var proto = Constructor.prototype;
+	    var autoBindPairs = proto.__reactAutoBindPairs;
+
+	    // By handling mixins before any other properties, we ensure the same
+	    // chaining order is applied to methods with DEFINE_MANY policy, whether
+	    // mixins are listed before or after these methods in the spec.
+	    if (spec.hasOwnProperty(MIXINS_KEY)) {
+	      RESERVED_SPEC_KEYS.mixins(Constructor, spec.mixins);
+	    }
+
+	    for (var name in spec) {
+	      if (!spec.hasOwnProperty(name)) {
+	        continue;
+	      }
+
+	      if (name === MIXINS_KEY) {
+	        // We have already handled mixins in a special case above.
+	        continue;
+	      }
+
+	      var property = spec[name];
+	      var isAlreadyDefined = proto.hasOwnProperty(name);
+	      validateMethodOverride(isAlreadyDefined, name);
+
+	      if (RESERVED_SPEC_KEYS.hasOwnProperty(name)) {
+	        RESERVED_SPEC_KEYS[name](Constructor, property);
+	      } else {
+	        // Setup methods on prototype:
+	        // The following member methods should not be automatically bound:
+	        // 1. Expected ReactClass methods (in the "interface").
+	        // 2. Overridden methods (that were mixed in).
+	        var isReactClassMethod = ReactClassInterface.hasOwnProperty(name);
+	        var isFunction = typeof property === 'function';
+	        var shouldAutoBind =
+	          isFunction &&
+	          !isReactClassMethod &&
+	          !isAlreadyDefined &&
+	          spec.autobind !== false;
+
+	        if (shouldAutoBind) {
+	          autoBindPairs.push(name, property);
+	          proto[name] = property;
+	        } else {
+	          if (isAlreadyDefined) {
+	            var specPolicy = ReactClassInterface[name];
+
+	            // These cases should already be caught by validateMethodOverride.
+	            _invariant(
+	              isReactClassMethod &&
+	                (specPolicy === 'DEFINE_MANY_MERGED' ||
+	                  specPolicy === 'DEFINE_MANY'),
+	              'ReactClass: Unexpected spec policy %s for key %s ' +
+	                'when mixing in component specs.',
+	              specPolicy,
+	              name
+	            );
+
+	            // For methods which are defined more than once, call the existing
+	            // methods before calling the new property, merging if appropriate.
+	            if (specPolicy === 'DEFINE_MANY_MERGED') {
+	              proto[name] = createMergedResultFunction(proto[name], property);
+	            } else if (specPolicy === 'DEFINE_MANY') {
+	              proto[name] = createChainedFunction(proto[name], property);
+	            }
+	          } else {
+	            proto[name] = property;
+	            if (process.env.NODE_ENV !== 'production') {
+	              // Add verbose displayName to the function, which helps when looking
+	              // at profiling tools.
+	              if (typeof property === 'function' && spec.displayName) {
+	                proto[name].displayName = spec.displayName + '_' + name;
+	              }
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+
+	  function mixStaticSpecIntoComponent(Constructor, statics) {
+	    if (!statics) {
+	      return;
+	    }
+	    for (var name in statics) {
+	      var property = statics[name];
+	      if (!statics.hasOwnProperty(name)) {
+	        continue;
+	      }
+
+	      var isReserved = name in RESERVED_SPEC_KEYS;
+	      _invariant(
+	        !isReserved,
+	        'ReactClass: You are attempting to define a reserved ' +
+	          'property, `%s`, that shouldn\'t be on the "statics" key. Define it ' +
+	          'as an instance property instead; it will still be accessible on the ' +
+	          'constructor.',
+	        name
+	      );
+
+	      var isInherited = name in Constructor;
+	      _invariant(
+	        !isInherited,
+	        'ReactClass: You are attempting to define ' +
+	          '`%s` on your component more than once. This conflict may be ' +
+	          'due to a mixin.',
+	        name
+	      );
+	      Constructor[name] = property;
+	    }
+	  }
+
+	  /**
+	   * Merge two objects, but throw if both contain the same key.
+	   *
+	   * @param {object} one The first object, which is mutated.
+	   * @param {object} two The second object
+	   * @return {object} one after it has been mutated to contain everything in two.
+	   */
+	  function mergeIntoWithNoDuplicateKeys(one, two) {
+	    _invariant(
+	      one && two && typeof one === 'object' && typeof two === 'object',
+	      'mergeIntoWithNoDuplicateKeys(): Cannot merge non-objects.'
+	    );
+
+	    for (var key in two) {
+	      if (two.hasOwnProperty(key)) {
+	        _invariant(
+	          one[key] === undefined,
+	          'mergeIntoWithNoDuplicateKeys(): ' +
+	            'Tried to merge two objects with the same key: `%s`. This conflict ' +
+	            'may be due to a mixin; in particular, this may be caused by two ' +
+	            'getInitialState() or getDefaultProps() methods returning objects ' +
+	            'with clashing keys.',
+	          key
+	        );
+	        one[key] = two[key];
+	      }
+	    }
+	    return one;
+	  }
+
+	  /**
+	   * Creates a function that invokes two functions and merges their return values.
+	   *
+	   * @param {function} one Function to invoke first.
+	   * @param {function} two Function to invoke second.
+	   * @return {function} Function that invokes the two argument functions.
+	   * @private
+	   */
+	  function createMergedResultFunction(one, two) {
+	    return function mergedResult() {
+	      var a = one.apply(this, arguments);
+	      var b = two.apply(this, arguments);
+	      if (a == null) {
+	        return b;
+	      } else if (b == null) {
+	        return a;
+	      }
+	      var c = {};
+	      mergeIntoWithNoDuplicateKeys(c, a);
+	      mergeIntoWithNoDuplicateKeys(c, b);
+	      return c;
+	    };
+	  }
+
+	  /**
+	   * Creates a function that invokes two functions and ignores their return vales.
+	   *
+	   * @param {function} one Function to invoke first.
+	   * @param {function} two Function to invoke second.
+	   * @return {function} Function that invokes the two argument functions.
+	   * @private
+	   */
+	  function createChainedFunction(one, two) {
+	    return function chainedFunction() {
+	      one.apply(this, arguments);
+	      two.apply(this, arguments);
+	    };
+	  }
+
+	  /**
+	   * Binds a method to the component.
+	   *
+	   * @param {object} component Component whose method is going to be bound.
+	   * @param {function} method Method to be bound.
+	   * @return {function} The bound method.
+	   */
+	  function bindAutoBindMethod(component, method) {
+	    var boundMethod = method.bind(component);
+	    if (process.env.NODE_ENV !== 'production') {
+	      boundMethod.__reactBoundContext = component;
+	      boundMethod.__reactBoundMethod = method;
+	      boundMethod.__reactBoundArguments = null;
+	      var componentName = component.constructor.displayName;
+	      var _bind = boundMethod.bind;
+	      boundMethod.bind = function(newThis) {
+	        for (
+	          var _len = arguments.length,
+	            args = Array(_len > 1 ? _len - 1 : 0),
+	            _key = 1;
+	          _key < _len;
+	          _key++
+	        ) {
+	          args[_key - 1] = arguments[_key];
+	        }
+
+	        // User is trying to bind() an autobound method; we effectively will
+	        // ignore the value of "this" that the user is trying to use, so
+	        // let's warn.
+	        if (newThis !== component && newThis !== null) {
+	          if (process.env.NODE_ENV !== 'production') {
+	            warning(
+	              false,
+	              'bind(): React component methods may only be bound to the ' +
+	                'component instance. See %s',
+	              componentName
+	            );
+	          }
+	        } else if (!args.length) {
+	          if (process.env.NODE_ENV !== 'production') {
+	            warning(
+	              false,
+	              'bind(): You are binding a component method to the component. ' +
+	                'React does this for you automatically in a high-performance ' +
+	                'way, so you can safely remove this call. See %s',
+	              componentName
+	            );
+	          }
+	          return boundMethod;
+	        }
+	        var reboundMethod = _bind.apply(boundMethod, arguments);
+	        reboundMethod.__reactBoundContext = component;
+	        reboundMethod.__reactBoundMethod = method;
+	        reboundMethod.__reactBoundArguments = args;
+	        return reboundMethod;
+	      };
+	    }
+	    return boundMethod;
+	  }
+
+	  /**
+	   * Binds all auto-bound methods in a component.
+	   *
+	   * @param {object} component Component whose method is going to be bound.
+	   */
+	  function bindAutoBindMethods(component) {
+	    var pairs = component.__reactAutoBindPairs;
+	    for (var i = 0; i < pairs.length; i += 2) {
+	      var autoBindKey = pairs[i];
+	      var method = pairs[i + 1];
+	      component[autoBindKey] = bindAutoBindMethod(component, method);
+	    }
+	  }
+
+	  var IsMountedPreMixin = {
+	    componentDidMount: function() {
+	      this.__isMounted = true;
+	    }
+	  };
+
+	  var IsMountedPostMixin = {
+	    componentWillUnmount: function() {
+	      this.__isMounted = false;
+	    }
+	  };
+
+	  /**
+	   * Add more to the ReactClass base class. These are all legacy features and
+	   * therefore not already part of the modern ReactComponent.
+	   */
+	  var ReactClassMixin = {
+	    /**
+	     * TODO: This will be deprecated because state should always keep a consistent
+	     * type signature and the only use case for this, is to avoid that.
+	     */
+	    replaceState: function(newState, callback) {
+	      this.updater.enqueueReplaceState(this, newState, callback);
+	    },
+
+	    /**
+	     * Checks whether or not this composite component is mounted.
+	     * @return {boolean} True if mounted, false otherwise.
+	     * @protected
+	     * @final
+	     */
+	    isMounted: function() {
+	      if (process.env.NODE_ENV !== 'production') {
+	        warning(
+	          this.__didWarnIsMounted,
+	          '%s: isMounted is deprecated. Instead, make sure to clean up ' +
+	            'subscriptions and pending requests in componentWillUnmount to ' +
+	            'prevent memory leaks.',
+	          (this.constructor && this.constructor.displayName) ||
+	            this.name ||
+	            'Component'
+	        );
+	        this.__didWarnIsMounted = true;
+	      }
+	      return !!this.__isMounted;
+	    }
+	  };
+
+	  var ReactClassComponent = function() {};
+	  _assign(
+	    ReactClassComponent.prototype,
+	    ReactComponent.prototype,
+	    ReactClassMixin
+	  );
+
+	  /**
+	   * Creates a composite component class given a class specification.
+	   * See https://facebook.github.io/react/docs/top-level-api.html#react.createclass
+	   *
+	   * @param {object} spec Class specification (which must define `render`).
+	   * @return {function} Component constructor function.
+	   * @public
+	   */
+	  function createClass(spec) {
+	    // To keep our warnings more understandable, we'll use a little hack here to
+	    // ensure that Constructor.name !== 'Constructor'. This makes sure we don't
+	    // unnecessarily identify a class without displayName as 'Constructor'.
+	    var Constructor = identity(function(props, context, updater) {
+	      // This constructor gets overridden by mocks. The argument is used
+	      // by mocks to assert on what gets mounted.
+
+	      if (process.env.NODE_ENV !== 'production') {
+	        warning(
+	          this instanceof Constructor,
+	          'Something is calling a React component directly. Use a factory or ' +
+	            'JSX instead. See: https://fb.me/react-legacyfactory'
+	        );
+	      }
+
+	      // Wire up auto-binding
+	      if (this.__reactAutoBindPairs.length) {
+	        bindAutoBindMethods(this);
+	      }
+
+	      this.props = props;
+	      this.context = context;
+	      this.refs = emptyObject;
+	      this.updater = updater || ReactNoopUpdateQueue;
+
+	      this.state = null;
+
+	      // ReactClasses doesn't have constructors. Instead, they use the
+	      // getInitialState and componentWillMount methods for initialization.
+
+	      var initialState = this.getInitialState ? this.getInitialState() : null;
+	      if (process.env.NODE_ENV !== 'production') {
+	        // We allow auto-mocks to proceed as if they're returning null.
+	        if (
+	          initialState === undefined &&
+	          this.getInitialState._isMockFunction
+	        ) {
+	          // This is probably bad practice. Consider warning here and
+	          // deprecating this convenience.
+	          initialState = null;
+	        }
+	      }
+	      _invariant(
+	        typeof initialState === 'object' && !Array.isArray(initialState),
+	        '%s.getInitialState(): must return an object or null',
+	        Constructor.displayName || 'ReactCompositeComponent'
+	      );
+
+	      this.state = initialState;
+	    });
+	    Constructor.prototype = new ReactClassComponent();
+	    Constructor.prototype.constructor = Constructor;
+	    Constructor.prototype.__reactAutoBindPairs = [];
+
+	    injectedMixins.forEach(mixSpecIntoComponent.bind(null, Constructor));
+
+	    mixSpecIntoComponent(Constructor, IsMountedPreMixin);
+	    mixSpecIntoComponent(Constructor, spec);
+	    mixSpecIntoComponent(Constructor, IsMountedPostMixin);
+
+	    // Initialize the defaultProps property after all mixins have been merged.
+	    if (Constructor.getDefaultProps) {
+	      Constructor.defaultProps = Constructor.getDefaultProps();
+	    }
+
+	    if (process.env.NODE_ENV !== 'production') {
+	      // This is a tag to indicate that the use of these method names is ok,
+	      // since it's used with createClass. If it's not, then it's likely a
+	      // mistake so we'll warn you to use the static property, property
+	      // initializer or constructor respectively.
+	      if (Constructor.getDefaultProps) {
+	        Constructor.getDefaultProps.isReactClassApproved = {};
+	      }
+	      if (Constructor.prototype.getInitialState) {
+	        Constructor.prototype.getInitialState.isReactClassApproved = {};
+	      }
+	    }
+
+	    _invariant(
+	      Constructor.prototype.render,
+	      'createClass(...): Class specification must implement a `render` method.'
+	    );
+
+	    if (process.env.NODE_ENV !== 'production') {
+	      warning(
+	        !Constructor.prototype.componentShouldUpdate,
+	        '%s has a method called ' +
+	          'componentShouldUpdate(). Did you mean shouldComponentUpdate()? ' +
+	          'The name is phrased as a question because the function is ' +
+	          'expected to return a value.',
+	        spec.displayName || 'A component'
+	      );
+	      warning(
+	        !Constructor.prototype.componentWillRecieveProps,
+	        '%s has a method called ' +
+	          'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
+	        spec.displayName || 'A component'
+	      );
+	    }
+
+	    // Reduce time spent doing lookups by setting these on the prototype.
+	    for (var methodName in ReactClassInterface) {
+	      if (!Constructor.prototype[methodName]) {
+	        Constructor.prototype[methodName] = null;
+	      }
+	    }
+
+	    return Constructor;
+	  }
+
+	  return createClass;
+	}
+
+	module.exports = factory;
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(4)))
+
+/***/ },
+/* 15 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(process) {/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 *
+	 */
+
+	'use strict';
+
+	var emptyObject = {};
+
+	if (process.env.NODE_ENV !== 'production') {
+	  Object.freeze(emptyObject);
+	}
+
+	module.exports = emptyObject;
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(4)))
+
+/***/ },
+/* 16 */
+/***/ function(module, exports, __webpack_require__) {
+
 	/*
 	   See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 	*/
 	'use strict';
 
 	var React = __webpack_require__(2);
-	var GridTitle = __webpack_require__(4);
-	var GridRowContainer = __webpack_require__(166);
-	var ColumnProperties = __webpack_require__(5);
-	var RowProperties = __webpack_require__(173);
+	var createReactClass = __webpack_require__(13);
+	var GridTitle = __webpack_require__(17);
+	var GridRowContainer = __webpack_require__(179);
+	var ColumnProperties = __webpack_require__(18);
+	var RowProperties = __webpack_require__(186);
 
-	var GridTable = React.createClass({
-	  displayName: 'GridTable',
-
+	var GridTable = createReactClass({
 	  getDefaultProps: function getDefaultProps() {
 	    return {
 	      "data": [],
@@ -1320,7 +3439,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = GridTable;
 
 /***/ },
-/* 4 */
+/* 17 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -1339,20 +3458,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 	var React = __webpack_require__(2);
-	var ColumnProperties = __webpack_require__(5);
-	var assign = __webpack_require__(161);
+	var createReactClass = __webpack_require__(13);
+	var ColumnProperties = __webpack_require__(18);
+	var assign = __webpack_require__(174);
 
-	var DefaultHeaderComponent = React.createClass({
-	    displayName: 'DefaultHeaderComponent',
-
+	var DefaultHeaderComponent = createReactClass({
 	    render: function render() {
 	        return React.createElement('span', null, this.props.displayName);
 	    }
 	});
 
-	var GridTitle = React.createClass({
-	    displayName: 'GridTitle',
-
+	var GridTitle = createReactClass({
 	    getDefaultProps: function getDefaultProps() {
 	        return {
 	            "columnSettings": null,
@@ -1455,7 +3571,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = GridTitle;
 
 /***/ },
-/* 5 */
+/* 18 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1464,11 +3580,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-	var map = __webpack_require__(6);
-	var filter = __webpack_require__(128);
-	var find = __webpack_require__(130);
-	var sortBy = __webpack_require__(137);
-	var difference = __webpack_require__(153);
+	var map = __webpack_require__(19);
+	var filter = __webpack_require__(141);
+	var find = __webpack_require__(143);
+	var sortBy = __webpack_require__(150);
+	var difference = __webpack_require__(166);
 
 	var ColumnProperties = (function () {
 	  function ColumnProperties() {
@@ -1563,13 +3679,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 6 */
+/* 19 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayMap = __webpack_require__(7),
-	    baseIteratee = __webpack_require__(8),
-	    baseMap = __webpack_require__(122),
-	    isArray = __webpack_require__(71);
+	var arrayMap = __webpack_require__(20),
+	    baseIteratee = __webpack_require__(21),
+	    baseMap = __webpack_require__(135),
+	    isArray = __webpack_require__(84);
 
 	/**
 	 * Creates an array of values by running each element in `collection` thru
@@ -1622,7 +3738,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 7 */
+/* 20 */
 /***/ function(module, exports) {
 
 	/**
@@ -1649,14 +3765,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 8 */
+/* 21 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseMatches = __webpack_require__(9),
-	    baseMatchesProperty = __webpack_require__(103),
-	    identity = __webpack_require__(118),
-	    isArray = __webpack_require__(71),
-	    property = __webpack_require__(119);
+	var baseMatches = __webpack_require__(22),
+	    baseMatchesProperty = __webpack_require__(116),
+	    identity = __webpack_require__(131),
+	    isArray = __webpack_require__(84),
+	    property = __webpack_require__(132);
 
 	/**
 	 * The base implementation of `_.iteratee`.
@@ -1686,12 +3802,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 9 */
+/* 22 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseIsMatch = __webpack_require__(10),
-	    getMatchData = __webpack_require__(100),
-	    matchesStrictComparable = __webpack_require__(102);
+	var baseIsMatch = __webpack_require__(23),
+	    getMatchData = __webpack_require__(113),
+	    matchesStrictComparable = __webpack_require__(115);
 
 	/**
 	 * The base implementation of `_.matches` which doesn't clone `source`.
@@ -1714,11 +3830,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 10 */
+/* 23 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var Stack = __webpack_require__(11),
-	    baseIsEqual = __webpack_require__(55);
+	var Stack = __webpack_require__(24),
+	    baseIsEqual = __webpack_require__(68);
 
 	/** Used to compose bitmasks for value comparisons. */
 	var COMPARE_PARTIAL_FLAG = 1,
@@ -1782,15 +3898,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 11 */
+/* 24 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var ListCache = __webpack_require__(12),
-	    stackClear = __webpack_require__(20),
-	    stackDelete = __webpack_require__(21),
-	    stackGet = __webpack_require__(22),
-	    stackHas = __webpack_require__(23),
-	    stackSet = __webpack_require__(24);
+	var ListCache = __webpack_require__(25),
+	    stackClear = __webpack_require__(33),
+	    stackDelete = __webpack_require__(34),
+	    stackGet = __webpack_require__(35),
+	    stackHas = __webpack_require__(36),
+	    stackSet = __webpack_require__(37);
 
 	/**
 	 * Creates a stack cache object to store key-value pairs.
@@ -1815,14 +3931,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 12 */
+/* 25 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var listCacheClear = __webpack_require__(13),
-	    listCacheDelete = __webpack_require__(14),
-	    listCacheGet = __webpack_require__(17),
-	    listCacheHas = __webpack_require__(18),
-	    listCacheSet = __webpack_require__(19);
+	var listCacheClear = __webpack_require__(26),
+	    listCacheDelete = __webpack_require__(27),
+	    listCacheGet = __webpack_require__(30),
+	    listCacheHas = __webpack_require__(31),
+	    listCacheSet = __webpack_require__(32);
 
 	/**
 	 * Creates an list cache object.
@@ -1853,7 +3969,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 13 */
+/* 26 */
 /***/ function(module, exports) {
 
 	/**
@@ -1872,10 +3988,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 14 */
+/* 27 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var assocIndexOf = __webpack_require__(15);
+	var assocIndexOf = __webpack_require__(28);
 
 	/** Used for built-in method references. */
 	var arrayProto = Array.prototype;
@@ -1913,10 +4029,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 15 */
+/* 28 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var eq = __webpack_require__(16);
+	var eq = __webpack_require__(29);
 
 	/**
 	 * Gets the index at which the `key` is found in `array` of key-value pairs.
@@ -1940,7 +4056,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 16 */
+/* 29 */
 /***/ function(module, exports) {
 
 	/**
@@ -1983,10 +4099,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 17 */
+/* 30 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var assocIndexOf = __webpack_require__(15);
+	var assocIndexOf = __webpack_require__(28);
 
 	/**
 	 * Gets the list cache value for `key`.
@@ -2008,10 +4124,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 18 */
+/* 31 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var assocIndexOf = __webpack_require__(15);
+	var assocIndexOf = __webpack_require__(28);
 
 	/**
 	 * Checks if a list cache value for `key` exists.
@@ -2030,10 +4146,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 19 */
+/* 32 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var assocIndexOf = __webpack_require__(15);
+	var assocIndexOf = __webpack_require__(28);
 
 	/**
 	 * Sets the list cache `key` to `value`.
@@ -2062,10 +4178,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 20 */
+/* 33 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var ListCache = __webpack_require__(12);
+	var ListCache = __webpack_require__(25);
 
 	/**
 	 * Removes all key-value entries from the stack.
@@ -2083,7 +4199,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 21 */
+/* 34 */
 /***/ function(module, exports) {
 
 	/**
@@ -2107,7 +4223,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 22 */
+/* 35 */
 /***/ function(module, exports) {
 
 	/**
@@ -2127,7 +4243,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 23 */
+/* 36 */
 /***/ function(module, exports) {
 
 	/**
@@ -2147,12 +4263,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 24 */
+/* 37 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var ListCache = __webpack_require__(12),
-	    Map = __webpack_require__(25),
-	    MapCache = __webpack_require__(40);
+	var ListCache = __webpack_require__(25),
+	    Map = __webpack_require__(38),
+	    MapCache = __webpack_require__(53);
 
 	/** Used as the size to enable large array optimizations. */
 	var LARGE_ARRAY_SIZE = 200;
@@ -2187,11 +4303,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 25 */
+/* 38 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var getNative = __webpack_require__(26),
-	    root = __webpack_require__(31);
+	var getNative = __webpack_require__(39),
+	    root = __webpack_require__(44);
 
 	/* Built-in method references that are verified to be native. */
 	var Map = getNative(root, 'Map');
@@ -2200,11 +4316,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 26 */
+/* 39 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseIsNative = __webpack_require__(27),
-	    getValue = __webpack_require__(39);
+	var baseIsNative = __webpack_require__(40),
+	    getValue = __webpack_require__(52);
 
 	/**
 	 * Gets the native function at `key` of `object`.
@@ -2223,13 +4339,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 27 */
+/* 40 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isFunction = __webpack_require__(28),
-	    isMasked = __webpack_require__(36),
-	    isObject = __webpack_require__(35),
-	    toSource = __webpack_require__(38);
+	var isFunction = __webpack_require__(41),
+	    isMasked = __webpack_require__(49),
+	    isObject = __webpack_require__(48),
+	    toSource = __webpack_require__(51);
 
 	/**
 	 * Used to match `RegExp`
@@ -2276,11 +4392,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 28 */
+/* 41 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGetTag = __webpack_require__(29),
-	    isObject = __webpack_require__(35);
+	var baseGetTag = __webpack_require__(42),
+	    isObject = __webpack_require__(48);
 
 	/** `Object#toString` result references. */
 	var asyncTag = '[object AsyncFunction]',
@@ -2319,12 +4435,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 29 */
+/* 42 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var Symbol = __webpack_require__(30),
-	    getRawTag = __webpack_require__(33),
-	    objectToString = __webpack_require__(34);
+	var Symbol = __webpack_require__(43),
+	    getRawTag = __webpack_require__(46),
+	    objectToString = __webpack_require__(47);
 
 	/** `Object#toString` result references. */
 	var nullTag = '[object Null]',
@@ -2353,10 +4469,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 30 */
+/* 43 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var root = __webpack_require__(31);
+	var root = __webpack_require__(44);
 
 	/** Built-in value references. */
 	var Symbol = root.Symbol;
@@ -2365,10 +4481,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 31 */
+/* 44 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var freeGlobal = __webpack_require__(32);
+	var freeGlobal = __webpack_require__(45);
 
 	/** Detect free variable `self`. */
 	var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
@@ -2380,7 +4496,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 32 */
+/* 45 */
 /***/ function(module, exports) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {/** Detect free variable `global` from Node.js. */
@@ -2391,10 +4507,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 33 */
+/* 46 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var Symbol = __webpack_require__(30);
+	var Symbol = __webpack_require__(43);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -2443,7 +4559,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 34 */
+/* 47 */
 /***/ function(module, exports) {
 
 	/** Used for built-in method references. */
@@ -2471,7 +4587,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 35 */
+/* 48 */
 /***/ function(module, exports) {
 
 	/**
@@ -2508,10 +4624,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 36 */
+/* 49 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var coreJsData = __webpack_require__(37);
+	var coreJsData = __webpack_require__(50);
 
 	/** Used to detect methods masquerading as native. */
 	var maskSrcKey = (function() {
@@ -2534,10 +4650,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 37 */
+/* 50 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var root = __webpack_require__(31);
+	var root = __webpack_require__(44);
 
 	/** Used to detect overreaching core-js shims. */
 	var coreJsData = root['__core-js_shared__'];
@@ -2546,7 +4662,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 38 */
+/* 51 */
 /***/ function(module, exports) {
 
 	/** Used for built-in method references. */
@@ -2578,7 +4694,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 39 */
+/* 52 */
 /***/ function(module, exports) {
 
 	/**
@@ -2597,14 +4713,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 40 */
+/* 53 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var mapCacheClear = __webpack_require__(41),
-	    mapCacheDelete = __webpack_require__(49),
-	    mapCacheGet = __webpack_require__(52),
-	    mapCacheHas = __webpack_require__(53),
-	    mapCacheSet = __webpack_require__(54);
+	var mapCacheClear = __webpack_require__(54),
+	    mapCacheDelete = __webpack_require__(62),
+	    mapCacheGet = __webpack_require__(65),
+	    mapCacheHas = __webpack_require__(66),
+	    mapCacheSet = __webpack_require__(67);
 
 	/**
 	 * Creates a map cache object to store key-value pairs.
@@ -2635,12 +4751,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 41 */
+/* 54 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var Hash = __webpack_require__(42),
-	    ListCache = __webpack_require__(12),
-	    Map = __webpack_require__(25);
+	var Hash = __webpack_require__(55),
+	    ListCache = __webpack_require__(25),
+	    Map = __webpack_require__(38);
 
 	/**
 	 * Removes all key-value entries from the map.
@@ -2662,14 +4778,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 42 */
+/* 55 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var hashClear = __webpack_require__(43),
-	    hashDelete = __webpack_require__(45),
-	    hashGet = __webpack_require__(46),
-	    hashHas = __webpack_require__(47),
-	    hashSet = __webpack_require__(48);
+	var hashClear = __webpack_require__(56),
+	    hashDelete = __webpack_require__(58),
+	    hashGet = __webpack_require__(59),
+	    hashHas = __webpack_require__(60),
+	    hashSet = __webpack_require__(61);
 
 	/**
 	 * Creates a hash object.
@@ -2700,10 +4816,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 43 */
+/* 56 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var nativeCreate = __webpack_require__(44);
+	var nativeCreate = __webpack_require__(57);
 
 	/**
 	 * Removes all key-value entries from the hash.
@@ -2721,10 +4837,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 44 */
+/* 57 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var getNative = __webpack_require__(26);
+	var getNative = __webpack_require__(39);
 
 	/* Built-in method references that are verified to be native. */
 	var nativeCreate = getNative(Object, 'create');
@@ -2733,7 +4849,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 45 */
+/* 58 */
 /***/ function(module, exports) {
 
 	/**
@@ -2756,10 +4872,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 46 */
+/* 59 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var nativeCreate = __webpack_require__(44);
+	var nativeCreate = __webpack_require__(57);
 
 	/** Used to stand-in for `undefined` hash values. */
 	var HASH_UNDEFINED = '__lodash_hash_undefined__';
@@ -2792,10 +4908,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 47 */
+/* 60 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var nativeCreate = __webpack_require__(44);
+	var nativeCreate = __webpack_require__(57);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -2821,10 +4937,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 48 */
+/* 61 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var nativeCreate = __webpack_require__(44);
+	var nativeCreate = __webpack_require__(57);
 
 	/** Used to stand-in for `undefined` hash values. */
 	var HASH_UNDEFINED = '__lodash_hash_undefined__';
@@ -2850,10 +4966,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 49 */
+/* 62 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var getMapData = __webpack_require__(50);
+	var getMapData = __webpack_require__(63);
 
 	/**
 	 * Removes `key` and its value from the map.
@@ -2874,10 +4990,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 50 */
+/* 63 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isKeyable = __webpack_require__(51);
+	var isKeyable = __webpack_require__(64);
 
 	/**
 	 * Gets the data for `map`.
@@ -2898,7 +5014,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 51 */
+/* 64 */
 /***/ function(module, exports) {
 
 	/**
@@ -2919,10 +5035,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 52 */
+/* 65 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var getMapData = __webpack_require__(50);
+	var getMapData = __webpack_require__(63);
 
 	/**
 	 * Gets the map value for `key`.
@@ -2941,10 +5057,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 53 */
+/* 66 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var getMapData = __webpack_require__(50);
+	var getMapData = __webpack_require__(63);
 
 	/**
 	 * Checks if a map value for `key` exists.
@@ -2963,10 +5079,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 54 */
+/* 67 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var getMapData = __webpack_require__(50);
+	var getMapData = __webpack_require__(63);
 
 	/**
 	 * Sets the map `key` to `value`.
@@ -2991,11 +5107,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 55 */
+/* 68 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseIsEqualDeep = __webpack_require__(56),
-	    isObjectLike = __webpack_require__(80);
+	var baseIsEqualDeep = __webpack_require__(69),
+	    isObjectLike = __webpack_require__(93);
 
 	/**
 	 * The base implementation of `_.isEqual` which supports partial comparisons
@@ -3025,17 +5141,17 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 56 */
+/* 69 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var Stack = __webpack_require__(11),
-	    equalArrays = __webpack_require__(57),
-	    equalByTag = __webpack_require__(63),
-	    equalObjects = __webpack_require__(67),
-	    getTag = __webpack_require__(95),
-	    isArray = __webpack_require__(71),
-	    isBuffer = __webpack_require__(81),
-	    isTypedArray = __webpack_require__(85);
+	var Stack = __webpack_require__(24),
+	    equalArrays = __webpack_require__(70),
+	    equalByTag = __webpack_require__(76),
+	    equalObjects = __webpack_require__(80),
+	    getTag = __webpack_require__(108),
+	    isArray = __webpack_require__(84),
+	    isBuffer = __webpack_require__(94),
+	    isTypedArray = __webpack_require__(98);
 
 	/** Used to compose bitmasks for value comparisons. */
 	var COMPARE_PARTIAL_FLAG = 1;
@@ -3114,12 +5230,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 57 */
+/* 70 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var SetCache = __webpack_require__(58),
-	    arraySome = __webpack_require__(61),
-	    cacheHas = __webpack_require__(62);
+	var SetCache = __webpack_require__(71),
+	    arraySome = __webpack_require__(74),
+	    cacheHas = __webpack_require__(75);
 
 	/** Used to compose bitmasks for value comparisons. */
 	var COMPARE_PARTIAL_FLAG = 1,
@@ -3203,12 +5319,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 58 */
+/* 71 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var MapCache = __webpack_require__(40),
-	    setCacheAdd = __webpack_require__(59),
-	    setCacheHas = __webpack_require__(60);
+	var MapCache = __webpack_require__(53),
+	    setCacheAdd = __webpack_require__(72),
+	    setCacheHas = __webpack_require__(73);
 
 	/**
 	 *
@@ -3236,7 +5352,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 59 */
+/* 72 */
 /***/ function(module, exports) {
 
 	/** Used to stand-in for `undefined` hash values. */
@@ -3261,7 +5377,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 60 */
+/* 73 */
 /***/ function(module, exports) {
 
 	/**
@@ -3281,7 +5397,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 61 */
+/* 74 */
 /***/ function(module, exports) {
 
 	/**
@@ -3310,7 +5426,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 62 */
+/* 75 */
 /***/ function(module, exports) {
 
 	/**
@@ -3329,15 +5445,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 63 */
+/* 76 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var Symbol = __webpack_require__(30),
-	    Uint8Array = __webpack_require__(64),
-	    eq = __webpack_require__(16),
-	    equalArrays = __webpack_require__(57),
-	    mapToArray = __webpack_require__(65),
-	    setToArray = __webpack_require__(66);
+	var Symbol = __webpack_require__(43),
+	    Uint8Array = __webpack_require__(77),
+	    eq = __webpack_require__(29),
+	    equalArrays = __webpack_require__(70),
+	    mapToArray = __webpack_require__(78),
+	    setToArray = __webpack_require__(79);
 
 	/** Used to compose bitmasks for value comparisons. */
 	var COMPARE_PARTIAL_FLAG = 1,
@@ -3447,10 +5563,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 64 */
+/* 77 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var root = __webpack_require__(31);
+	var root = __webpack_require__(44);
 
 	/** Built-in value references. */
 	var Uint8Array = root.Uint8Array;
@@ -3459,7 +5575,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 65 */
+/* 78 */
 /***/ function(module, exports) {
 
 	/**
@@ -3483,7 +5599,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 66 */
+/* 79 */
 /***/ function(module, exports) {
 
 	/**
@@ -3507,10 +5623,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 67 */
+/* 80 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var getAllKeys = __webpack_require__(68);
+	var getAllKeys = __webpack_require__(81);
 
 	/** Used to compose bitmasks for value comparisons. */
 	var COMPARE_PARTIAL_FLAG = 1;
@@ -3602,12 +5718,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 68 */
+/* 81 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGetAllKeys = __webpack_require__(69),
-	    getSymbols = __webpack_require__(72),
-	    keys = __webpack_require__(75);
+	var baseGetAllKeys = __webpack_require__(82),
+	    getSymbols = __webpack_require__(85),
+	    keys = __webpack_require__(88);
 
 	/**
 	 * Creates an array of own enumerable property names and symbols of `object`.
@@ -3624,11 +5740,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 69 */
+/* 82 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayPush = __webpack_require__(70),
-	    isArray = __webpack_require__(71);
+	var arrayPush = __webpack_require__(83),
+	    isArray = __webpack_require__(84);
 
 	/**
 	 * The base implementation of `getAllKeys` and `getAllKeysIn` which uses
@@ -3650,7 +5766,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 70 */
+/* 83 */
 /***/ function(module, exports) {
 
 	/**
@@ -3676,7 +5792,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 71 */
+/* 84 */
 /***/ function(module, exports) {
 
 	/**
@@ -3708,11 +5824,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 72 */
+/* 85 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayFilter = __webpack_require__(73),
-	    stubArray = __webpack_require__(74);
+	var arrayFilter = __webpack_require__(86),
+	    stubArray = __webpack_require__(87);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -3744,7 +5860,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 73 */
+/* 86 */
 /***/ function(module, exports) {
 
 	/**
@@ -3775,7 +5891,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 74 */
+/* 87 */
 /***/ function(module, exports) {
 
 	/**
@@ -3804,12 +5920,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 75 */
+/* 88 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayLikeKeys = __webpack_require__(76),
-	    baseKeys = __webpack_require__(90),
-	    isArrayLike = __webpack_require__(94);
+	var arrayLikeKeys = __webpack_require__(89),
+	    baseKeys = __webpack_require__(103),
+	    isArrayLike = __webpack_require__(107);
 
 	/**
 	 * Creates an array of the own enumerable property names of `object`.
@@ -3847,15 +5963,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 76 */
+/* 89 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseTimes = __webpack_require__(77),
-	    isArguments = __webpack_require__(78),
-	    isArray = __webpack_require__(71),
-	    isBuffer = __webpack_require__(81),
-	    isIndex = __webpack_require__(84),
-	    isTypedArray = __webpack_require__(85);
+	var baseTimes = __webpack_require__(90),
+	    isArguments = __webpack_require__(91),
+	    isArray = __webpack_require__(84),
+	    isBuffer = __webpack_require__(94),
+	    isIndex = __webpack_require__(97),
+	    isTypedArray = __webpack_require__(98);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -3902,7 +6018,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 77 */
+/* 90 */
 /***/ function(module, exports) {
 
 	/**
@@ -3928,11 +6044,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 78 */
+/* 91 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseIsArguments = __webpack_require__(79),
-	    isObjectLike = __webpack_require__(80);
+	var baseIsArguments = __webpack_require__(92),
+	    isObjectLike = __webpack_require__(93);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -3970,11 +6086,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 79 */
+/* 92 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGetTag = __webpack_require__(29),
-	    isObjectLike = __webpack_require__(80);
+	var baseGetTag = __webpack_require__(42),
+	    isObjectLike = __webpack_require__(93);
 
 	/** `Object#toString` result references. */
 	var argsTag = '[object Arguments]';
@@ -3994,7 +6110,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 80 */
+/* 93 */
 /***/ function(module, exports) {
 
 	/**
@@ -4029,11 +6145,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 81 */
+/* 94 */
 /***/ function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(module) {var root = __webpack_require__(31),
-	    stubFalse = __webpack_require__(83);
+	/* WEBPACK VAR INJECTION */(function(module) {var root = __webpack_require__(44),
+	    stubFalse = __webpack_require__(96);
 
 	/** Detect free variable `exports`. */
 	var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
@@ -4071,10 +6187,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = isBuffer;
 
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(82)(module)))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(95)(module)))
 
 /***/ },
-/* 82 */
+/* 95 */
 /***/ function(module, exports) {
 
 	module.exports = function(module) {
@@ -4090,7 +6206,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 83 */
+/* 96 */
 /***/ function(module, exports) {
 
 	/**
@@ -4114,7 +6230,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 84 */
+/* 97 */
 /***/ function(module, exports) {
 
 	/** Used as references for various `Number` constants. */
@@ -4142,12 +6258,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 85 */
+/* 98 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseIsTypedArray = __webpack_require__(86),
-	    baseUnary = __webpack_require__(88),
-	    nodeUtil = __webpack_require__(89);
+	var baseIsTypedArray = __webpack_require__(99),
+	    baseUnary = __webpack_require__(101),
+	    nodeUtil = __webpack_require__(102);
 
 	/* Node.js helper references. */
 	var nodeIsTypedArray = nodeUtil && nodeUtil.isTypedArray;
@@ -4175,12 +6291,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 86 */
+/* 99 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGetTag = __webpack_require__(29),
-	    isLength = __webpack_require__(87),
-	    isObjectLike = __webpack_require__(80);
+	var baseGetTag = __webpack_require__(42),
+	    isLength = __webpack_require__(100),
+	    isObjectLike = __webpack_require__(93);
 
 	/** `Object#toString` result references. */
 	var argsTag = '[object Arguments]',
@@ -4241,7 +6357,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 87 */
+/* 100 */
 /***/ function(module, exports) {
 
 	/** Used as references for various `Number` constants. */
@@ -4282,7 +6398,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 88 */
+/* 101 */
 /***/ function(module, exports) {
 
 	/**
@@ -4302,10 +6418,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 89 */
+/* 102 */
 /***/ function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(module) {var freeGlobal = __webpack_require__(32);
+	/* WEBPACK VAR INJECTION */(function(module) {var freeGlobal = __webpack_require__(45);
 
 	/** Detect free variable `exports`. */
 	var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
@@ -4328,14 +6444,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = nodeUtil;
 
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(82)(module)))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(95)(module)))
 
 /***/ },
-/* 90 */
+/* 103 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isPrototype = __webpack_require__(91),
-	    nativeKeys = __webpack_require__(92);
+	var isPrototype = __webpack_require__(104),
+	    nativeKeys = __webpack_require__(105);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -4367,7 +6483,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 91 */
+/* 104 */
 /***/ function(module, exports) {
 
 	/** Used for built-in method references. */
@@ -4391,10 +6507,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 92 */
+/* 105 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var overArg = __webpack_require__(93);
+	var overArg = __webpack_require__(106);
 
 	/* Built-in method references for those with the same name as other `lodash` methods. */
 	var nativeKeys = overArg(Object.keys, Object);
@@ -4403,7 +6519,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 93 */
+/* 106 */
 /***/ function(module, exports) {
 
 	/**
@@ -4424,11 +6540,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 94 */
+/* 107 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isFunction = __webpack_require__(28),
-	    isLength = __webpack_require__(87);
+	var isFunction = __webpack_require__(41),
+	    isLength = __webpack_require__(100);
 
 	/**
 	 * Checks if `value` is array-like. A value is considered array-like if it's
@@ -4463,16 +6579,16 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 95 */
+/* 108 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var DataView = __webpack_require__(96),
-	    Map = __webpack_require__(25),
-	    Promise = __webpack_require__(97),
-	    Set = __webpack_require__(98),
-	    WeakMap = __webpack_require__(99),
-	    baseGetTag = __webpack_require__(29),
-	    toSource = __webpack_require__(38);
+	var DataView = __webpack_require__(109),
+	    Map = __webpack_require__(38),
+	    Promise = __webpack_require__(110),
+	    Set = __webpack_require__(111),
+	    WeakMap = __webpack_require__(112),
+	    baseGetTag = __webpack_require__(42),
+	    toSource = __webpack_require__(51);
 
 	/** `Object#toString` result references. */
 	var mapTag = '[object Map]',
@@ -4527,11 +6643,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 96 */
+/* 109 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var getNative = __webpack_require__(26),
-	    root = __webpack_require__(31);
+	var getNative = __webpack_require__(39),
+	    root = __webpack_require__(44);
 
 	/* Built-in method references that are verified to be native. */
 	var DataView = getNative(root, 'DataView');
@@ -4540,11 +6656,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 97 */
+/* 110 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var getNative = __webpack_require__(26),
-	    root = __webpack_require__(31);
+	var getNative = __webpack_require__(39),
+	    root = __webpack_require__(44);
 
 	/* Built-in method references that are verified to be native. */
 	var Promise = getNative(root, 'Promise');
@@ -4553,11 +6669,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 98 */
+/* 111 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var getNative = __webpack_require__(26),
-	    root = __webpack_require__(31);
+	var getNative = __webpack_require__(39),
+	    root = __webpack_require__(44);
 
 	/* Built-in method references that are verified to be native. */
 	var Set = getNative(root, 'Set');
@@ -4566,11 +6682,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 99 */
+/* 112 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var getNative = __webpack_require__(26),
-	    root = __webpack_require__(31);
+	var getNative = __webpack_require__(39),
+	    root = __webpack_require__(44);
 
 	/* Built-in method references that are verified to be native. */
 	var WeakMap = getNative(root, 'WeakMap');
@@ -4579,11 +6695,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 100 */
+/* 113 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isStrictComparable = __webpack_require__(101),
-	    keys = __webpack_require__(75);
+	var isStrictComparable = __webpack_require__(114),
+	    keys = __webpack_require__(88);
 
 	/**
 	 * Gets the property names, values, and compare flags of `object`.
@@ -4609,10 +6725,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 101 */
+/* 114 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isObject = __webpack_require__(35);
+	var isObject = __webpack_require__(48);
 
 	/**
 	 * Checks if `value` is suitable for strict equality comparisons, i.e. `===`.
@@ -4630,7 +6746,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 102 */
+/* 115 */
 /***/ function(module, exports) {
 
 	/**
@@ -4656,16 +6772,16 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 103 */
+/* 116 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseIsEqual = __webpack_require__(55),
-	    get = __webpack_require__(104),
-	    hasIn = __webpack_require__(115),
-	    isKey = __webpack_require__(107),
-	    isStrictComparable = __webpack_require__(101),
-	    matchesStrictComparable = __webpack_require__(102),
-	    toKey = __webpack_require__(114);
+	var baseIsEqual = __webpack_require__(68),
+	    get = __webpack_require__(117),
+	    hasIn = __webpack_require__(128),
+	    isKey = __webpack_require__(120),
+	    isStrictComparable = __webpack_require__(114),
+	    matchesStrictComparable = __webpack_require__(115),
+	    toKey = __webpack_require__(127);
 
 	/** Used to compose bitmasks for value comparisons. */
 	var COMPARE_PARTIAL_FLAG = 1,
@@ -4695,10 +6811,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 104 */
+/* 117 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGet = __webpack_require__(105);
+	var baseGet = __webpack_require__(118);
 
 	/**
 	 * Gets the value at `path` of `object`. If the resolved value is
@@ -4734,11 +6850,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 105 */
+/* 118 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var castPath = __webpack_require__(106),
-	    toKey = __webpack_require__(114);
+	var castPath = __webpack_require__(119),
+	    toKey = __webpack_require__(127);
 
 	/**
 	 * The base implementation of `_.get` without support for default values.
@@ -4764,13 +6880,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 106 */
+/* 119 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isArray = __webpack_require__(71),
-	    isKey = __webpack_require__(107),
-	    stringToPath = __webpack_require__(109),
-	    toString = __webpack_require__(112);
+	var isArray = __webpack_require__(84),
+	    isKey = __webpack_require__(120),
+	    stringToPath = __webpack_require__(122),
+	    toString = __webpack_require__(125);
 
 	/**
 	 * Casts `value` to a path array if it's not one.
@@ -4791,11 +6907,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 107 */
+/* 120 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isArray = __webpack_require__(71),
-	    isSymbol = __webpack_require__(108);
+	var isArray = __webpack_require__(84),
+	    isSymbol = __webpack_require__(121);
 
 	/** Used to match property names within property paths. */
 	var reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/,
@@ -4826,11 +6942,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 108 */
+/* 121 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGetTag = __webpack_require__(29),
-	    isObjectLike = __webpack_require__(80);
+	var baseGetTag = __webpack_require__(42),
+	    isObjectLike = __webpack_require__(93);
 
 	/** `Object#toString` result references. */
 	var symbolTag = '[object Symbol]';
@@ -4861,10 +6977,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 109 */
+/* 122 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var memoizeCapped = __webpack_require__(110);
+	var memoizeCapped = __webpack_require__(123);
 
 	/** Used to match property names within property paths. */
 	var reLeadingDot = /^\./,
@@ -4895,10 +7011,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 110 */
+/* 123 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var memoize = __webpack_require__(111);
+	var memoize = __webpack_require__(124);
 
 	/** Used as the maximum memoize cache size. */
 	var MAX_MEMOIZE_SIZE = 500;
@@ -4927,10 +7043,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 111 */
+/* 124 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var MapCache = __webpack_require__(40);
+	var MapCache = __webpack_require__(53);
 
 	/** Error message constants. */
 	var FUNC_ERROR_TEXT = 'Expected a function';
@@ -5006,10 +7122,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 112 */
+/* 125 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseToString = __webpack_require__(113);
+	var baseToString = __webpack_require__(126);
 
 	/**
 	 * Converts `value` to a string. An empty string is returned for `null`
@@ -5040,13 +7156,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 113 */
+/* 126 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var Symbol = __webpack_require__(30),
-	    arrayMap = __webpack_require__(7),
-	    isArray = __webpack_require__(71),
-	    isSymbol = __webpack_require__(108);
+	var Symbol = __webpack_require__(43),
+	    arrayMap = __webpack_require__(20),
+	    isArray = __webpack_require__(84),
+	    isSymbol = __webpack_require__(121);
 
 	/** Used as references for various `Number` constants. */
 	var INFINITY = 1 / 0;
@@ -5083,10 +7199,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 114 */
+/* 127 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isSymbol = __webpack_require__(108);
+	var isSymbol = __webpack_require__(121);
 
 	/** Used as references for various `Number` constants. */
 	var INFINITY = 1 / 0;
@@ -5110,11 +7226,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 115 */
+/* 128 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseHasIn = __webpack_require__(116),
-	    hasPath = __webpack_require__(117);
+	var baseHasIn = __webpack_require__(129),
+	    hasPath = __webpack_require__(130);
 
 	/**
 	 * Checks if `path` is a direct or inherited property of `object`.
@@ -5150,7 +7266,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 116 */
+/* 129 */
 /***/ function(module, exports) {
 
 	/**
@@ -5169,15 +7285,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 117 */
+/* 130 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var castPath = __webpack_require__(106),
-	    isArguments = __webpack_require__(78),
-	    isArray = __webpack_require__(71),
-	    isIndex = __webpack_require__(84),
-	    isLength = __webpack_require__(87),
-	    toKey = __webpack_require__(114);
+	var castPath = __webpack_require__(119),
+	    isArguments = __webpack_require__(91),
+	    isArray = __webpack_require__(84),
+	    isIndex = __webpack_require__(97),
+	    isLength = __webpack_require__(100),
+	    toKey = __webpack_require__(127);
 
 	/**
 	 * Checks if `path` exists on `object`.
@@ -5214,7 +7330,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 118 */
+/* 131 */
 /***/ function(module, exports) {
 
 	/**
@@ -5241,13 +7357,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 119 */
+/* 132 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseProperty = __webpack_require__(120),
-	    basePropertyDeep = __webpack_require__(121),
-	    isKey = __webpack_require__(107),
-	    toKey = __webpack_require__(114);
+	var baseProperty = __webpack_require__(133),
+	    basePropertyDeep = __webpack_require__(134),
+	    isKey = __webpack_require__(120),
+	    toKey = __webpack_require__(127);
 
 	/**
 	 * Creates a function that returns the value at `path` of a given object.
@@ -5279,7 +7395,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 120 */
+/* 133 */
 /***/ function(module, exports) {
 
 	/**
@@ -5299,10 +7415,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 121 */
+/* 134 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGet = __webpack_require__(105);
+	var baseGet = __webpack_require__(118);
 
 	/**
 	 * A specialized version of `baseProperty` which supports deep paths.
@@ -5321,11 +7437,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 122 */
+/* 135 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseEach = __webpack_require__(123),
-	    isArrayLike = __webpack_require__(94);
+	var baseEach = __webpack_require__(136),
+	    isArrayLike = __webpack_require__(107);
 
 	/**
 	 * The base implementation of `_.map` without support for iteratee shorthands.
@@ -5349,11 +7465,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 123 */
+/* 136 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseForOwn = __webpack_require__(124),
-	    createBaseEach = __webpack_require__(127);
+	var baseForOwn = __webpack_require__(137),
+	    createBaseEach = __webpack_require__(140);
 
 	/**
 	 * The base implementation of `_.forEach` without support for iteratee shorthands.
@@ -5369,11 +7485,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 124 */
+/* 137 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseFor = __webpack_require__(125),
-	    keys = __webpack_require__(75);
+	var baseFor = __webpack_require__(138),
+	    keys = __webpack_require__(88);
 
 	/**
 	 * The base implementation of `_.forOwn` without support for iteratee shorthands.
@@ -5391,10 +7507,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 125 */
+/* 138 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var createBaseFor = __webpack_require__(126);
+	var createBaseFor = __webpack_require__(139);
 
 	/**
 	 * The base implementation of `baseForOwn` which iterates over `object`
@@ -5413,7 +7529,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 126 */
+/* 139 */
 /***/ function(module, exports) {
 
 	/**
@@ -5444,10 +7560,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 127 */
+/* 140 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isArrayLike = __webpack_require__(94);
+	var isArrayLike = __webpack_require__(107);
 
 	/**
 	 * Creates a `baseEach` or `baseEachRight` function.
@@ -5482,13 +7598,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 128 */
+/* 141 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayFilter = __webpack_require__(73),
-	    baseFilter = __webpack_require__(129),
-	    baseIteratee = __webpack_require__(8),
-	    isArray = __webpack_require__(71);
+	var arrayFilter = __webpack_require__(86),
+	    baseFilter = __webpack_require__(142),
+	    baseIteratee = __webpack_require__(21),
+	    isArray = __webpack_require__(84);
 
 	/**
 	 * Iterates over elements of `collection`, returning an array of all elements
@@ -5536,10 +7652,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 129 */
+/* 142 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseEach = __webpack_require__(123);
+	var baseEach = __webpack_require__(136);
 
 	/**
 	 * The base implementation of `_.filter` without support for iteratee shorthands.
@@ -5563,11 +7679,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 130 */
+/* 143 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var createFind = __webpack_require__(131),
-	    findIndex = __webpack_require__(132);
+	var createFind = __webpack_require__(144),
+	    findIndex = __webpack_require__(145);
 
 	/**
 	 * Iterates over elements of `collection`, returning the first element
@@ -5611,12 +7727,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 131 */
+/* 144 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseIteratee = __webpack_require__(8),
-	    isArrayLike = __webpack_require__(94),
-	    keys = __webpack_require__(75);
+	var baseIteratee = __webpack_require__(21),
+	    isArrayLike = __webpack_require__(107),
+	    keys = __webpack_require__(88);
 
 	/**
 	 * Creates a `_.find` or `_.findLast` function.
@@ -5642,12 +7758,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 132 */
+/* 145 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseFindIndex = __webpack_require__(133),
-	    baseIteratee = __webpack_require__(8),
-	    toInteger = __webpack_require__(134);
+	var baseFindIndex = __webpack_require__(146),
+	    baseIteratee = __webpack_require__(21),
+	    toInteger = __webpack_require__(147);
 
 	/* Built-in method references for those with the same name as other `lodash` methods. */
 	var nativeMax = Math.max;
@@ -5703,7 +7819,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 133 */
+/* 146 */
 /***/ function(module, exports) {
 
 	/**
@@ -5733,10 +7849,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 134 */
+/* 147 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var toFinite = __webpack_require__(135);
+	var toFinite = __webpack_require__(148);
 
 	/**
 	 * Converts `value` to an integer.
@@ -5775,10 +7891,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 135 */
+/* 148 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var toNumber = __webpack_require__(136);
+	var toNumber = __webpack_require__(149);
 
 	/** Used as references for various `Number` constants. */
 	var INFINITY = 1 / 0,
@@ -5823,11 +7939,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 136 */
+/* 149 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isObject = __webpack_require__(35),
-	    isSymbol = __webpack_require__(108);
+	var isObject = __webpack_require__(48),
+	    isSymbol = __webpack_require__(121);
 
 	/** Used as references for various `Number` constants. */
 	var NAN = 0 / 0;
@@ -5895,13 +8011,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 137 */
+/* 150 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseFlatten = __webpack_require__(138),
-	    baseOrderBy = __webpack_require__(140),
-	    baseRest = __webpack_require__(144),
-	    isIterateeCall = __webpack_require__(152);
+	var baseFlatten = __webpack_require__(151),
+	    baseOrderBy = __webpack_require__(153),
+	    baseRest = __webpack_require__(157),
+	    isIterateeCall = __webpack_require__(165);
 
 	/**
 	 * Creates an array of elements, sorted in ascending order by the results of
@@ -5949,11 +8065,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 138 */
+/* 151 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayPush = __webpack_require__(70),
-	    isFlattenable = __webpack_require__(139);
+	var arrayPush = __webpack_require__(83),
+	    isFlattenable = __webpack_require__(152);
 
 	/**
 	 * The base implementation of `_.flatten` with support for restricting flattening.
@@ -5993,12 +8109,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 139 */
+/* 152 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var Symbol = __webpack_require__(30),
-	    isArguments = __webpack_require__(78),
-	    isArray = __webpack_require__(71);
+	var Symbol = __webpack_require__(43),
+	    isArguments = __webpack_require__(91),
+	    isArray = __webpack_require__(84);
 
 	/** Built-in value references. */
 	var spreadableSymbol = Symbol ? Symbol.isConcatSpreadable : undefined;
@@ -6019,16 +8135,16 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 140 */
+/* 153 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayMap = __webpack_require__(7),
-	    baseIteratee = __webpack_require__(8),
-	    baseMap = __webpack_require__(122),
-	    baseSortBy = __webpack_require__(141),
-	    baseUnary = __webpack_require__(88),
-	    compareMultiple = __webpack_require__(142),
-	    identity = __webpack_require__(118);
+	var arrayMap = __webpack_require__(20),
+	    baseIteratee = __webpack_require__(21),
+	    baseMap = __webpack_require__(135),
+	    baseSortBy = __webpack_require__(154),
+	    baseUnary = __webpack_require__(101),
+	    compareMultiple = __webpack_require__(155),
+	    identity = __webpack_require__(131);
 
 	/**
 	 * The base implementation of `_.orderBy` without param guards.
@@ -6059,7 +8175,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 141 */
+/* 154 */
 /***/ function(module, exports) {
 
 	/**
@@ -6086,10 +8202,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 142 */
+/* 155 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var compareAscending = __webpack_require__(143);
+	var compareAscending = __webpack_require__(156);
 
 	/**
 	 * Used by `_.orderBy` to compare multiple properties of a value to another
@@ -6136,10 +8252,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 143 */
+/* 156 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isSymbol = __webpack_require__(108);
+	var isSymbol = __webpack_require__(121);
 
 	/**
 	 * Compares values to sort them in ascending order.
@@ -6183,12 +8299,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 144 */
+/* 157 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var identity = __webpack_require__(118),
-	    overRest = __webpack_require__(145),
-	    setToString = __webpack_require__(147);
+	var identity = __webpack_require__(131),
+	    overRest = __webpack_require__(158),
+	    setToString = __webpack_require__(160);
 
 	/**
 	 * The base implementation of `_.rest` which doesn't validate or coerce arguments.
@@ -6206,10 +8322,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 145 */
+/* 158 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var apply = __webpack_require__(146);
+	var apply = __webpack_require__(159);
 
 	/* Built-in method references for those with the same name as other `lodash` methods. */
 	var nativeMax = Math.max;
@@ -6248,7 +8364,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 146 */
+/* 159 */
 /***/ function(module, exports) {
 
 	/**
@@ -6275,11 +8391,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 147 */
+/* 160 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseSetToString = __webpack_require__(148),
-	    shortOut = __webpack_require__(151);
+	var baseSetToString = __webpack_require__(161),
+	    shortOut = __webpack_require__(164);
 
 	/**
 	 * Sets the `toString` method of `func` to return `string`.
@@ -6295,12 +8411,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 148 */
+/* 161 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var constant = __webpack_require__(149),
-	    defineProperty = __webpack_require__(150),
-	    identity = __webpack_require__(118);
+	var constant = __webpack_require__(162),
+	    defineProperty = __webpack_require__(163),
+	    identity = __webpack_require__(131);
 
 	/**
 	 * The base implementation of `setToString` without support for hot loop shorting.
@@ -6323,7 +8439,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 149 */
+/* 162 */
 /***/ function(module, exports) {
 
 	/**
@@ -6355,10 +8471,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 150 */
+/* 163 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var getNative = __webpack_require__(26);
+	var getNative = __webpack_require__(39);
 
 	var defineProperty = (function() {
 	  try {
@@ -6372,7 +8488,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 151 */
+/* 164 */
 /***/ function(module, exports) {
 
 	/** Used to detect hot functions by number of calls within a span of milliseconds. */
@@ -6415,13 +8531,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 152 */
+/* 165 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var eq = __webpack_require__(16),
-	    isArrayLike = __webpack_require__(94),
-	    isIndex = __webpack_require__(84),
-	    isObject = __webpack_require__(35);
+	var eq = __webpack_require__(29),
+	    isArrayLike = __webpack_require__(107),
+	    isIndex = __webpack_require__(97),
+	    isObject = __webpack_require__(48);
 
 	/**
 	 * Checks if the given arguments are from an iteratee call.
@@ -6451,13 +8567,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 153 */
+/* 166 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseDifference = __webpack_require__(154),
-	    baseFlatten = __webpack_require__(138),
-	    baseRest = __webpack_require__(144),
-	    isArrayLikeObject = __webpack_require__(160);
+	var baseDifference = __webpack_require__(167),
+	    baseFlatten = __webpack_require__(151),
+	    baseRest = __webpack_require__(157),
+	    isArrayLikeObject = __webpack_require__(173);
 
 	/**
 	 * Creates an array of `array` values not included in the other given arrays
@@ -6490,15 +8606,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 154 */
+/* 167 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var SetCache = __webpack_require__(58),
-	    arrayIncludes = __webpack_require__(155),
-	    arrayIncludesWith = __webpack_require__(159),
-	    arrayMap = __webpack_require__(7),
-	    baseUnary = __webpack_require__(88),
-	    cacheHas = __webpack_require__(62);
+	var SetCache = __webpack_require__(71),
+	    arrayIncludes = __webpack_require__(168),
+	    arrayIncludesWith = __webpack_require__(172),
+	    arrayMap = __webpack_require__(20),
+	    baseUnary = __webpack_require__(101),
+	    cacheHas = __webpack_require__(75);
 
 	/** Used as the size to enable large array optimizations. */
 	var LARGE_ARRAY_SIZE = 200;
@@ -6563,10 +8679,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 155 */
+/* 168 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseIndexOf = __webpack_require__(156);
+	var baseIndexOf = __webpack_require__(169);
 
 	/**
 	 * A specialized version of `_.includes` for arrays without support for
@@ -6586,12 +8702,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 156 */
+/* 169 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseFindIndex = __webpack_require__(133),
-	    baseIsNaN = __webpack_require__(157),
-	    strictIndexOf = __webpack_require__(158);
+	var baseFindIndex = __webpack_require__(146),
+	    baseIsNaN = __webpack_require__(170),
+	    strictIndexOf = __webpack_require__(171);
 
 	/**
 	 * The base implementation of `_.indexOf` without `fromIndex` bounds checks.
@@ -6612,7 +8728,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 157 */
+/* 170 */
 /***/ function(module, exports) {
 
 	/**
@@ -6630,7 +8746,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 158 */
+/* 171 */
 /***/ function(module, exports) {
 
 	/**
@@ -6659,7 +8775,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 159 */
+/* 172 */
 /***/ function(module, exports) {
 
 	/**
@@ -6687,11 +8803,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 160 */
+/* 173 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isArrayLike = __webpack_require__(94),
-	    isObjectLike = __webpack_require__(80);
+	var isArrayLike = __webpack_require__(107),
+	    isObjectLike = __webpack_require__(93);
 
 	/**
 	 * This method is like `_.isArrayLike` except that it also checks if `value`
@@ -6726,15 +8842,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 161 */
+/* 174 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var assignValue = __webpack_require__(162),
-	    copyObject = __webpack_require__(164),
-	    createAssigner = __webpack_require__(165),
-	    isArrayLike = __webpack_require__(94),
-	    isPrototype = __webpack_require__(91),
-	    keys = __webpack_require__(75);
+	var assignValue = __webpack_require__(175),
+	    copyObject = __webpack_require__(177),
+	    createAssigner = __webpack_require__(178),
+	    isArrayLike = __webpack_require__(107),
+	    isPrototype = __webpack_require__(104),
+	    keys = __webpack_require__(88);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -6790,11 +8906,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 162 */
+/* 175 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseAssignValue = __webpack_require__(163),
-	    eq = __webpack_require__(16);
+	var baseAssignValue = __webpack_require__(176),
+	    eq = __webpack_require__(29);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -6824,10 +8940,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 163 */
+/* 176 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var defineProperty = __webpack_require__(150);
+	var defineProperty = __webpack_require__(163);
 
 	/**
 	 * The base implementation of `assignValue` and `assignMergeValue` without
@@ -6855,11 +8971,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 164 */
+/* 177 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var assignValue = __webpack_require__(162),
-	    baseAssignValue = __webpack_require__(163);
+	var assignValue = __webpack_require__(175),
+	    baseAssignValue = __webpack_require__(176);
 
 	/**
 	 * Copies properties of `source` to `object`.
@@ -6901,11 +9017,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 165 */
+/* 178 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseRest = __webpack_require__(144),
-	    isIterateeCall = __webpack_require__(152);
+	var baseRest = __webpack_require__(157),
+	    isIterateeCall = __webpack_require__(165);
 
 	/**
 	 * Creates a function like `_.assign`.
@@ -6944,7 +9060,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 166 */
+/* 179 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -6953,12 +9069,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 	var React = __webpack_require__(2);
-	var ColumnProperties = __webpack_require__(5);
-	var pick = __webpack_require__(167);
+	var createReactClass = __webpack_require__(13);
+	var ColumnProperties = __webpack_require__(18);
+	var pick = __webpack_require__(180);
 
-	var GridRowContainer = React.createClass({
-	  displayName: 'GridRowContainer',
-
+	var GridRowContainer = createReactClass({
 	  getDefaultProps: function getDefaultProps() {
 	    return {
 	      "useGriddleStyles": true,
@@ -7082,11 +9197,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = GridRowContainer;
 
 /***/ },
-/* 167 */
+/* 180 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var basePick = __webpack_require__(168),
-	    flatRest = __webpack_require__(171);
+	var basePick = __webpack_require__(181),
+	    flatRest = __webpack_require__(184);
 
 	/**
 	 * Creates an object composed of the picked `object` properties.
@@ -7113,11 +9228,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 168 */
+/* 181 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var basePickBy = __webpack_require__(169),
-	    hasIn = __webpack_require__(115);
+	var basePickBy = __webpack_require__(182),
+	    hasIn = __webpack_require__(128);
 
 	/**
 	 * The base implementation of `_.pick` without support for individual
@@ -7138,12 +9253,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 169 */
+/* 182 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGet = __webpack_require__(105),
-	    baseSet = __webpack_require__(170),
-	    castPath = __webpack_require__(106);
+	var baseGet = __webpack_require__(118),
+	    baseSet = __webpack_require__(183),
+	    castPath = __webpack_require__(119);
 
 	/**
 	 * The base implementation of  `_.pickBy` without support for iteratee shorthands.
@@ -7174,14 +9289,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 170 */
+/* 183 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var assignValue = __webpack_require__(162),
-	    castPath = __webpack_require__(106),
-	    isIndex = __webpack_require__(84),
-	    isObject = __webpack_require__(35),
-	    toKey = __webpack_require__(114);
+	var assignValue = __webpack_require__(175),
+	    castPath = __webpack_require__(119),
+	    isIndex = __webpack_require__(97),
+	    isObject = __webpack_require__(48),
+	    toKey = __webpack_require__(127);
 
 	/**
 	 * The base implementation of `_.set`.
@@ -7227,12 +9342,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 171 */
+/* 184 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var flatten = __webpack_require__(172),
-	    overRest = __webpack_require__(145),
-	    setToString = __webpack_require__(147);
+	var flatten = __webpack_require__(185),
+	    overRest = __webpack_require__(158),
+	    setToString = __webpack_require__(160);
 
 	/**
 	 * A specialized version of `baseRest` which flattens the rest array.
@@ -7249,10 +9364,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 172 */
+/* 185 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseFlatten = __webpack_require__(138);
+	var baseFlatten = __webpack_require__(151);
 
 	/**
 	 * Flattens `array` a single level deep.
@@ -7277,7 +9392,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 173 */
+/* 186 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -7286,7 +9401,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-	var _uniqueId = __webpack_require__(174);
+	var _uniqueId = __webpack_require__(187);
 
 	var RowProperties = (function () {
 	  function RowProperties() {
@@ -7353,10 +9468,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 174 */
+/* 187 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var toString = __webpack_require__(112);
+	var toString = __webpack_require__(125);
 
 	/** Used to generate unique IDs. */
 	var idCounter = 0;
@@ -7387,19 +9502,18 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 175 */
+/* 188 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
 	   See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 	*/
-	"use strict";
+	'use strict';
 
 	var React = __webpack_require__(2);
+	var createReactClass = __webpack_require__(13);
 
-	var GridFilter = React.createClass({
-	    displayName: "GridFilter",
-
+	var GridFilter = createReactClass({
 	    getDefaultProps: function getDefaultProps() {
 	        return {
 	            "placeholderText": ""
@@ -7409,14 +9523,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	        this.props.changeFilter(event.target.value);
 	    },
 	    render: function render() {
-	        return React.createElement("div", { className: "filter-container" }, React.createElement("input", { type: "text", name: "filter", placeholder: this.props.placeholderText, className: "form-control", onChange: this.handleChange }));
+	        return React.createElement('div', { className: 'filter-container' }, React.createElement('input', { type: 'text', name: 'filter', placeholder: this.props.placeholderText, className: 'form-control', onChange: this.handleChange }));
 	    }
 	});
 
 	module.exports = GridFilter;
 
 /***/ },
-/* 176 */
+/* 189 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -7425,12 +9539,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 	var React = __webpack_require__(2);
-	var assign = __webpack_require__(161);
+	var createReactClass = __webpack_require__(13);
+	var assign = __webpack_require__(174);
 
 	//needs props maxPage, currentPage, nextFunction, prevFunction
-	var GridPagination = React.createClass({
-	    displayName: 'GridPagination',
-
+	var GridPagination = createReactClass({
 	    getDefaultProps: function getDefaultProps() {
 	        return {
 	            "maxPage": 0,
@@ -7488,7 +9601,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = GridPagination;
 
 /***/ },
-/* 177 */
+/* 190 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -7497,13 +9610,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 	var React = __webpack_require__(2);
-	var includes = __webpack_require__(178);
-	var without = __webpack_require__(182);
-	var find = __webpack_require__(130);
+	var createReactClass = __webpack_require__(13);
+	var includes = __webpack_require__(191);
+	var without = __webpack_require__(195);
+	var find = __webpack_require__(143);
 
-	var GridSettings = React.createClass({
-	    displayName: 'GridSettings',
-
+	var GridSettings = createReactClass({
 	    getDefaultProps: function getDefaultProps() {
 	        return {
 	            "columns": [],
@@ -7568,14 +9680,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = GridSettings;
 
 /***/ },
-/* 178 */
+/* 191 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseIndexOf = __webpack_require__(156),
-	    isArrayLike = __webpack_require__(94),
-	    isString = __webpack_require__(179),
-	    toInteger = __webpack_require__(134),
-	    values = __webpack_require__(180);
+	var baseIndexOf = __webpack_require__(169),
+	    isArrayLike = __webpack_require__(107),
+	    isString = __webpack_require__(192),
+	    toInteger = __webpack_require__(147),
+	    values = __webpack_require__(193);
 
 	/* Built-in method references for those with the same name as other `lodash` methods. */
 	var nativeMax = Math.max;
@@ -7627,12 +9739,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 179 */
+/* 192 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGetTag = __webpack_require__(29),
-	    isArray = __webpack_require__(71),
-	    isObjectLike = __webpack_require__(80);
+	var baseGetTag = __webpack_require__(42),
+	    isArray = __webpack_require__(84),
+	    isObjectLike = __webpack_require__(93);
 
 	/** `Object#toString` result references. */
 	var stringTag = '[object String]';
@@ -7663,11 +9775,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 180 */
+/* 193 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseValues = __webpack_require__(181),
-	    keys = __webpack_require__(75);
+	var baseValues = __webpack_require__(194),
+	    keys = __webpack_require__(88);
 
 	/**
 	 * Creates an array of the own enumerable string keyed property values of `object`.
@@ -7703,10 +9815,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 181 */
+/* 194 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayMap = __webpack_require__(7);
+	var arrayMap = __webpack_require__(20);
 
 	/**
 	 * The base implementation of `_.values` and `_.valuesIn` which creates an
@@ -7728,12 +9840,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 182 */
+/* 195 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseDifference = __webpack_require__(154),
-	    baseRest = __webpack_require__(144),
-	    isArrayLikeObject = __webpack_require__(160);
+	var baseDifference = __webpack_require__(167),
+	    baseRest = __webpack_require__(157),
+	    isArrayLikeObject = __webpack_require__(173);
 
 	/**
 	 * Creates an array excluding all given values using
@@ -7765,35 +9877,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 183 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/*
-	   See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
-	*/
-	"use strict";
-
-	var React = __webpack_require__(2);
-
-	var GridNoData = React.createClass({
-	    displayName: "GridNoData",
-
-	    getDefaultProps: function getDefaultProps() {
-	        return {
-	            "noDataMessage": "No Data"
-	        };
-	    },
-	    render: function render() {
-	        var that = this;
-
-	        return React.createElement("div", null, this.props.noDataMessage);
-	    }
-	});
-
-	module.exports = GridNoData;
-
-/***/ },
-/* 184 */
+/* 196 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -7802,18 +9886,44 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 	var React = __webpack_require__(2);
-	var ColumnProperties = __webpack_require__(5);
-	var deep = __webpack_require__(185);
-	var isFunction = __webpack_require__(28);
-	var zipObject = __webpack_require__(192);
-	var assign = __webpack_require__(161);
-	var defaults = __webpack_require__(194);
-	var toPairs = __webpack_require__(200);
-	var without = __webpack_require__(182);
+	var createReactClass = __webpack_require__(13);
 
-	var GridRow = React.createClass({
-	    displayName: 'GridRow',
+	var GridNoData = createReactClass({
+	    getDefaultProps: function getDefaultProps() {
+	        return {
+	            "noDataMessage": "No Data"
+	        };
+	    },
+	    render: function render() {
+	        var that = this;
 
+	        return React.createElement('div', null, this.props.noDataMessage);
+	    }
+	});
+
+	module.exports = GridNoData;
+
+/***/ },
+/* 197 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/*
+	   See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
+	*/
+	'use strict';
+
+	var React = __webpack_require__(2);
+	var createReactClass = __webpack_require__(13);
+	var ColumnProperties = __webpack_require__(18);
+	var deep = __webpack_require__(198);
+	var isFunction = __webpack_require__(41);
+	var zipObject = __webpack_require__(205);
+	var assign = __webpack_require__(174);
+	var defaults = __webpack_require__(207);
+	var toPairs = __webpack_require__(213);
+	var without = __webpack_require__(195);
+
+	var GridRow = createReactClass({
 	    getDefaultProps: function getDefaultProps() {
 	        return {
 	            "isChildRow": false,
@@ -7990,17 +10100,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = GridRow;
 
 /***/ },
-/* 185 */
+/* 198 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var forEach = __webpack_require__(186);
-	var isObject = __webpack_require__(35);
-	var isArray = __webpack_require__(71);
-	var isFunction = __webpack_require__(28);
-	var isPlainObject = __webpack_require__(189);
-	var forOwn = __webpack_require__(191);
+	var forEach = __webpack_require__(199);
+	var isObject = __webpack_require__(48);
+	var isArray = __webpack_require__(84);
+	var isFunction = __webpack_require__(41);
+	var isPlainObject = __webpack_require__(202);
+	var forOwn = __webpack_require__(204);
 
 	// Credits: https://github.com/documentcloud/underscore-contrib
 	// Sub module: underscore.object.selectors
@@ -8145,13 +10255,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 186 */
+/* 199 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayEach = __webpack_require__(187),
-	    baseEach = __webpack_require__(123),
-	    castFunction = __webpack_require__(188),
-	    isArray = __webpack_require__(71);
+	var arrayEach = __webpack_require__(200),
+	    baseEach = __webpack_require__(136),
+	    castFunction = __webpack_require__(201),
+	    isArray = __webpack_require__(84);
 
 	/**
 	 * Iterates over elements of `collection` and invokes `iteratee` for each element.
@@ -8192,7 +10302,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 187 */
+/* 200 */
 /***/ function(module, exports) {
 
 	/**
@@ -8220,10 +10330,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 188 */
+/* 201 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var identity = __webpack_require__(118);
+	var identity = __webpack_require__(131);
 
 	/**
 	 * Casts `value` to `identity` if it's not a function.
@@ -8240,12 +10350,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 189 */
+/* 202 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGetTag = __webpack_require__(29),
-	    getPrototype = __webpack_require__(190),
-	    isObjectLike = __webpack_require__(80);
+	var baseGetTag = __webpack_require__(42),
+	    getPrototype = __webpack_require__(203),
+	    isObjectLike = __webpack_require__(93);
 
 	/** `Object#toString` result references. */
 	var objectTag = '[object Object]';
@@ -8308,10 +10418,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 190 */
+/* 203 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var overArg = __webpack_require__(93);
+	var overArg = __webpack_require__(106);
 
 	/** Built-in value references. */
 	var getPrototype = overArg(Object.getPrototypeOf, Object);
@@ -8320,11 +10430,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 191 */
+/* 204 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseForOwn = __webpack_require__(124),
-	    castFunction = __webpack_require__(188);
+	var baseForOwn = __webpack_require__(137),
+	    castFunction = __webpack_require__(201);
 
 	/**
 	 * Iterates over own enumerable string keyed properties of an object and
@@ -8362,11 +10472,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 192 */
+/* 205 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var assignValue = __webpack_require__(162),
-	    baseZipObject = __webpack_require__(193);
+	var assignValue = __webpack_require__(175),
+	    baseZipObject = __webpack_require__(206);
 
 	/**
 	 * This method is like `_.fromPairs` except that it accepts two arrays,
@@ -8392,7 +10502,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 193 */
+/* 206 */
 /***/ function(module, exports) {
 
 	/**
@@ -8421,13 +10531,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 194 */
+/* 207 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var apply = __webpack_require__(146),
-	    assignInWith = __webpack_require__(195),
-	    baseRest = __webpack_require__(144),
-	    customDefaultsAssignIn = __webpack_require__(199);
+	var apply = __webpack_require__(159),
+	    assignInWith = __webpack_require__(208),
+	    baseRest = __webpack_require__(157),
+	    customDefaultsAssignIn = __webpack_require__(212);
 
 	/**
 	 * Assigns own and inherited enumerable string keyed properties of source
@@ -8459,12 +10569,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 195 */
+/* 208 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var copyObject = __webpack_require__(164),
-	    createAssigner = __webpack_require__(165),
-	    keysIn = __webpack_require__(196);
+	var copyObject = __webpack_require__(177),
+	    createAssigner = __webpack_require__(178),
+	    keysIn = __webpack_require__(209);
 
 	/**
 	 * This method is like `_.assignIn` except that it accepts `customizer`
@@ -8503,12 +10613,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 196 */
+/* 209 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayLikeKeys = __webpack_require__(76),
-	    baseKeysIn = __webpack_require__(197),
-	    isArrayLike = __webpack_require__(94);
+	var arrayLikeKeys = __webpack_require__(89),
+	    baseKeysIn = __webpack_require__(210),
+	    isArrayLike = __webpack_require__(107);
 
 	/**
 	 * Creates an array of the own and inherited enumerable property names of `object`.
@@ -8541,12 +10651,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 197 */
+/* 210 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isObject = __webpack_require__(35),
-	    isPrototype = __webpack_require__(91),
-	    nativeKeysIn = __webpack_require__(198);
+	var isObject = __webpack_require__(48),
+	    isPrototype = __webpack_require__(104),
+	    nativeKeysIn = __webpack_require__(211);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -8580,7 +10690,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 198 */
+/* 211 */
 /***/ function(module, exports) {
 
 	/**
@@ -8606,10 +10716,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 199 */
+/* 212 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var eq = __webpack_require__(16);
+	var eq = __webpack_require__(29);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -8641,11 +10751,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 200 */
+/* 213 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var createToPairs = __webpack_require__(201),
-	    keys = __webpack_require__(75);
+	var createToPairs = __webpack_require__(214),
+	    keys = __webpack_require__(88);
 
 	/**
 	 * Creates an array of own enumerable string keyed-value pairs for `object`
@@ -8677,13 +10787,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 201 */
+/* 214 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseToPairs = __webpack_require__(202),
-	    getTag = __webpack_require__(95),
-	    mapToArray = __webpack_require__(65),
-	    setToPairs = __webpack_require__(203);
+	var baseToPairs = __webpack_require__(215),
+	    getTag = __webpack_require__(108),
+	    mapToArray = __webpack_require__(78),
+	    setToPairs = __webpack_require__(216);
 
 	/** `Object#toString` result references. */
 	var mapTag = '[object Map]',
@@ -8713,10 +10823,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 202 */
+/* 215 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayMap = __webpack_require__(7);
+	var arrayMap = __webpack_require__(20);
 
 	/**
 	 * The base implementation of `_.toPairs` and `_.toPairsIn` which creates an array
@@ -8737,7 +10847,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 203 */
+/* 216 */
 /***/ function(module, exports) {
 
 	/**
@@ -8761,7 +10871,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 204 */
+/* 217 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -8771,13 +10881,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	   See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 	*/
-	"use strict";
+	'use strict';
 
 	var React = __webpack_require__(2);
+	var createReactClass = __webpack_require__(13);
 
-	var CustomRowComponentContainer = React.createClass({
-	  displayName: "CustomRowComponentContainer",
-
+	var CustomRowComponentContainer = createReactClass({
 	  getDefaultProps: function getDefaultProps() {
 	    return {
 	      "data": [],
@@ -8792,7 +10901,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    if (typeof that.props.customComponent !== 'function') {
 	      console.log("Couldn't find valid template.");
-	      return React.createElement("div", { className: this.props.className });
+	      return React.createElement('div', { className: this.props.className });
 	    }
 
 	    var nodes = this.props.data.map(function (row, index) {
@@ -8800,14 +10909,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	    });
 
 	    var footer = this.props.showPager && this.props.pagingContent;
-	    return React.createElement("div", { className: this.props.className, style: this.props.style }, nodes);
+	    return React.createElement('div', { className: this.props.className, style: this.props.style }, nodes);
 	  }
 	});
 
 	module.exports = CustomRowComponentContainer;
 
 /***/ },
-/* 205 */
+/* 218 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -8817,7 +10926,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	   See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 	*/
-	"use strict";
+	'use strict';
 
 	var _extends = Object.assign || function (target) {
 	  for (var i = 1; i < arguments.length; i++) {
@@ -8830,10 +10939,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 	var React = __webpack_require__(2);
+	var createReactClass = __webpack_require__(13);
 
-	var CustomPaginationContainer = React.createClass({
-	  displayName: "CustomPaginationContainer",
-
+	var CustomPaginationContainer = createReactClass({
 	  getDefaultProps: function getDefaultProps() {
 	    return {
 	      "maxPage": 0,
@@ -8849,7 +10957,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    if (typeof that.props.customPagerComponent !== 'function') {
 	      console.log("Couldn't find valid template.");
-	      return React.createElement("div", null);
+	      return React.createElement('div', null);
 	    }
 
 	    return React.createElement(that.props.customPagerComponent, _extends({}, this.props.customPagerComponentOptions, { maxPage: this.props.maxPage, nextText: this.props.nextText, previousText: this.props.previousText, currentPage: this.props.currentPage, setPage: this.props.setPage, previous: this.props.previous, next: this.props.next }));
@@ -8859,19 +10967,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = CustomPaginationContainer;
 
 /***/ },
-/* 206 */
+/* 219 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
 	   See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 	*/
-	"use strict";
+	'use strict';
 
 	var React = __webpack_require__(2);
+	var createReactClass = __webpack_require__(13);
 
-	var CustomFilterContainer = React.createClass({
-	  displayName: "CustomFilterContainer",
-
+	var CustomFilterContainer = createReactClass({
 	  getDefaultProps: function getDefaultProps() {
 	    return {
 	      "placeholderText": ""
@@ -8882,7 +10989,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    if (typeof that.props.customFilterComponent !== 'function') {
 	      console.log("Couldn't find valid template.");
-	      return React.createElement("div", null);
+	      return React.createElement('div', null);
 	    }
 
 	    return React.createElement(that.props.customFilterComponent, {
@@ -8896,11 +11003,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = CustomFilterContainer;
 
 /***/ },
-/* 207 */
+/* 220 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseSlice = __webpack_require__(208),
-	    toInteger = __webpack_require__(134);
+	var baseSlice = __webpack_require__(221),
+	    toInteger = __webpack_require__(147);
 
 	/**
 	 * Creates a slice of `array` with `n` elements dropped from the beginning.
@@ -8940,7 +11047,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 208 */
+/* 221 */
 /***/ function(module, exports) {
 
 	/**
@@ -8977,11 +11084,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 209 */
+/* 222 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseSlice = __webpack_require__(208),
-	    toInteger = __webpack_require__(134);
+	var baseSlice = __webpack_require__(221),
+	    toInteger = __webpack_require__(147);
 
 	/**
 	 * Creates a slice of `array` with `n` elements dropped from the end.
@@ -9022,11 +11129,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 210 */
+/* 223 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseSlice = __webpack_require__(208),
-	    toInteger = __webpack_require__(134);
+	var baseSlice = __webpack_require__(221),
+	    toInteger = __webpack_require__(147);
 
 	/**
 	 * Creates a slice of `array` with `n` elements taken from the beginning.
@@ -9065,10 +11172,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 211 */
+/* 224 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseSlice = __webpack_require__(208);
+	var baseSlice = __webpack_require__(221);
 
 	/**
 	 * Gets all but the last element of `array`.
@@ -9093,13 +11200,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 212 */
+/* 225 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayMap = __webpack_require__(7),
-	    baseIntersection = __webpack_require__(213),
-	    baseRest = __webpack_require__(144),
-	    castArrayLikeObject = __webpack_require__(214);
+	var arrayMap = __webpack_require__(20),
+	    baseIntersection = __webpack_require__(226),
+	    baseRest = __webpack_require__(157),
+	    castArrayLikeObject = __webpack_require__(227);
 
 	/**
 	 * Creates an array of unique values that are included in all given arrays
@@ -9129,15 +11236,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 213 */
+/* 226 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var SetCache = __webpack_require__(58),
-	    arrayIncludes = __webpack_require__(155),
-	    arrayIncludesWith = __webpack_require__(159),
-	    arrayMap = __webpack_require__(7),
-	    baseUnary = __webpack_require__(88),
-	    cacheHas = __webpack_require__(62);
+	var SetCache = __webpack_require__(71),
+	    arrayIncludes = __webpack_require__(168),
+	    arrayIncludesWith = __webpack_require__(172),
+	    arrayMap = __webpack_require__(20),
+	    baseUnary = __webpack_require__(101),
+	    cacheHas = __webpack_require__(75);
 
 	/* Built-in method references for those with the same name as other `lodash` methods. */
 	var nativeMin = Math.min;
@@ -9209,10 +11316,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 214 */
+/* 227 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isArrayLikeObject = __webpack_require__(160);
+	var isArrayLikeObject = __webpack_require__(173);
 
 	/**
 	 * Casts `value` to an empty array if it's not an array like object.
@@ -9229,17 +11336,17 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 215 */
+/* 228 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseKeys = __webpack_require__(90),
-	    getTag = __webpack_require__(95),
-	    isArguments = __webpack_require__(78),
-	    isArray = __webpack_require__(71),
-	    isArrayLike = __webpack_require__(94),
-	    isBuffer = __webpack_require__(81),
-	    isPrototype = __webpack_require__(91),
-	    isTypedArray = __webpack_require__(85);
+	var baseKeys = __webpack_require__(103),
+	    getTag = __webpack_require__(108),
+	    isArguments = __webpack_require__(91),
+	    isArray = __webpack_require__(84),
+	    isArrayLike = __webpack_require__(107),
+	    isBuffer = __webpack_require__(94),
+	    isPrototype = __webpack_require__(104),
+	    isTypedArray = __webpack_require__(98);
 
 	/** `Object#toString` result references. */
 	var mapTag = '[object Map]',
@@ -9312,7 +11419,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 216 */
+/* 229 */
 /***/ function(module, exports) {
 
 	/**
@@ -9340,7 +11447,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 217 */
+/* 230 */
 /***/ function(module, exports) {
 
 	/**
@@ -9368,17 +11475,17 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 218 */
+/* 231 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayMap = __webpack_require__(7),
-	    baseClone = __webpack_require__(219),
-	    baseUnset = __webpack_require__(242),
-	    castPath = __webpack_require__(106),
-	    copyObject = __webpack_require__(164),
-	    customOmitClone = __webpack_require__(245),
-	    flatRest = __webpack_require__(171),
-	    getAllKeysIn = __webpack_require__(227);
+	var arrayMap = __webpack_require__(20),
+	    baseClone = __webpack_require__(232),
+	    baseUnset = __webpack_require__(255),
+	    castPath = __webpack_require__(119),
+	    copyObject = __webpack_require__(177),
+	    customOmitClone = __webpack_require__(258),
+	    flatRest = __webpack_require__(184),
+	    getAllKeysIn = __webpack_require__(240);
 
 	/** Used to compose bitmasks for cloning. */
 	var CLONE_DEEP_FLAG = 1,
@@ -9431,28 +11538,28 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 219 */
+/* 232 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var Stack = __webpack_require__(11),
-	    arrayEach = __webpack_require__(187),
-	    assignValue = __webpack_require__(162),
-	    baseAssign = __webpack_require__(220),
-	    baseAssignIn = __webpack_require__(221),
-	    cloneBuffer = __webpack_require__(222),
-	    copyArray = __webpack_require__(223),
-	    copySymbols = __webpack_require__(224),
-	    copySymbolsIn = __webpack_require__(225),
-	    getAllKeys = __webpack_require__(68),
-	    getAllKeysIn = __webpack_require__(227),
-	    getTag = __webpack_require__(95),
-	    initCloneArray = __webpack_require__(228),
-	    initCloneByTag = __webpack_require__(229),
-	    initCloneObject = __webpack_require__(240),
-	    isArray = __webpack_require__(71),
-	    isBuffer = __webpack_require__(81),
-	    isObject = __webpack_require__(35),
-	    keys = __webpack_require__(75);
+	var Stack = __webpack_require__(24),
+	    arrayEach = __webpack_require__(200),
+	    assignValue = __webpack_require__(175),
+	    baseAssign = __webpack_require__(233),
+	    baseAssignIn = __webpack_require__(234),
+	    cloneBuffer = __webpack_require__(235),
+	    copyArray = __webpack_require__(236),
+	    copySymbols = __webpack_require__(237),
+	    copySymbolsIn = __webpack_require__(238),
+	    getAllKeys = __webpack_require__(81),
+	    getAllKeysIn = __webpack_require__(240),
+	    getTag = __webpack_require__(108),
+	    initCloneArray = __webpack_require__(241),
+	    initCloneByTag = __webpack_require__(242),
+	    initCloneObject = __webpack_require__(253),
+	    isArray = __webpack_require__(84),
+	    isBuffer = __webpack_require__(94),
+	    isObject = __webpack_require__(48),
+	    keys = __webpack_require__(88);
 
 	/** Used to compose bitmasks for cloning. */
 	var CLONE_DEEP_FLAG = 1,
@@ -9590,11 +11697,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 220 */
+/* 233 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var copyObject = __webpack_require__(164),
-	    keys = __webpack_require__(75);
+	var copyObject = __webpack_require__(177),
+	    keys = __webpack_require__(88);
 
 	/**
 	 * The base implementation of `_.assign` without support for multiple sources
@@ -9613,11 +11720,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 221 */
+/* 234 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var copyObject = __webpack_require__(164),
-	    keysIn = __webpack_require__(196);
+	var copyObject = __webpack_require__(177),
+	    keysIn = __webpack_require__(209);
 
 	/**
 	 * The base implementation of `_.assignIn` without support for multiple sources
@@ -9636,10 +11743,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 222 */
+/* 235 */
 /***/ function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(module) {var root = __webpack_require__(31);
+	/* WEBPACK VAR INJECTION */(function(module) {var root = __webpack_require__(44);
 
 	/** Detect free variable `exports`. */
 	var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
@@ -9675,10 +11782,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = cloneBuffer;
 
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(82)(module)))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(95)(module)))
 
 /***/ },
-/* 223 */
+/* 236 */
 /***/ function(module, exports) {
 
 	/**
@@ -9704,11 +11811,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 224 */
+/* 237 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var copyObject = __webpack_require__(164),
-	    getSymbols = __webpack_require__(72);
+	var copyObject = __webpack_require__(177),
+	    getSymbols = __webpack_require__(85);
 
 	/**
 	 * Copies own symbols of `source` to `object`.
@@ -9726,11 +11833,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 225 */
+/* 238 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var copyObject = __webpack_require__(164),
-	    getSymbolsIn = __webpack_require__(226);
+	var copyObject = __webpack_require__(177),
+	    getSymbolsIn = __webpack_require__(239);
 
 	/**
 	 * Copies own and inherited symbols of `source` to `object`.
@@ -9748,13 +11855,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 226 */
+/* 239 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayPush = __webpack_require__(70),
-	    getPrototype = __webpack_require__(190),
-	    getSymbols = __webpack_require__(72),
-	    stubArray = __webpack_require__(74);
+	var arrayPush = __webpack_require__(83),
+	    getPrototype = __webpack_require__(203),
+	    getSymbols = __webpack_require__(85),
+	    stubArray = __webpack_require__(87);
 
 	/* Built-in method references for those with the same name as other `lodash` methods. */
 	var nativeGetSymbols = Object.getOwnPropertySymbols;
@@ -9779,12 +11886,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 227 */
+/* 240 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGetAllKeys = __webpack_require__(69),
-	    getSymbolsIn = __webpack_require__(226),
-	    keysIn = __webpack_require__(196);
+	var baseGetAllKeys = __webpack_require__(82),
+	    getSymbolsIn = __webpack_require__(239),
+	    keysIn = __webpack_require__(209);
 
 	/**
 	 * Creates an array of own and inherited enumerable property names and
@@ -9802,7 +11909,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 228 */
+/* 241 */
 /***/ function(module, exports) {
 
 	/** Used for built-in method references. */
@@ -9834,16 +11941,16 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 229 */
+/* 242 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var cloneArrayBuffer = __webpack_require__(230),
-	    cloneDataView = __webpack_require__(231),
-	    cloneMap = __webpack_require__(232),
-	    cloneRegExp = __webpack_require__(235),
-	    cloneSet = __webpack_require__(236),
-	    cloneSymbol = __webpack_require__(238),
-	    cloneTypedArray = __webpack_require__(239);
+	var cloneArrayBuffer = __webpack_require__(243),
+	    cloneDataView = __webpack_require__(244),
+	    cloneMap = __webpack_require__(245),
+	    cloneRegExp = __webpack_require__(248),
+	    cloneSet = __webpack_require__(249),
+	    cloneSymbol = __webpack_require__(251),
+	    cloneTypedArray = __webpack_require__(252);
 
 	/** `Object#toString` result references. */
 	var boolTag = '[object Boolean]',
@@ -9920,10 +12027,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 230 */
+/* 243 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var Uint8Array = __webpack_require__(64);
+	var Uint8Array = __webpack_require__(77);
 
 	/**
 	 * Creates a clone of `arrayBuffer`.
@@ -9942,10 +12049,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 231 */
+/* 244 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var cloneArrayBuffer = __webpack_require__(230);
+	var cloneArrayBuffer = __webpack_require__(243);
 
 	/**
 	 * Creates a clone of `dataView`.
@@ -9964,12 +12071,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 232 */
+/* 245 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var addMapEntry = __webpack_require__(233),
-	    arrayReduce = __webpack_require__(234),
-	    mapToArray = __webpack_require__(65);
+	var addMapEntry = __webpack_require__(246),
+	    arrayReduce = __webpack_require__(247),
+	    mapToArray = __webpack_require__(78);
 
 	/** Used to compose bitmasks for cloning. */
 	var CLONE_DEEP_FLAG = 1;
@@ -9992,7 +12099,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 233 */
+/* 246 */
 /***/ function(module, exports) {
 
 	/**
@@ -10013,7 +12120,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 234 */
+/* 247 */
 /***/ function(module, exports) {
 
 	/**
@@ -10045,7 +12152,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 235 */
+/* 248 */
 /***/ function(module, exports) {
 
 	/** Used to match `RegExp` flags from their coerced string values. */
@@ -10068,12 +12175,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 236 */
+/* 249 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var addSetEntry = __webpack_require__(237),
-	    arrayReduce = __webpack_require__(234),
-	    setToArray = __webpack_require__(66);
+	var addSetEntry = __webpack_require__(250),
+	    arrayReduce = __webpack_require__(247),
+	    setToArray = __webpack_require__(79);
 
 	/** Used to compose bitmasks for cloning. */
 	var CLONE_DEEP_FLAG = 1;
@@ -10096,7 +12203,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 237 */
+/* 250 */
 /***/ function(module, exports) {
 
 	/**
@@ -10117,10 +12224,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 238 */
+/* 251 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var Symbol = __webpack_require__(30);
+	var Symbol = __webpack_require__(43);
 
 	/** Used to convert symbols to primitives and strings. */
 	var symbolProto = Symbol ? Symbol.prototype : undefined,
@@ -10141,10 +12248,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 239 */
+/* 252 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var cloneArrayBuffer = __webpack_require__(230);
+	var cloneArrayBuffer = __webpack_require__(243);
 
 	/**
 	 * Creates a clone of `typedArray`.
@@ -10163,12 +12270,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 240 */
+/* 253 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseCreate = __webpack_require__(241),
-	    getPrototype = __webpack_require__(190),
-	    isPrototype = __webpack_require__(91);
+	var baseCreate = __webpack_require__(254),
+	    getPrototype = __webpack_require__(203),
+	    isPrototype = __webpack_require__(104);
 
 	/**
 	 * Initializes an object clone.
@@ -10187,10 +12294,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 241 */
+/* 254 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isObject = __webpack_require__(35);
+	var isObject = __webpack_require__(48);
 
 	/** Built-in value references. */
 	var objectCreate = Object.create;
@@ -10223,13 +12330,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 242 */
+/* 255 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var castPath = __webpack_require__(106),
-	    last = __webpack_require__(243),
-	    parent = __webpack_require__(244),
-	    toKey = __webpack_require__(114);
+	var castPath = __webpack_require__(119),
+	    last = __webpack_require__(256),
+	    parent = __webpack_require__(257),
+	    toKey = __webpack_require__(127);
 
 	/**
 	 * The base implementation of `_.unset`.
@@ -10249,7 +12356,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 243 */
+/* 256 */
 /***/ function(module, exports) {
 
 	/**
@@ -10275,11 +12382,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 244 */
+/* 257 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGet = __webpack_require__(105),
-	    baseSlice = __webpack_require__(208);
+	var baseGet = __webpack_require__(118),
+	    baseSlice = __webpack_require__(221);
 
 	/**
 	 * Gets the parent value at `path` of `object`.
@@ -10297,10 +12404,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 245 */
+/* 258 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isPlainObject = __webpack_require__(189);
+	var isPlainObject = __webpack_require__(202);
 
 	/**
 	 * Used by `_.omit` to customize its `_.cloneDeep` use to only clone plain
@@ -10319,11 +12426,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 246 */
+/* 259 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseOrderBy = __webpack_require__(140),
-	    isArray = __webpack_require__(71);
+	var baseOrderBy = __webpack_require__(153),
+	    isArray = __webpack_require__(84);
 
 	/**
 	 * This method is like `_.sortBy` except that it allows specifying the sort
@@ -10372,14 +12479,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 247 */
+/* 260 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arraySome = __webpack_require__(61),
-	    baseIteratee = __webpack_require__(8),
-	    baseSome = __webpack_require__(248),
-	    isArray = __webpack_require__(71),
-	    isIterateeCall = __webpack_require__(152);
+	var arraySome = __webpack_require__(74),
+	    baseIteratee = __webpack_require__(21),
+	    baseSome = __webpack_require__(261),
+	    isArray = __webpack_require__(84),
+	    isIterateeCall = __webpack_require__(165);
 
 	/**
 	 * Checks if `predicate` returns truthy for **any** element of `collection`.
@@ -10429,10 +12536,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 248 */
+/* 261 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseEach = __webpack_require__(123);
+	var baseEach = __webpack_require__(136);
 
 	/**
 	 * The base implementation of `_.some` without support for iteratee shorthands.

--- a/docs/src/markdown/customization.md
+++ b/docs/src/markdown/customization.md
@@ -199,7 +199,7 @@ var someData =  [
 We want the **name** column to be a link to `/speakers/state/name` (where state and name are pulled in from the data). We can define a customComponent to be rendered as follows:
 
 ```
-var LinkComponent = React.createClass({
+var LinkComponent = createReactClass({
   render: function(){
     url ="speakers/" + this.props.rowData.state + "/" + this.props.data;
     return <a href={url}>{this.props.data}</a>
@@ -210,7 +210,7 @@ var LinkComponent = React.createClass({
 Additionally, we want the city and state column headers to be highlighted a specific color and have a filter by column input. We can define a custom header component as:
 
 ```
-var HeaderComponent = React.createClass({
+var HeaderComponent = createReactClass({
   textOnClick: function(e) {
     e.stopPropagation();
   },
@@ -373,7 +373,7 @@ Sometimes you may want to display grid data in a format other than a grid but st
 We are going to render our grid as a series of cards, keeping the pagination and filtering from Griddle in tact. Assume we are using the same data in the custom column example. We will need to create a custom component as follows:
 
 ```
-var OtherComponent = React.createClass({
+var OtherComponent = createReactClass({
   getDefaultProps: function(){
     return { "data": {} };
   },
@@ -423,7 +423,7 @@ In some cases, it may be ideal to use Griddle but display a global format other 
 As stated above we are going to render a visualization of temperature data rather than a chart. To start off we need to create a visualization component that uses a data property to obtain its values (the following example uses the awesome [chartist library](http://gionkunz.github.io/chartist-js/) and [accompanying react component](https://fraserxu.me/react-chartist/)):
 
 ```
-var TestLineChart = React.createClass({
+var TestLineChart = createReactClass({
   render: function(){
     var simpleLineChartData = {
       labels: _.keys(this.props.data[0]),
@@ -463,7 +463,7 @@ This example shows how to make a custom filter component with a custom filter fu
     });
   };
 
-  var customFilterComponent = React.createClass({
+  var customFilterComponent = createReactClass({
     getDefaultProps: function() {
       return {
         "query": ""
@@ -522,7 +522,7 @@ If you want to customize the paging component, just set the property 'useCustomP
 #####Example#####
 
 ```javascript
-var OtherPager = React.createClass({
+var OtherPager = createReactClass({
     getDefaultProps: function(){
         return{
             "maxPage": 0,
@@ -624,7 +624,7 @@ Outside of the NoData message, Griddle can take a `customNoDataComponent` that w
 #####Example:#####
 
 ```
-var NoDataComponent = React.createClass({
+var NoDataComponent = createReactClass({
     render: function(){
       return (<div>
           <h1>No data is available</h1>

--- a/docs/src/markdown/externalData.md
+++ b/docs/src/markdown/externalData.md
@@ -61,7 +61,7 @@ Griddle comes with a handful of required properties that must be set when workin
 Below is a skeleton wrapper component for dealing with external results in Griddle. This wrapper does not need to be used but it could serve as a decent starting point. 
 
 ```
-var ExternalComponent = React.createClass({
+var ExternalComponent = createReactClass({
     getInitialState: function(){
       var initial = { "results": [],
           "currentPage": 0,
@@ -131,7 +131,7 @@ getExternalData: function (page){
 The component was then modified to use getExternalData method for changing the pages and obtaining the initial data. Notice that filtering, sorting, etc are not enabled on this example (the next example has all of these options turned on). 
 
 ```javascript
-var ExternalSwapiComponent = React.createClass({
+var ExternalSwapiComponent = createReactClass({
     getInitialState: function(){
       var initial = { "results": [],
           "currentPage": 0,
@@ -184,7 +184,7 @@ Please keep in mind that a good deal of this code is to simulate the type of act
 ```javascript
 var externalData = fakeData.slice(0, 53);
  
-var SimulatedExternalComponent = React.createClass({
+var SimulatedExternalComponent = createReactClass({
     getInitialState: function(){
       var initial = { "results": [],
           "currentPage": 0,

--- a/docs/src/markdown/quickstart.md
+++ b/docs/src/markdown/quickstart.md
@@ -10,6 +10,7 @@ npm install griddle-react --save
 From there, require React and Griddle in your modules and you should be all set!
 ```
 var React = require('react');
+var createReactClass = require('create-react-class');
 var Griddle = require('griddle-react');
 ```
 Please take a look at a basic [gulp example](https://github.com/ryanlanciaux/griddle-gulp-test) or a [webpack example](https://github.com/ryanlanciaux/griddle-webpack-test) for more information.

--- a/examples/assets/scripts/GriddleWithCallback.js
+++ b/examples/assets/scripts/GriddleWithCallback.js
@@ -58,7 +58,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _ = __webpack_require__(2);
 	var Griddle = __webpack_require__(3);
 
-	var GriddleWithCallback = React.createClass({displayName: "GriddleWithCallback",
+	var GriddleWithCallback = createReactClass({displayName: "GriddleWithCallback",
 		getDefaultProps: function(){
 			return {
 				getExternalResults: null,
@@ -286,7 +286,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var CustomPaginationContainer = __webpack_require__(11);
 	var _ = __webpack_require__(2);
 
-	var Griddle = React.createClass({displayName: 'Griddle',
+	var Griddle = createReactClass({displayName: 'Griddle',
 	    getDefaultProps: function() {
 	        return{
 	            "columns": [],
@@ -850,7 +850,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var GridRowContainer = __webpack_require__(12);
 	var _ = __webpack_require__(2);
 
-	var GridTable = React.createClass({displayName: 'GridTable',
+	var GridTable = createReactClass({displayName: 'GridTable',
 	  getDefaultProps: function(){
 	    return{
 	      "data": [],
@@ -1064,7 +1064,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	*/
 	var React = __webpack_require__(1);
 
-	var GridFilter = React.createClass({displayName: 'GridFilter',
+	var GridFilter = createReactClass({displayName: 'GridFilter',
 	    getDefaultProps: function(){
 	      return {
 	        "placeholderText": ""
@@ -1098,7 +1098,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _ = __webpack_require__(2);
 
 	//needs props maxPage, currentPage, nextFunction, prevFunction
-	var GridPagination = React.createClass({displayName: 'GridPagination',
+	var GridPagination = createReactClass({displayName: 'GridPagination',
 	    getDefaultProps: function(){
 	        return{
 	            "maxPage": 0,
@@ -1182,7 +1182,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var React = __webpack_require__(1);
 	var _ = __webpack_require__(2);
 
-	var GridSettings = React.createClass({displayName: 'GridSettings',
+	var GridSettings = createReactClass({displayName: 'GridSettings',
 	    getDefaultProps: function(){
 	        return {
 	            "columns": [],
@@ -1284,7 +1284,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var React = __webpack_require__(1);
 	var _ = __webpack_require__(2);
 
-	var GridTitle = React.createClass({displayName: 'GridTitle',
+	var GridTitle = createReactClass({displayName: 'GridTitle',
 	    getDefaultProps: function(){
 	        return {
 	           "columns":[],
@@ -1372,7 +1372,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	*/
 	var React = __webpack_require__(1);
 
-	var GridNoData = React.createClass({displayName: 'GridNoData',
+	var GridNoData = createReactClass({displayName: 'GridNoData',
 	    getDefaultProps: function(){
 	        return {
 	            "noDataMessage": "No Data"
@@ -1405,7 +1405,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	*/
 	var React = __webpack_require__(1);
 
-	var CustomRowComponentContainer = React.createClass({displayName: 'CustomRowComponentContainer',
+	var CustomRowComponentContainer = createReactClass({displayName: 'CustomRowComponentContainer',
 	  getDefaultProps: function(){
 	    return{
 	      "data": [],
@@ -1453,7 +1453,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	*/
 	var React = __webpack_require__(1);
 
-	var CustomPaginationContainer = React.createClass({displayName: 'CustomPaginationContainer',
+	var CustomPaginationContainer = createReactClass({displayName: 'CustomPaginationContainer',
 	  getDefaultProps: function(){
 	    return{
 	      "maxPage": 0,
@@ -1494,7 +1494,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var React = __webpack_require__(1);
 	var GridRow = __webpack_require__(13);
 
-	var GridRowContainer = React.createClass({displayName: 'GridRowContainer',
+	var GridRowContainer = createReactClass({displayName: 'GridRowContainer',
 	    getDefaultProps: function(){
 	      return {
 	        "useGriddleStyles": true,
@@ -1579,7 +1579,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var React = __webpack_require__(1);
 	var _ = __webpack_require__(2);
 
-	var GridRow = React.createClass({displayName: 'GridRow',
+	var GridRow = createReactClass({displayName: 'GridRow',
 	    getDefaultProps: function(){
 	      return {
 	        "isChildRow": false,

--- a/examples/assets/scripts/testChart.jsx
+++ b/examples/assets/scripts/testChart.jsx
@@ -8,9 +8,10 @@
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
 var React = require('react');
+var createReactClass = require('create-react-class');
 var ChartistGraph = require('react-chartist'); 
 
-var TestChart = React.createClass({
+var TestChart = createReactClass({
 	getInitialProps: function(){
 
 	},

--- a/examples/assets/scripts/testComponent.js
+++ b/examples/assets/scripts/testComponent.js
@@ -2,7 +2,7 @@
 
 //This whole file is pretty junky... just an example
 
-var BoldFormatter = React.createClass({
+var BoldFormatter = createReactClass({
     render: function(){
         return <strong>{this.props.data}</strong>
     }
@@ -13,7 +13,7 @@ var externalData = fakeData.slice(0, 53);
 //This whole thing is throw-away code.
 //It's basically to show that you can wrap up griddle
 //and give external data to it from another source (api / localstorage / etc)
-var ExternalComponent = React.createClass({
+var ExternalComponent = createReactClass({
 
     getInitialState: function(){
       var initial = { "results": [],
@@ -116,7 +116,7 @@ var ExternalComponent = React.createClass({
 });
 
 
-var TestComponent = React.createClass({
+var TestComponent = createReactClass({
     getDefaultProps: function() {
         return{
             "simple": true,
@@ -145,14 +145,14 @@ var TestComponent = React.createClass({
     }
 });
 
-var CustomNoDataComponent = React.createClass({
+var CustomNoDataComponent = createReactClass({
     render: function() {
         return (
         <div>This is a custom component showing that there is no data to be displayed.</div>);
     }
 });
 
-var OtherComponent = React.createClass({
+var OtherComponent = createReactClass({
     getDefaultProps: function(){
         return { "data": {} };
     },
@@ -170,7 +170,7 @@ var OtherComponent = React.createClass({
     }
 });
 
-var OtherPager = React.createClass({
+var OtherPager = createReactClass({
     getDefaultProps: function(){
         return{
             "maxPage": 0,

--- a/examples/customization/customPaging.html
+++ b/examples/customization/customPaging.html
@@ -2,7 +2,7 @@
 
 
 <script type="text/jsx">
-var OtherPager = React.createClass({
+var OtherPager = createReactClass({
     getDefaultProps: function(){
         return{
             "maxPage": 0,

--- a/examples/customization/customRow.html
+++ b/examples/customization/customRow.html
@@ -4,7 +4,7 @@
 <script type="text/jsx">
 /** @jsx React.DOM */
 
-var OtherComponent = React.createClass({
+var OtherComponent = createReactClass({
   getDefaultProps: function(){
     return { "data": {} };
   },

--- a/examples/customization/nodata-component.html
+++ b/examples/customization/nodata-component.html
@@ -1,7 +1,7 @@
 <div id="griddle-nodata-component"></div>
 
 <script type="text/jsx">
-  var NoDataComponent = React.createClass({
+  var NoDataComponent = createReactClass({
     render: function(){
       return (<div className="noDataComponent">
         <h1>No data is available</h1>

--- a/examples/customization/testChart.html
+++ b/examples/customization/testChart.html
@@ -28,7 +28,7 @@ var data = [
 }
 ];
 
-var TestLineChart = React.createClass({
+var TestLineChart = createReactClass({
   render: function(){
     var type = this.props.type || 'Line'
     var simpleLineChartData = {

--- a/examples/externalData/external-simulated.html
+++ b/examples/externalData/external-simulated.html
@@ -3,7 +3,7 @@
 <script type="text/jsx">
 var externalData = fakeData.slice(0, 53);
 
-var SimulatedExternalComponent = React.createClass({
+var SimulatedExternalComponent = createReactClass({
     getInitialState: function(){
       var initial = { "results": [],
           "currentPage": 0,

--- a/examples/externalData/external-swapi.html
+++ b/examples/externalData/external-swapi.html
@@ -3,7 +3,7 @@
 <script type="text/javascript" src="scripts/swapi.min.js"></script>
 
 <script type="text/jsx">
-var Loading = React.createClass({
+var Loading = createReactClass({
   getDefaultProps: function(){
     return {
       loadingText: "Loading"
@@ -14,7 +14,7 @@ var Loading = React.createClass({
   }
 });
 
-var ExternalSwapiComponent = React.createClass({
+var ExternalSwapiComponent = createReactClass({
     getInitialState: function(){
       var initial = { "results": [],
           "currentPage": 0,

--- a/examples/infiniteScroll/infiniteScrollExternalResults.html
+++ b/examples/infiniteScroll/infiniteScrollExternalResults.html
@@ -67,7 +67,7 @@
 		}, 1000);
 	};
 
-	var Loading = React.createClass({
+	var Loading = createReactClass({
 		getDefaultProps: function(){
 			return {
 				loadingText: "Loading"

--- a/examples/properties/properties.html
+++ b/examples/properties/properties.html
@@ -476,7 +476,7 @@ var propertiesItem = [
     "default": "null"
   }
 ];
-var DefinitionItem = React.createClass({
+var DefinitionItem = createReactClass({
   getDefaultProps: function() {
     return { "data": {
       "property": "",

--- a/modules/customFilterContainer.jsx.js
+++ b/modules/customFilterContainer.jsx.js
@@ -1,13 +1,12 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
-"use strict";
+'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var CustomFilterContainer = React.createClass({
-  displayName: "CustomFilterContainer",
-
+var CustomFilterContainer = createReactClass({
   getDefaultProps: function getDefaultProps() {
     return {
       "placeholderText": ""
@@ -18,7 +17,7 @@ var CustomFilterContainer = React.createClass({
 
     if (typeof that.props.customFilterComponent !== 'function') {
       console.log("Couldn't find valid template.");
-      return React.createElement("div", null);
+      return React.createElement('div', null);
     }
 
     return React.createElement(that.props.customFilterComponent, {

--- a/modules/customPaginationContainer.jsx.js
+++ b/modules/customPaginationContainer.jsx.js
@@ -5,7 +5,7 @@
 
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
-"use strict";
+'use strict';
 
 var _extends = Object.assign || function (target) {
   for (var i = 1; i < arguments.length; i++) {
@@ -18,10 +18,9 @@ var _extends = Object.assign || function (target) {
 };
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var CustomPaginationContainer = React.createClass({
-  displayName: "CustomPaginationContainer",
-
+var CustomPaginationContainer = createReactClass({
   getDefaultProps: function getDefaultProps() {
     return {
       "maxPage": 0,
@@ -37,7 +36,7 @@ var CustomPaginationContainer = React.createClass({
 
     if (typeof that.props.customPagerComponent !== 'function') {
       console.log("Couldn't find valid template.");
-      return React.createElement("div", null);
+      return React.createElement('div', null);
     }
 
     return React.createElement(that.props.customPagerComponent, _extends({}, this.props.customPagerComponentOptions, { maxPage: this.props.maxPage, nextText: this.props.nextText, previousText: this.props.previousText, currentPage: this.props.currentPage, setPage: this.props.setPage, previous: this.props.previous, next: this.props.next }));

--- a/modules/customRowComponentContainer.jsx.js
+++ b/modules/customRowComponentContainer.jsx.js
@@ -5,13 +5,12 @@
 
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
-"use strict";
+'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var CustomRowComponentContainer = React.createClass({
-  displayName: "CustomRowComponentContainer",
-
+var CustomRowComponentContainer = createReactClass({
   getDefaultProps: function getDefaultProps() {
     return {
       "data": [],
@@ -26,7 +25,7 @@ var CustomRowComponentContainer = React.createClass({
 
     if (typeof that.props.customComponent !== 'function') {
       console.log("Couldn't find valid template.");
-      return React.createElement("div", { className: this.props.className });
+      return React.createElement('div', { className: this.props.className });
     }
 
     var nodes = this.props.data.map(function (row, index) {
@@ -34,7 +33,7 @@ var CustomRowComponentContainer = React.createClass({
     });
 
     var footer = this.props.showPager && this.props.pagingContent;
-    return React.createElement("div", { className: this.props.className, style: this.props.style }, nodes);
+    return React.createElement('div', { className: this.props.className, style: this.props.style }, nodes);
   }
 });
 

--- a/modules/gridFilter.jsx.js
+++ b/modules/gridFilter.jsx.js
@@ -1,13 +1,12 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
-"use strict";
+'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var GridFilter = React.createClass({
-    displayName: "GridFilter",
-
+var GridFilter = createReactClass({
     getDefaultProps: function getDefaultProps() {
         return {
             "placeholderText": ""
@@ -17,7 +16,7 @@ var GridFilter = React.createClass({
         this.props.changeFilter(event.target.value);
     },
     render: function render() {
-        return React.createElement("div", { className: "filter-container" }, React.createElement("input", { type: "text", name: "filter", placeholder: this.props.placeholderText, className: "form-control", onChange: this.handleChange }));
+        return React.createElement('div', { className: 'filter-container' }, React.createElement('input', { type: 'text', name: 'filter', placeholder: this.props.placeholderText, className: 'form-control', onChange: this.handleChange }));
     }
 });
 

--- a/modules/gridNoData.jsx.js
+++ b/modules/gridNoData.jsx.js
@@ -1,13 +1,12 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
-"use strict";
+'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var GridNoData = React.createClass({
-    displayName: "GridNoData",
-
+var GridNoData = createReactClass({
     getDefaultProps: function getDefaultProps() {
         return {
             "noDataMessage": "No Data"
@@ -16,7 +15,7 @@ var GridNoData = React.createClass({
     render: function render() {
         var that = this;
 
-        return React.createElement("div", null, this.props.noDataMessage);
+        return React.createElement('div', null, this.props.noDataMessage);
     }
 });
 

--- a/modules/gridPagination.jsx.js
+++ b/modules/gridPagination.jsx.js
@@ -4,12 +4,11 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var assign = require('lodash/assign');
 
 //needs props maxPage, currentPage, nextFunction, prevFunction
-var GridPagination = React.createClass({
-    displayName: 'GridPagination',
-
+var GridPagination = createReactClass({
     getDefaultProps: function getDefaultProps() {
         return {
             "maxPage": 0,

--- a/modules/gridRow.jsx.js
+++ b/modules/gridRow.jsx.js
@@ -4,6 +4,7 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var ColumnProperties = require('./columnProperties.js');
 var deep = require('./deep.js');
 var isFunction = require('lodash/isFunction');
@@ -13,9 +14,7 @@ var defaults = require('lodash/defaults');
 var toPairs = require('lodash/toPairs');
 var without = require('lodash/without');
 
-var GridRow = React.createClass({
-    displayName: 'GridRow',
-
+var GridRow = createReactClass({
     getDefaultProps: function getDefaultProps() {
         return {
             "isChildRow": false,

--- a/modules/gridRowContainer.jsx.js
+++ b/modules/gridRowContainer.jsx.js
@@ -4,12 +4,11 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var ColumnProperties = require('./columnProperties.js');
 var pick = require('lodash/pick');
 
-var GridRowContainer = React.createClass({
-  displayName: 'GridRowContainer',
-
+var GridRowContainer = createReactClass({
   getDefaultProps: function getDefaultProps() {
     return {
       "useGriddleStyles": true,

--- a/modules/gridSettings.jsx.js
+++ b/modules/gridSettings.jsx.js
@@ -4,13 +4,12 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var includes = require('lodash/includes');
 var without = require('lodash/without');
 var find = require('lodash/find');
 
-var GridSettings = React.createClass({
-    displayName: 'GridSettings',
-
+var GridSettings = createReactClass({
     getDefaultProps: function getDefaultProps() {
         return {
             "columns": [],

--- a/modules/gridTable.jsx.js
+++ b/modules/gridTable.jsx.js
@@ -4,14 +4,13 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var GridTitle = require('./gridTitle.jsx');
 var GridRowContainer = require('./gridRowContainer.jsx');
 var ColumnProperties = require('./columnProperties.js');
 var RowProperties = require('./rowProperties.js');
 
-var GridTable = React.createClass({
-  displayName: 'GridTable',
-
+var GridTable = createReactClass({
   getDefaultProps: function getDefaultProps() {
     return {
       "data": [],

--- a/modules/gridTitle.jsx.js
+++ b/modules/gridTitle.jsx.js
@@ -14,20 +14,17 @@ var _extends = Object.assign || function (target) {
 };
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var ColumnProperties = require('./columnProperties.js');
 var assign = require('lodash/assign');
 
-var DefaultHeaderComponent = React.createClass({
-    displayName: 'DefaultHeaderComponent',
-
+var DefaultHeaderComponent = createReactClass({
     render: function render() {
         return React.createElement('span', null, this.props.displayName);
     }
 });
 
-var GridTitle = React.createClass({
-    displayName: 'GridTitle',
-
+var GridTitle = createReactClass({
     getDefaultProps: function getDefaultProps() {
         return {
             "columnSettings": null,

--- a/modules/griddle.jsx.js
+++ b/modules/griddle.jsx.js
@@ -18,6 +18,8 @@ var _extends = Object.assign || function (target) {
 };
 
 var React = require('react');
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var GridTable = require('./gridTable.jsx');
 var GridFilter = require('./gridFilter.jsx');
 var GridPagination = require('./gridPagination.jsx');
@@ -53,9 +55,7 @@ var _property = require('lodash/property');
 var _get = require('lodash/get');
 var _some = require('lodash/some');
 
-var Griddle = React.createClass({
-    displayName: 'Griddle',
-
+var Griddle = createReactClass({
     statics: {
         GridTable: GridTable,
         GridFilter: GridFilter,
@@ -161,11 +161,11 @@ var Griddle = React.createClass({
         };
     },
     propTypes: {
-        isMultipleSelection: React.PropTypes.bool,
-        selectedRowIds: React.PropTypes.oneOfType([React.PropTypes.arrayOf(React.PropTypes.number), React.PropTypes.arrayOf(React.PropTypes.string)]),
-        uniqueIdentifier: React.PropTypes.string,
-        onSelectionChange: React.PropTypes.func,
-        columnFilterFunc: React.PropTypes.func
+        isMultipleSelection: PropTypes.bool,
+        selectedRowIds: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.number), PropTypes.arrayOf(PropTypes.string)]),
+        uniqueIdentifier: PropTypes.string,
+        onSelectionChange: PropTypes.func,
+        columnFilterFunc: PropTypes.func
     },
     defaultFilter: function defaultFilter(results, filter) {
         var that = this;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "griddle-react",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Griddle - A fast and flexible grid component for React.",
   "keywords": [
     "react-component",
@@ -11,14 +11,15 @@
   ],
   "main": "modules/griddle.jsx.js",
   "peerDependencies": {
-    "react": "^0.14.3 || ^15.0.1"
+    "react": "^0.14.3 || ^15.0.1 || ^16.0.0"
   },
   "dependencies": {
-    "lodash": "^4.12.0"
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "babel-jest": "^5.2.1",
     "babel-loader": "^5.3.3",
+    "create-react-class": "15.6.2",
     "grunt": "^0.4.5",
     "grunt-babel": "^5.0.3",
     "grunt-cli": "^1.2.0",
@@ -39,10 +40,11 @@
     "karma-webpack": "^1.7.0",
     "phantomjs-polyfill": "0.0.1",
     "phantomjs-prebuilt": "^2.1.7",
-    "react": "^0.14.3 || ^15.0.1",
+    "prop-types": "^15.6.0",
+    "react": "^0.14.3 || ^15.0.1 || ^16.0.0",
     "react-addons-test-utils": "^0.14.3 || ^15.0.1",
     "react-chartist": "^0.10.2",
-    "react-dom": "^0.14.3 || ^15.0.1",
+    "react-dom": "^0.14.3 || ^15.0.1 || ^16.0.0",
     "webpack": "1.12.3",
     "webpack-dev-server": "1.12.1"
   },

--- a/scripts/__tests__/gridFilter-test.js
+++ b/scripts/__tests__/gridFilter-test.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 var TestUtils = require('react-addons-test-utils');
 var GridFilter = require('../gridFilter.jsx');
 

--- a/scripts/__tests__/gridPagination-test.js
+++ b/scripts/__tests__/gridPagination-test.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 var GridPagination = require('../gridPagination.jsx');
 var TestUtils = require('react-addons-test-utils');
 

--- a/scripts/__tests__/gridRow-test.js
+++ b/scripts/__tests__/gridRow-test.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 var GridRow = require('../gridRow.jsx');
 var ColumnProperties = require('../columnProperties.js');
 var RowProperties = require('../rowProperties.js');
@@ -226,7 +227,7 @@ describe('GridRow', function(){
 
 		var mock = jasmine.createSpy();
 
-    const FakeTable = React.createClass({
+    const FakeTable = createReactClass({
       render() {
         return (<table>
           <tbody>
@@ -278,7 +279,7 @@ describe('GridRow', function(){
 
 		var mock = jasmine.createSpy();
 
-    const FakeTable = React.createClass({
+    const FakeTable = createReactClass({
       render() {
         return (<table>
           <tbody>

--- a/scripts/__tests__/gridSettings-test.js
+++ b/scripts/__tests__/gridSettings-test.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 var GridSettings = require('../gridSettings.jsx');
 var TestUtils = require('react-addons-test-utils');
 

--- a/scripts/__tests__/gridTitle-test.js
+++ b/scripts/__tests__/gridTitle-test.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 var GridTitle = require('../gridTitle.jsx');
 var TestUtils = require('react-addons-test-utils');
 var ColumnProperties = require('../columnProperties.js');

--- a/scripts/__tests__/griddle-test.js
+++ b/scripts/__tests__/griddle-test.js
@@ -1,10 +1,11 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 var ReactDOM = require('react-dom');
 var Griddle = require('../griddle.jsx');
 var TestUtils = require('react-addons-test-utils');
 var assign = require('lodash/assign');
 
-var SomeCustomComponent = React.createClass({
+var SomeCustomComponent = createReactClass({
   render: function(){
     return <h1>Test</h1>
   }
@@ -16,7 +17,7 @@ describe('Griddle', function() {
   var grid;
   var multipleSelectOptions;
 
-  var CustomGridComponent = React.createClass({
+  var CustomGridComponent = createReactClass({
     getInitialProps: function(){
       return {
         data: []
@@ -632,7 +633,7 @@ describe('Griddle', function() {
   });
 
   it('should display a warning if useCustomGridComponent and useCustomRowComponent are both true', function(){
-    var mock = React.createClass({ render: function(){ return <h1>mock</h1>}});
+    var mock = createReactClass({ render: function(){ return <h1>mock</h1>}});
     var grid2 = TestUtils.renderIntoDocument(<Griddle results={fakeData}
       useCustomGridComponent={true} customGridComponent={mock}
       useCustomRowComponent={true} customRowComponent={mock} />)

--- a/scripts/customFilterContainer.jsx
+++ b/scripts/customFilterContainer.jsx
@@ -2,8 +2,9 @@
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var CustomFilterContainer = React.createClass({
+var CustomFilterContainer = createReactClass({
   getDefaultProps: function(){
     return {
       "placeholderText": ""

--- a/scripts/customPaginationContainer.jsx
+++ b/scripts/customPaginationContainer.jsx
@@ -6,8 +6,9 @@
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var CustomPaginationContainer = React.createClass({
+var CustomPaginationContainer = createReactClass({
   getDefaultProps: function(){
     return{
       "maxPage": 0,

--- a/scripts/customRowComponentContainer.jsx
+++ b/scripts/customRowComponentContainer.jsx
@@ -6,8 +6,9 @@
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var CustomRowComponentContainer = React.createClass({
+var CustomRowComponentContainer = createReactClass({
   getDefaultProps: function(){
     return{
       "data": [],

--- a/scripts/gridFilter.jsx
+++ b/scripts/gridFilter.jsx
@@ -2,8 +2,9 @@
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var GridFilter = React.createClass({
+var GridFilter = createReactClass({
     getDefaultProps: function(){
       return {
         "placeholderText": ""

--- a/scripts/gridNoData.jsx
+++ b/scripts/gridNoData.jsx
@@ -2,8 +2,9 @@
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var GridNoData = React.createClass({
+var GridNoData = createReactClass({
     getDefaultProps: function(){
         return {
             "noDataMessage": "No Data"

--- a/scripts/gridPagination.jsx
+++ b/scripts/gridPagination.jsx
@@ -2,10 +2,11 @@
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
 var React = require('react');
+var createReactClass = require('create-react-class');
 var assign = require('lodash/assign');
 
 //needs props maxPage, currentPage, nextFunction, prevFunction
-var GridPagination = React.createClass({
+var GridPagination = createReactClass({
     getDefaultProps: function(){
         return{
             "maxPage": 0,

--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -2,6 +2,7 @@
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
 var React = require('react');
+var createReactClass = require('create-react-class');
 var ColumnProperties = require('./columnProperties.js');
 var deep = require('./deep.js');
 var isFunction = require('lodash/isFunction');
@@ -11,7 +12,7 @@ var defaults = require('lodash/defaults');
 var toPairs = require('lodash/toPairs');
 var without = require('lodash/without');
 
-var GridRow = React.createClass({
+var GridRow = createReactClass({
     getDefaultProps: function(){
       return {
         "isChildRow": false,

--- a/scripts/gridRowContainer.jsx
+++ b/scripts/gridRowContainer.jsx
@@ -2,10 +2,11 @@
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
 var React = require('react');
+var createReactClass = require('create-react-class');
 var ColumnProperties = require('./columnProperties.js');
 var pick = require('lodash/pick');
 
-var GridRowContainer = React.createClass({
+var GridRowContainer = createReactClass({
     getDefaultProps: function(){
       return {
         "useGriddleStyles": true,

--- a/scripts/gridSettings.jsx
+++ b/scripts/gridSettings.jsx
@@ -2,11 +2,12 @@
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
 var React = require('react');
+var createReactClass = require('create-react-class');
 var includes = require('lodash/includes');
 var without = require('lodash/without');
 var find = require('lodash/find');
 
-var GridSettings = React.createClass({
+var GridSettings = createReactClass({
     getDefaultProps: function(){
         return {
             "columns": [],

--- a/scripts/gridTable.jsx
+++ b/scripts/gridTable.jsx
@@ -2,12 +2,13 @@
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
 var React = require('react');
+var createReactClass = require('create-react-class');
 var GridTitle = require('./gridTitle.jsx');
 var GridRowContainer = require('./gridRowContainer.jsx');
 var ColumnProperties = require('./columnProperties.js');
 var RowProperties = require('./rowProperties.js');
 
-var GridTable = React.createClass({
+var GridTable = createReactClass({
   getDefaultProps: function(){
     return{
       "data": [],

--- a/scripts/gridTitle.jsx
+++ b/scripts/gridTitle.jsx
@@ -2,16 +2,17 @@
  See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
  */
 var React = require('react');
+var createReactClass = require('create-react-class');
 var ColumnProperties = require('./columnProperties.js');
 var assign = require('lodash/assign');
 
-var DefaultHeaderComponent = React.createClass({
+var DefaultHeaderComponent = createReactClass({
     render: function () {
         return (<span>{this.props.displayName}</span>);
     }
 });
 
-var GridTitle = React.createClass({
+var GridTitle = createReactClass({
     getDefaultProps: function () {
         return {
             "columnSettings": null,

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -6,6 +6,8 @@
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
 */
 var React = require('react');
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var GridTable = require('./gridTable.jsx');
 var GridFilter = require('./gridFilter.jsx');
 var GridPagination = require('./gridPagination.jsx');
@@ -41,7 +43,7 @@ var _property = require('lodash/property');
 var _get = require('lodash/get');
 var _some = require('lodash/some');
 
-var Griddle = React.createClass({
+var Griddle = createReactClass({
     statics: {
         GridTable: GridTable,
         GridFilter: GridFilter,
@@ -147,14 +149,14 @@ var Griddle = React.createClass({
         };
     },
     propTypes: {
-        isMultipleSelection: React.PropTypes.bool,
-        selectedRowIds: React.PropTypes.oneOfType([
-            React.PropTypes.arrayOf(React.PropTypes.number),
-            React.PropTypes.arrayOf(React.PropTypes.string)
+        isMultipleSelection: PropTypes.bool,
+        selectedRowIds: PropTypes.oneOfType([
+            PropTypes.arrayOf(PropTypes.number),
+            PropTypes.arrayOf(PropTypes.string)
         ]),
-        uniqueIdentifier: React.PropTypes.string,
-        onSelectionChange: React.PropTypes.func,
-        columnFilterFunc: React.PropTypes.func
+        uniqueIdentifier: PropTypes.string,
+        onSelectionChange: PropTypes.func,
+        columnFilterFunc: PropTypes.func
     },
     defaultFilter: function(results, filter) {
       var that = this;


### PR DESCRIPTION
## Griddle major version
v0 (0.8.1)

## Changes proposed in this pull request
use `createReactClass` from `create-react-class` package and `PropTypes` from `prop-types` package.

## Why these changes are made
Make it compatible with React 16
