### PR TITLE
Preserve Sort Properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -156,9 +156,17 @@ class Griddle extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { data, pageProperties, sortProperties } = nextProps;
+    const newState = Object.keys(nextProps).reduce((updatedState, key) => {
+      return this.props[key] !== nextProps[key] ? {
+      ...updatedState,
+      [key]: nextProps[key],
+     } : updatedState;
+    }, {});
 
-    this.store.dispatch(actions.updateState({ data, pageProperties, sortProperties }));
+    // Only update the state if something has changed.
+    if (Object.keys(newState).length > 0) {
+     this.store.dispatch(actions.updateState(newState));
+    }
   }
 
   getStoreKey = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -156,12 +156,9 @@ class Griddle extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const newState = Object.keys(nextProps).reduce((updatedState, key) => {
-      return this.props[key] !== nextProps[key] ? {
-      ...updatedState,
-      [key]: nextProps[key],
-     } : updatedState;
-    }, {});
+    const newState = _.pickBy(nextProps, (value, key) => {
+      return this.props[key] !== value;
+    })
 
     // Only update the state if something has changed.
     if (Object.keys(newState).length > 0) {


### PR DESCRIPTION
## Griddle major version
v1

## Changes proposed in this pull request
Updates `componentShouldUpdate` to only pass properties that have changed to the `updateState` action.

Previously, if an initial sort value was passed in while data changed, the user-selected sorting option would be reset to the initial value.

## Why these changes are made
To resolve #697

## Are there tests?
No 😞 