### PR TITLE
Extract Initializer

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -11,6 +11,7 @@ const include = path.resolve(__dirname, '../');
 // to "React Create App". This only has babel loader to load JavaScript.
 
 module.exports = {
+  devtool: 'source-map',
   entry: './stories/index.tsx',
   output: {
     filename: include + '/dist/examples/storybook.js'

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,0 +1,15 @@
+import components from '../components';
+import * as reducer from '../reducers/dataReducer';
+import * as selectors from '../selectors/dataSelectors';
+import * as actions from '../actions';
+import initialState from './initialState';
+
+const CorePlugin = {
+  components,
+  reducer,
+  selectors,
+  actions,
+  ...initialState,
+};
+
+export default CorePlugin;

--- a/src/core/initialState.js
+++ b/src/core/initialState.js
@@ -1,0 +1,45 @@
+const styleConfig = {
+  icons: {
+    TableHeadingCell: {
+      sortDescendingIcon: '▼',
+      sortAscendingIcon: '▲'
+    },
+  },
+  classNames: {
+    Cell: 'griddle-cell',
+    Filter: 'griddle-filter',
+    Loading: 'griddle-loadingResults',
+    NextButton: 'griddle-next-button',
+    NoResults: 'griddle-noResults',
+    PageDropdown: 'griddle-page-select',
+    Pagination: 'griddle-pagination',
+    PreviousButton: 'griddle-previous-button',
+    Row: 'griddle-row',
+    RowDefinition: 'griddle-row-definition',
+    Settings: 'griddle-settings',
+    SettingsToggle: 'griddle-settings-toggle',
+    Table: 'griddle-table',
+    TableBody: 'griddle-table-body',
+    TableHeading: 'griddle-table-heading',
+    TableHeadingCell: 'griddle-table-heading-cell',
+    TableHeadingCellAscending: 'griddle-heading-ascending',
+    TableHeadingCellDescending: 'griddle-heading-descending',
+  },
+  styles: {
+  }
+};
+
+export default {
+  styleConfig,
+
+  pageProperties: {
+    currentPage: 1,
+    pageSize: 10
+  },
+  enableSettings: true,
+  textProperties: {
+    next: 'Next',
+    previous: 'Previous',
+    settingsToggle: 'Settings'
+  },
+};

--- a/src/index.js
+++ b/src/index.js
@@ -10,16 +10,8 @@ import settingsComponentObjects from './settingsComponentObjects';
 import * as selectors from './selectors/dataSelectors';
 
 import init from './utils/initializer';
-import { setSortProperties } from './utils/sortUtils';
 import { StoreListener } from './utils/listenerUtils';
 import * as actions from './actions';
-
-const defaultEvents = {
-  ...actions,
-  onFilter: actions.setFilter,
-  setSortProperties
-};
-
 
 const defaultStyleConfig = {
   icons: {

--- a/src/index.js
+++ b/src/index.js
@@ -4,45 +4,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
-import * as dataReducers from './reducers/dataReducer';
-import components from './components';
-import settingsComponentObjects from './settingsComponentObjects';
-import * as selectors from './selectors/dataSelectors';
-
+import corePlugin from './core';
 import init from './utils/initializer';
 import { StoreListener } from './utils/listenerUtils';
 import * as actions from './actions';
-
-const defaultStyleConfig = {
-  icons: {
-    TableHeadingCell: {
-      sortDescendingIcon: '▼',
-      sortAscendingIcon: '▲'
-    },
-  },
-  classNames: {
-    Cell: 'griddle-cell',
-    Filter: 'griddle-filter',
-    Loading: 'griddle-loadingResults',
-    NextButton: 'griddle-next-button',
-    NoResults: 'griddle-noResults',
-    PageDropdown: 'griddle-page-select',
-    Pagination: 'griddle-pagination',
-    PreviousButton: 'griddle-previous-button',
-    Row: 'griddle-row',
-    RowDefinition: 'griddle-row-definition',
-    Settings: 'griddle-settings',
-    SettingsToggle: 'griddle-settings-toggle',
-    Table: 'griddle-table',
-    TableBody: 'griddle-table-body',
-    TableHeading: 'griddle-table-heading',
-    TableHeadingCell: 'griddle-table-heading-cell',
-    TableHeadingCellAscending: 'griddle-heading-ascending',
-    TableHeadingCellDescending: 'griddle-heading-descending',
-  },
-  styles: {
-  }
-};
 
 class Griddle extends Component {
   static childContextTypes = {
@@ -58,27 +23,11 @@ class Griddle extends Component {
     super(props);
 
     const {
+      core = corePlugin,
       storeKey = Griddle.storeKey || 'store',
     } = props;
 
-    const { initialState, reducers, reduxMiddleware } = init.call(this, {
-      reducers: dataReducers,
-      components,
-      settingsComponentObjects,
-      selectors,
-      styleConfig: defaultStyleConfig,
-
-      pageProperties: {
-        currentPage: 1,
-        pageSize: 10
-      },
-      enableSettings: true,
-      textProperties: {
-        next: 'Next',
-        previous: 'Previous',
-        settingsToggle: 'Settings'
-      },
-    });
+    const { initialState, reducers, reduxMiddleware } = init.call(this, core);
 
     const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
     this.store = createStore(

--- a/src/index.js
+++ b/src/index.js
@@ -79,13 +79,12 @@ class Griddle extends Component {
         currentPage: 1,
         pageSize: 10
       },
-      initialState: {
-        enableSettings: true,
-        textProperties: {
-          next: 'Next',
-          previous: 'Previous',
-          settingsToggle: 'Settings'
-        },
+
+      enableSettings: true,
+      textProperties: {
+        next: 'Next',
+        previous: 'Previous',
+        settingsToggle: 'Settings'
       },
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,10 @@ class Griddle extends Component {
   }
 
   render() {
+    if (!this.components.Layout) {
+      return null;
+    }
+
     return (
       <this.provider store={this.store}>
         <this.components.Layout />

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import { createStore, combineReducers, bindActionCreators, applyMiddleware, compose } from 'redux';
-import Immutable from 'immutable';
 import { createProvider } from 'react-redux';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -10,9 +9,7 @@ import components from './components';
 import settingsComponentObjects from './settingsComponentObjects';
 import * as selectors from './selectors/dataSelectors';
 
-import { buildGriddleReducer, buildGriddleComponents } from './utils/compositionUtils';
-import { getColumnProperties } from './utils/columnUtils';
-import { getRowProperties } from './utils/rowUtils';
+import init from './utils/initializer';
 import { setSortProperties } from './utils/sortUtils';
 import { StoreListener } from './utils/listenerUtils';
 import * as actions from './actions';
@@ -69,55 +66,20 @@ class Griddle extends Component {
     super(props);
 
     const {
-      plugins=[],
-      data,
-      children:rowPropertiesComponent,
-      events={},
-      sortProperties={},
-      styleConfig={},
-      pageProperties:importedPageProperties,
-      components:userComponents,
-      renderProperties:userRenderProperties={},
-      settingsComponentObjects:userSettingsComponentObjects,
       storeKey = Griddle.storeKey || 'store',
-      reduxMiddleware = [],
-      listeners = {},
-      ...userInitialState
     } = props;
 
-    const rowProperties = getRowProperties(rowPropertiesComponent);
-    const columnProperties = getColumnProperties(rowPropertiesComponent);
-
-    //Combine / compose the reducers to make a single, unified reducer
-    const reducers = buildGriddleReducer([dataReducers, ...plugins.map(p => p.reducer)]);
-
-    //Combine / Compose the components to make a single component for each component type
-    this.components = buildGriddleComponents([components, ...plugins.map(p => p.components), userComponents]);
-
-    this.settingsComponentObjects = Object.assign({}, settingsComponentObjects, ...plugins.map(p => p.settingsComponentObjects), userSettingsComponentObjects);
-
-    this.events = Object.assign({}, events, ...plugins.map(p => p.events));
-
-    this.selectors = plugins.reduce((combined, plugin) => ({ ...combined, ...plugin.selectors }), {...selectors});
-
-    const mergedStyleConfig = _.merge({}, defaultStyleConfig, ...plugins.map(p => p.styleConfig), styleConfig);
-
-    const pageProperties = Object.assign({}, {
+    const { initialState, reducers, reduxMiddleware } = init.call(this, {
+      reducers: dataReducers,
+      components,
+      settingsComponentObjects,
+      selectors,
+      styleConfig: defaultStyleConfig,
+      pageProperties: {
         currentPage: 1,
         pageSize: 10
       },
-      importedPageProperties,
-    );
-
-    //TODO: This should also look at the default and plugin initial state objects
-    const renderProperties = Object.assign({
-      rowProperties,
-      columnProperties
-    }, ...plugins.map(p => p.renderProperties), userRenderProperties);
-
-    // TODO: Make this its own method
-    const initialState = _.merge(
-      {
+      initialState: {
         enableSettings: true,
         textProperties: {
           next: 'Next',
@@ -125,30 +87,19 @@ class Griddle extends Component {
           settingsToggle: 'Settings'
         },
       },
-      ...plugins.map(p => p.initialState),
-      userInitialState,
-      {
-        data,
-        pageProperties,
-        renderProperties,
-        sortProperties,
-        styleConfig: mergedStyleConfig,
-      }
-    );
+    });
 
     const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
     this.store = createStore(
       reducers,
       initialState,
       composeEnhancers(
-        applyMiddleware(..._.compact(_.flatten(plugins.map(p => p.reduxMiddleware))), ...reduxMiddleware)
+        applyMiddleware(...reduxMiddleware)
       )
     );
 
     this.provider = createProvider(storeKey);
 
-    const sanitizedListeners = _.pickBy(listeners, (value, key) => typeof value === "function");
-    this.listeners = plugins.reduce((combined, plugin) => ({...combined, ..._.pickBy(plugin.listeners, (value, key) => typeof value === "function")}), {...sanitizedListeners});
     this.storeListener = new StoreListener(this.store);
     _.forIn(this.listeners, (listener, name) => {
       this.storeListener.addListener(listener, name, {events: this.events, selectors: this.selectors});

--- a/src/index.js
+++ b/src/index.js
@@ -75,11 +75,11 @@ class Griddle extends Component {
       settingsComponentObjects,
       selectors,
       styleConfig: defaultStyleConfig,
+
       pageProperties: {
         currentPage: 1,
         pageSize: 10
       },
-
       enableSettings: true,
       textProperties: {
         next: 'Next',

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -383,6 +383,7 @@ interface GriddleExtensibility {
 
 interface GriddleInitialState {
     enableSettings?: boolean;
+    pageProperties?: GriddlePageProperties;
     sortMethod?: (data: any[], column: string, sortAscending?: boolean) => number;
     textProperties?: {
       next?: string,
@@ -402,7 +403,6 @@ export interface GriddleProps<T> extends GriddlePlugin, GriddleInitialState {
     plugins?: GriddlePlugin[];
     data?: T[];
     sortProperties?: GriddleSortKey[];
-    pageProperties?: GriddlePageProperties;
     storeKey?: string;
 }
 

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -385,6 +385,7 @@ interface GriddleInitialState {
     enableSettings?: boolean;
     pageProperties?: GriddlePageProperties;
     sortMethod?: (data: any[], column: string, sortAscending?: boolean) => number;
+    sortProperties?: GriddleSortKey[];
     textProperties?: {
       next?: string,
       previous?: string,
@@ -402,7 +403,6 @@ export interface GriddlePlugin extends GriddleExtensibility {
 export interface GriddleProps<T> extends GriddlePlugin, GriddleInitialState {
     plugins?: GriddlePlugin[];
     data?: T[];
-    sortProperties?: GriddleSortKey[];
     storeKey?: string;
 }
 

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -401,6 +401,7 @@ export interface GriddlePlugin extends GriddleExtensibility {
 }
 
 export interface GriddleProps<T> extends GriddlePlugin, GriddleInitialState {
+    core?: GriddlePlugin;
     plugins?: GriddlePlugin[];
     data?: T[];
     storeKey?: string;
@@ -441,6 +442,8 @@ export namespace utils {
 }
 
 export namespace plugins {
+    var CorePlugin : GriddlePlugin;
+
     var LegacyStylePlugin : GriddlePlugin;
 
     var LocalPlugin : GriddlePlugin;

--- a/src/module.js
+++ b/src/module.js
@@ -7,11 +7,13 @@ import * as selectors from './selectors/dataSelectors';
 import settingsComponentObjects from './settingsComponentObjects';
 import utils from './utils';
 
+import CorePlugin from './core';
 import LegacyStylePlugin from './plugins/legacyStyle';
 import LocalPlugin from './plugins/local';
 import PositionPlugin from './plugins/position';
 
 const plugins = {
+  CorePlugin,
   LegacyStylePlugin,
   LocalPlugin,
   PositionPlugin,

--- a/src/utils/__tests__/compositionUtilsTest.js
+++ b/src/utils/__tests__/compositionUtilsTest.js
@@ -379,6 +379,21 @@ test('builds griddle reducer without BEFORE / AFTER if they dont exist', (t) => 
   t.deepEqual(output, { number: 15 });
 });
 
+test('builds griddle reducer that calls GRIDDLE_INITIALIZED for missing action type, if it exists', (assert) => {
+  const initReducer = { GRIDDLE_INITIALIZED: () => ({ init: true }) };
+  const griddleReducer = buildGriddleReducer([initReducer]);
+  const output = griddleReducer({}, { type: 'MISSING' });
+
+  assert.deepEqual(output, { init: true });
+});
+
+test('builds griddle reducer that does noop for missing action type, if GRIDDLE_INITIALIZED is also missing', (assert) => {
+  const griddleReducer = buildGriddleReducer([]);
+  const output = griddleReducer({}, { type: 'MISSING' });
+
+  assert.deepEqual(output, {});
+});
+
 test('combineAndEnhanceComponents', test => {
   const initial = { one: (someNumber) => (someNumber + 5)}
   const enhancing = { oneEnhancer: originalMethod => (someNumber) => originalMethod(someNumber * 5)};

--- a/src/utils/__tests__/compositionUtilsTest.js
+++ b/src/utils/__tests__/compositionUtilsTest.js
@@ -11,7 +11,6 @@ import {
   removeHooksFromObject,
   isKeyGriddleHook,
   buildGriddleReducer,
-  buildGriddleReducerObject,
   getAfterHooksFromObject,
   getBeforeHooksFromObject,
   removeKeyNamePartFromObject,
@@ -326,7 +325,7 @@ test('builds griddle reducer', test => {
     }
   }
 
-  const griddleReducer = buildGriddleReducerObject([reducer1, reducer2, reducer3]);
+  const griddleReducer = buildGriddleReducer([reducer1, reducer2, reducer3]);
 
   test.deepEqual(Object.keys(griddleReducer), ['REDUCE_THING', 'REDUCE_OTHER']);
   test.deepEqual(griddleReducer.REDUCE_THING({ number: 5}), { number: -45 });
@@ -357,6 +356,7 @@ test('builds griddle reducer with BEFORE_REDUCE and AFTER_REDUCE', (t) => {
   const griddleReducer = buildGriddleReducer([reducer1, reducer2]);
   const output = griddleReducer({number: 5}, { type: 'REDUCE_THING'});
 
+  t.deepEqual(Object.keys(griddleReducer), ['AFTER_REDUCE', 'REDUCE_THING', 'BEFORE_REDUCE']);
   t.deepEqual(output, { number: 55 });
 });
 
@@ -376,6 +376,7 @@ test('builds griddle reducer without BEFORE / AFTER if they dont exist', (t) => 
   const griddleReducer = buildGriddleReducer([reducer1, reducer2]);
   const output = griddleReducer({number: 5}, { type: 'REDUCE_THING'});
 
+  t.deepEqual(Object.keys(griddleReducer), ['REDUCE_THING']);
   t.deepEqual(output, { number: 15 });
 });
 

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -11,7 +11,6 @@ const expectedDefaultInitialState = {
     rowProperties: null,
     columnProperties: {},
   },
-  sortProperties: {},
   styleConfig: {},
 };
 

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -21,6 +21,7 @@ test('init succeeds given empty defaults and props', (assert) => {
   });
 
   assert.is(typeof res.reducers, 'function');
+  assert.deepEqual(res.reducers({}, { type: 'REDUCE' }), {});
 
   assert.deepEqual(res.reduxMiddleware, []);
 

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -7,7 +7,6 @@ import { getRowProperties } from '../rowUtils';
 
 const expectedDefaultInitialState = {
   data: [],
-  pageProperties: {},
   renderProperties: {
     rowProperties: null,
     columnProperties: {},

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -313,3 +313,27 @@ test('init sets context.settingsComponentObjects as expected given plugins', (as
     User: true,
   });
 });
+
+test('init sets context.events as expected given plugins', (assert) => {
+  const ctx = {
+    props: {
+      plugins: [
+        { events: { Plugin: 0, User: false } },
+        { events: { Plugin: 1 } },
+      ],
+      events: { User: true, User2: true },
+    },
+  };
+  const defaults = {
+    // TODO: bug that defaultEvents is not used?
+  };
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(ctx.events, {
+    Plugin: 1,
+    User: false, // TODO: bug that plugins overwrite user events?
+    User2: true,
+  });
+});

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -286,3 +286,30 @@ test('init sets context.components as expected given plugins', (assert) => {
     User: true,
   });
 });
+
+test('init sets context.settingsComponentObjects as expected given plugins', (assert) => {
+  const ctx = {
+    props: {
+      plugins: [
+        { settingsComponentObjects: { Plugin: 0, User: false } },
+        { settingsComponentObjects: { Plugin: 1 } },
+      ],
+      settingsComponentObjects: { User: true },
+    },
+  };
+  const defaults = {
+    settingsComponentObjects: {
+      Defaults: true,
+      Plugin: false,
+    },
+  };
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(ctx.settingsComponentObjects, {
+    Defaults: true,
+    Plugin: 1,
+    User: true,
+  });
+});

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -1,0 +1,71 @@
+import test from 'ava';
+
+import init from '../initializer';
+
+test('init succeeds given empty defaults and props', (assert) => {
+  const ctx = { props: {} };
+  const defaults = {};
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(res.initialState, {
+    data: [],
+    pageProperties: {},
+    renderProperties: {
+      rowProperties: null,
+      columnProperties: {},
+    },
+    sortProperties: {},
+    styleConfig: {},
+  });
+
+  assert.is(typeof res.reducers, 'function');
+
+  assert.deepEqual(res.reduxMiddleware, []);
+
+  assert.deepEqual(ctx.components, {});
+  assert.deepEqual(ctx.settingsComponentObjects, {});
+  assert.deepEqual(ctx.events, {});
+  assert.deepEqual(ctx.selectors, {});
+  assert.deepEqual(ctx.listeners, {});
+});
+
+test('init returns defaults given minimum props', (assert) => {
+  const ctx = { props: { data: [] } };
+  const defaults = {
+    reducers: { REDUCE: () => ({ reduced: true }) },
+    components: { Layout: () => null },
+    settingsComponentObjects: { mySettings: { order: 10 } },
+    selectors: { aSelector: () => null },
+    styleConfig: { classNames: {} },
+    pageProperties: { pageSize: 100 },
+    initialState: { init: true },
+  };
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(res.initialState, {
+    init: true,
+    data: ctx.props.data,
+    pageProperties: defaults.pageProperties,
+    renderProperties: {
+      rowProperties: null,
+      columnProperties: {},
+    },
+    sortProperties: {},
+    styleConfig: defaults.styleConfig,
+  });
+
+  assert.is(typeof res.reducers, 'function');
+  assert.deepEqual(res.reducers({}, { type: 'REDUCE' }), { reduced: true });
+
+  assert.deepEqual(res.reduxMiddleware, []);
+
+  assert.deepEqual(ctx.components, defaults.components);
+  assert.deepEqual(ctx.settingsComponentObjects, defaults.settingsComponentObjects);
+  assert.deepEqual(ctx.events, {});
+  assert.deepEqual(ctx.selectors, defaults.selectors);
+  assert.deepEqual(ctx.listeners, {});
+});

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -360,3 +360,29 @@ test('init sets context.selectors as expected given plugins', (assert) => {
     Plugin: 1,
   });
 });
+
+
+test('init sets context.listeners as expected given props (plugins, user)', (assert) => {
+  const ctx = {
+    props: {
+      plugins: [
+        { listeners: { plugin: () => 0, user: () => false } },
+        { listeners: { plugin: () => 1 } },
+      ],
+      listeners: {
+        user: () => true,
+        user2: () => true,
+      },
+    },
+  };
+  const defaults = {};
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+  assert.truthy(res);
+
+  assert.false('defaults' in ctx.listeners);
+  assert.deepEqual(ctx.listeners.plugin(), 1);
+  assert.deepEqual(ctx.listeners.user(), false); // TODO: bug that plugins overwrite user listeners?
+  assert.deepEqual(ctx.listeners.user2(), true);
+});

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -60,6 +60,7 @@ test('init returns defaults given minimum props', (assert) => {
   });
 
   assert.is(typeof res.reducers, 'function');
+  assert.deepEqual(Object.keys(res.reducers), Object.keys(defaults.reducers));
   assert.deepEqual(res.reducers({}, { type: 'REDUCE' }), { reduced: true });
 
   assert.deepEqual(res.reduxMiddleware, []);

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -89,6 +89,28 @@ test('init returns expected initialState.data given props.data', (assert) => {
   assert.deepEqual(res.initialState.data, ctx.props.data);
 });
 
+test('init returns expected initialState.pageProperties given props (user)', (assert) => {
+  const ctx = {
+    props: {
+      pageProperties: { user: true },
+    },
+  };
+  const defaults = {
+    pageProperties: {
+      defaults: true,
+      user: false,
+    },
+  };
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(res.initialState.pageProperties, {
+    defaults: true,
+    user: true,
+  });
+});
+
 test('init returns expected initialState.renderProperties given props (children, plugins, user)', (assert) => {
   const ctx = {
     props: {

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -71,3 +71,17 @@ test('init returns defaults given minimum props', (assert) => {
   assert.deepEqual(ctx.selectors, defaults.selectors);
   assert.deepEqual(ctx.listeners, {});
 });
+
+test('init returns expected initialState.data given props.data', (assert) => {
+  const ctx = {
+    props: {
+      data: [{ foo: 'bar' }],
+    },
+  };
+  const defaults = {};
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(res.initialState.data, ctx.props.data);
+});

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -249,7 +249,7 @@ test('init returns flattened/compacted reduxMiddleware given plugins', (assert) 
         { reduxMiddleware: [null, mw[1], undefined, mw[2], null] },
         {},
       ],
-      reduxMiddleware: [mw[3]],
+      reduxMiddleware: [null, mw[3], undefined],
     },
   };
   const defaults = {};

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -5,6 +5,17 @@ import init from '../initializer';
 import { getColumnProperties } from '../columnUtils';
 import { getRowProperties } from '../rowUtils';
 
+const expectedDefaultInitialState = {
+  data: [],
+  pageProperties: {},
+  renderProperties: {
+    rowProperties: null,
+    columnProperties: {},
+  },
+  sortProperties: {},
+  styleConfig: {},
+};
+
 test('init succeeds given empty defaults and props', (assert) => {
   const ctx = { props: {} };
   const defaults = {};
@@ -12,16 +23,7 @@ test('init succeeds given empty defaults and props', (assert) => {
   const res = init.call(ctx, defaults);
   assert.truthy(res);
 
-  assert.deepEqual(res.initialState, {
-    data: [],
-    pageProperties: {},
-    renderProperties: {
-      rowProperties: null,
-      columnProperties: {},
-    },
-    sortProperties: {},
-    styleConfig: {},
-  });
+  assert.deepEqual(res.initialState, expectedDefaultInitialState);
 
   assert.is(typeof res.reducers, 'function');
   assert.deepEqual(res.reducers({}, { type: 'REDUCE' }), {});
@@ -51,14 +53,11 @@ test('init returns defaults given minimum props', (assert) => {
   assert.truthy(res);
 
   assert.deepEqual(res.initialState, {
+    ...expectedDefaultInitialState,
+
     init: true,
     data: ctx.props.data,
     pageProperties: defaults.pageProperties,
-    renderProperties: {
-      rowProperties: null,
-      columnProperties: {},
-    },
-    sortProperties: {},
     styleConfig: defaults.styleConfig,
   });
 
@@ -184,5 +183,35 @@ test('init returns merged initialState.styleConfig given props (plugins, user)',
       plugin: 1,
       user: true,
     },
+  });
+});
+
+test('init returns expected extra initialState given props (plugins, user)', (assert) => {
+  const ctx = {
+    props: {
+      plugins: [
+        { initialState: { plugin: 0, user: false } },
+        { initialState: { plugin: 1 } },
+      ],
+      user: true,
+    },
+  };
+  const defaults = {
+    initialState: {
+      defaults: true,
+      user: false,
+      plugin: false,
+    }
+  };
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(res.initialState, {
+    ...expectedDefaultInitialState,
+
+    defaults: true,
+    user: true,
+    plugin: 1,
   });
 });

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -259,3 +259,30 @@ test('init returns flattened/compacted reduxMiddleware given plugins', (assert) 
 
   assert.deepEqual(res.reduxMiddleware, mw);
 });
+
+test('init sets context.components as expected given plugins', (assert) => {
+  const ctx = {
+    props: {
+      plugins: [
+        { components: { Plugin: 0, User: false } },
+        { components: { Plugin: 1 } },
+      ],
+      components: { User: true },
+    },
+  };
+  const defaults = {
+    components: {
+      Defaults: true,
+      Plugin: false,
+    },
+  };
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(ctx.components, {
+    Defaults: true,
+    Plugin: 1,
+    User: true,
+  });
+});

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -2,6 +2,9 @@ import test from 'ava';
 
 import init from '../initializer';
 
+import { getColumnProperties } from '../columnUtils';
+import { getRowProperties } from '../rowUtils';
+
 test('init succeeds given empty defaults and props', (assert) => {
   const ctx = { props: {} };
   const defaults = {};
@@ -84,4 +87,32 @@ test('init returns expected initialState.data given props.data', (assert) => {
   assert.truthy(res);
 
   assert.deepEqual(res.initialState.data, ctx.props.data);
+});
+
+test('init returns expected initialState.renderProperties given props (children, plugins, user)', (assert) => {
+  const ctx = {
+    props: {
+      children: {
+        props: {
+          children: [{ props: { id: 'foo', order: 1 } }],
+        }
+      },
+      plugins: [
+        { renderProperties: { plugin: 0, user: false } },
+        { renderProperties: { plugin: 1 } },
+      ],
+      renderProperties: { user: true },
+    },
+  };
+  const defaults = {};
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(res.initialState.renderProperties, {
+    rowProperties: getRowProperties(ctx.props.children),
+    columnProperties: getColumnProperties(ctx.props.children),
+    plugin: 1,
+    user: true,
+  });
 });

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -324,9 +324,7 @@ test('init sets context.events as expected given plugins', (assert) => {
       events: { User: true, User2: true },
     },
   };
-  const defaults = {
-    // TODO: bug that defaultEvents is not used?
-  };
+  const defaults = {};
 
   const res = init.call(ctx, defaults);
   assert.truthy(res);

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -15,6 +15,27 @@ const expectedDefaultInitialState = {
   styleConfig: {},
 };
 
+test('init succeeds given null defaults and empty props', (assert) => {
+  const ctx = { props: {} };
+  const defaults = null;
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(res.initialState, expectedDefaultInitialState);
+
+  assert.is(typeof res.reducers, 'function');
+  assert.deepEqual(res.reducers({}, { type: 'REDUCE' }), {});
+
+  assert.deepEqual(res.reduxMiddleware, []);
+
+  assert.deepEqual(ctx.components, {});
+  assert.deepEqual(ctx.settingsComponentObjects, {});
+  assert.deepEqual(ctx.events, {});
+  assert.deepEqual(ctx.selectors, {});
+  assert.deepEqual(ctx.listeners, {});
+});
+
 test('init succeeds given empty defaults and props', (assert) => {
   const ctx = { props: {} };
   const defaults = {};

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -154,3 +154,35 @@ test('init returns expected initialState.sortProperties given props (user)', (as
     user: true,
   });
 });
+
+test('init returns merged initialState.styleConfig given props (plugins, user)', (assert) => {
+  const ctx = {
+    props: {
+      plugins: [
+        { styleConfig: { styles: { plugin: 0, user: false } } },
+        { styleConfig: { styles: { plugin: 1, defaults: false } } },
+      ],
+      styleConfig: {
+        styles: { user: true },
+      },
+    },
+  };
+  const defaults = {
+    styleConfig: {
+      classNames: { defaults: true },
+      styles: { defaults: true, plugin: false, user: false },
+    },
+  };
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(res.initialState.styleConfig, {
+    classNames: { defaults: true },
+    styles: {
+      defaults: false,
+      plugin: 1,
+      user: true,
+    },
+  });
+});

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -46,7 +46,7 @@ test('init returns defaults given minimum props', (assert) => {
     selectors: { aSelector: () => null },
     styleConfig: { classNames: {} },
     pageProperties: { pageSize: 100 },
-    initialState: { init: true },
+    init: true,
   };
 
   const res = init.call(ctx, defaults);
@@ -197,11 +197,9 @@ test('init returns expected extra initialState given props (plugins, user)', (as
     },
   };
   const defaults = {
-    initialState: {
-      defaults: true,
-      user: false,
-      plugin: false,
-    }
+    defaults: true,
+    user: false,
+    plugin: false,
   };
 
   const res = init.call(ctx, defaults);

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -211,3 +211,28 @@ test('init returns expected extra initialState given props (plugins, user)', (as
     plugin: 1,
   });
 });
+
+test('init returns composed reducer given plugins', (assert) => {
+  const ctx = {
+    props: {
+      plugins: [
+        { reducer: { PLUGIN: () => ({ plugin: 0 }) } },
+        { reducer: { PLUGIN: () => ({ plugin: 1 }) } },
+      ],
+    },
+  };
+  const defaults = {
+    reducers: {
+      DEFAULTS: () => ({ defaults: true }),
+      PLUGIN: () => ({ plugin: false }),
+    },
+  };
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.is(typeof res.reducers, 'function');
+  assert.deepEqual(Object.keys(res.reducers), ['DEFAULTS', 'PLUGIN']);
+  assert.deepEqual(res.reducers({}, { type: 'DEFAULTS' }), { defaults: true });
+  assert.deepEqual(res.reducers({}, { type: 'PLUGIN' }), { plugin: 1 });
+});

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -138,3 +138,19 @@ test('init returns expected initialState.renderProperties given props (children,
     user: true,
   });
 });
+
+test('init returns expected initialState.sortProperties given props (user)', (assert) => {
+  const ctx = {
+    props: {
+      sortProperties: { user: true },
+    },
+  };
+  const defaults = {};
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(res.initialState.sortProperties, {
+    user: true,
+  });
+});

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -337,3 +337,28 @@ test('init sets context.events as expected given plugins', (assert) => {
     User2: true,
   });
 });
+
+test('init sets context.selectors as expected given plugins', (assert) => {
+  const ctx = {
+    props: {
+      plugins: [
+        { selectors: { Plugin: 0 } },
+        { selectors: { Plugin: 1 } },
+      ],
+    },
+  };
+  const defaults = {
+    selectors: {
+      Defaults: true,
+      Plugin: false,
+    },
+  };
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(ctx.selectors, {
+    Defaults: true,
+    Plugin: 1,
+  });
+});

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import _ from 'lodash';
 
 import init from '../initializer';
 
@@ -235,4 +236,26 @@ test('init returns composed reducer given plugins', (assert) => {
   assert.deepEqual(Object.keys(res.reducers), ['DEFAULTS', 'PLUGIN']);
   assert.deepEqual(res.reducers({}, { type: 'DEFAULTS' }), { defaults: true });
   assert.deepEqual(res.reducers({}, { type: 'PLUGIN' }), { plugin: 1 });
+});
+
+test('init returns flattened/compacted reduxMiddleware given plugins', (assert) => {
+  const mw = _.range(0, 4).map(i => () => i);
+  const ctx = {
+    props: {
+      plugins: [
+        {},
+        { reduxMiddleware: [mw[0]] },
+        {},
+        { reduxMiddleware: [null, mw[1], undefined, mw[2], null] },
+        {},
+      ],
+      reduxMiddleware: [mw[3]],
+    },
+  };
+  const defaults = {};
+
+  const res = init.call(ctx, defaults);
+  assert.truthy(res);
+
+  assert.deepEqual(res.reduxMiddleware, mw);
 });

--- a/src/utils/compositionUtils.js
+++ b/src/utils/compositionUtils.js
@@ -171,9 +171,10 @@ export function composeReducerObjects(reducerObjects) {
 
 /** Builds a new reducer that composes hooks and extends standard reducers between reducerObjects
  * @param {Object <array>} reducers - An array of reducerObjects
+ * Note: this used to be exported, but the same properties are available from buildGriddleReducer.
  * TODO: This method should be broken down a bit -- it's doing too much currently
  */
-export function buildGriddleReducerObject(reducerObjects) {
+function buildGriddleReducerObject(reducerObjects) {
   let reducerMethodsWithoutHooks = [];
   let beforeHooks = [];
   let afterHooks = [];
@@ -241,7 +242,9 @@ export function callReducerWithBeforeAfterPipe(reducerObject, state, action) {
 */
 export function buildGriddleReducer(reducerObjects) {
   const reducerObject = buildGriddleReducerObject(reducerObjects);
-  return (state, action) => callReducerWithBeforeAfterPipe(reducerObject, state, action);
+  const reducer = (state, action) => callReducerWithBeforeAfterPipe(reducerObject, state, action);
+  Object.assign(reducer, reducerObject);
+  return reducer;
 }
 
 /** Gets all reducers by a specific wordEnding

--- a/src/utils/compositionUtils.js
+++ b/src/utils/compositionUtils.js
@@ -227,7 +227,7 @@ export function callReducerWithBeforeAfterPipe(reducerObject, state, action) {
   const call = (action.type &&
         reducerObject[action.type] &&
         reducerObject[action.type]
-      ) || reducerObject.GRIDDLE_INITIALIZED;
+      ) || reducerObject.GRIDDLE_INITIALIZED || noop;
 
   const partialCall = (partialAction => partialState => call(partialState, partialAction))(action);
 

--- a/src/utils/initializer.js
+++ b/src/utils/initializer.js
@@ -18,7 +18,7 @@ module.exports = function initializer(defaults) {
 
   const {
     plugins = [],
-    data,
+    data = [],
     children: rowPropertiesComponent,
     events: userEvents = {},
     sortProperties = {},

--- a/src/utils/initializer.js
+++ b/src/utils/initializer.js
@@ -13,7 +13,7 @@ module.exports = function initializer(defaults) {
     selectors,
     styleConfig: defaultStyleConfig,
     pageProperties: defaultPageProperties,
-    initialState: defaultInitialState,
+    ...defaultInitialState
   } = defaults;
 
   const {

--- a/src/utils/initializer.js
+++ b/src/utils/initializer.js
@@ -83,9 +83,9 @@ module.exports = function initializer(defaults) {
   return {
     initialState,
     reducers,
-    reduxMiddleware: [
-      ..._.compact(_.flatten(plugins.map(p => p.reduxMiddleware))),
+    reduxMiddleware: _.compact([
+      ..._.flatten(plugins.map(p => p.reduxMiddleware)),
       ...reduxMiddleware
-    ],
+    ]),
   };
 };

--- a/src/utils/initializer.js
+++ b/src/utils/initializer.js
@@ -12,7 +12,6 @@ module.exports = function initializer(defaults) {
     settingsComponentObjects,
     selectors,
     styleConfig: defaultStyleConfig,
-    pageProperties: defaultPageProperties,
     ...defaultInitialState
   } = defaults;
 
@@ -23,7 +22,6 @@ module.exports = function initializer(defaults) {
     events: userEvents = {},
     sortProperties = {},
     styleConfig: userStyleConfig = {},
-    pageProperties: userPageProperties,
     components: userComponents,
     renderProperties: userRenderProperties = {},
     settingsComponentObjects: userSettingsComponentObjects,
@@ -61,7 +59,6 @@ module.exports = function initializer(defaults) {
     ...plugins.map(p => p.styleConfig),
     userStyleConfig);
 
-  const pageProperties = Object.assign({}, defaultPageProperties, userPageProperties);
 
   // TODO: This should also look at the default and plugin initial state objects
   const renderProperties = Object.assign({
@@ -76,7 +73,6 @@ module.exports = function initializer(defaults) {
     userInitialState,
     {
       data,
-      pageProperties,
       renderProperties,
       sortProperties,
       styleConfig,

--- a/src/utils/initializer.js
+++ b/src/utils/initializer.js
@@ -1,0 +1,97 @@
+import _ from 'lodash';
+import { buildGriddleReducer, buildGriddleComponents } from './compositionUtils';
+import { getColumnProperties } from './columnUtils';
+import { getRowProperties } from './rowUtils';
+
+module.exports = function initializer(defaults) {
+  if (!this) throw new Error('this missing!');
+
+  const {
+    reducers: dataReducers,
+    components,
+    settingsComponentObjects,
+    selectors,
+    styleConfig: defaultStyleConfig,
+    pageProperties: defaultPageProperties,
+    initialState: defaultInitialState,
+  } = defaults;
+
+  const {
+    plugins = [],
+    data,
+    children: rowPropertiesComponent,
+    events: userEvents = {},
+    sortProperties = {},
+    styleConfig: userStyleConfig = {},
+    pageProperties: userPageProperties,
+    components: userComponents,
+    renderProperties: userRenderProperties = {},
+    settingsComponentObjects: userSettingsComponentObjects,
+    reduxMiddleware = [],
+    listeners = {},
+    ...userInitialState
+  } = this.props;
+
+  const rowProperties = getRowProperties(rowPropertiesComponent);
+  const columnProperties = getColumnProperties(rowPropertiesComponent);
+
+  // Combine / compose the reducers to make a single, unified reducer
+  const reducers = buildGriddleReducer([dataReducers, ...plugins.map(p => p.reducer)]);
+
+  // Combine / Compose the components to make a single component for each component type
+  this.components = buildGriddleComponents([
+    components,
+    ...plugins.map(p => p.components),
+    userComponents,
+  ]);
+
+  this.settingsComponentObjects = Object.assign(
+    { ...settingsComponentObjects },
+    ...plugins.map(p => p.settingsComponentObjects),
+    userSettingsComponentObjects);
+
+  this.events = Object.assign({}, userEvents, ...plugins.map(p => p.events));
+
+  this.selectors = plugins.reduce(
+    (combined, plugin) => ({ ...combined, ...plugin.selectors }),
+    { ...selectors });
+
+  const styleConfig = _.merge(
+    { ...defaultStyleConfig },
+    ...plugins.map(p => p.styleConfig),
+    userStyleConfig);
+
+  const pageProperties = Object.assign({}, defaultPageProperties, userPageProperties);
+
+  // TODO: This should also look at the default and plugin initial state objects
+  const renderProperties = Object.assign({
+    rowProperties,
+    columnProperties
+  }, ...plugins.map(p => p.renderProperties), userRenderProperties);
+
+  // TODO: Make this its own method
+  const initialState = _.merge(
+    defaultInitialState,
+    ...plugins.map(p => p.initialState),
+    userInitialState,
+    {
+      data,
+      pageProperties,
+      renderProperties,
+      sortProperties,
+      styleConfig,
+    }
+  );
+
+  const sanitizedListeners = _.pickBy(listeners, value => typeof value === 'function');
+  this.listeners = plugins.reduce((combined, plugin) => ({ ...combined, ..._.pickBy(plugin.listeners, value => typeof value === 'function') }), sanitizedListeners);
+
+  return {
+    initialState,
+    reducers,
+    reduxMiddleware: [
+      ..._.compact(_.flatten(plugins.map(p => p.reduxMiddleware))),
+      ...reduxMiddleware
+    ],
+  };
+};

--- a/src/utils/initializer.js
+++ b/src/utils/initializer.js
@@ -20,7 +20,6 @@ module.exports = function initializer(defaults) {
     data = [],
     children: rowPropertiesComponent,
     events: userEvents = {},
-    sortProperties = {},
     styleConfig: userStyleConfig = {},
     components: userComponents,
     renderProperties: userRenderProperties = {},
@@ -74,7 +73,6 @@ module.exports = function initializer(defaults) {
     {
       data,
       renderProperties,
-      sortProperties,
       styleConfig,
     }
   );

--- a/src/utils/initializer.js
+++ b/src/utils/initializer.js
@@ -13,7 +13,7 @@ module.exports = function initializer(defaults) {
     selectors,
     styleConfig: defaultStyleConfig,
     ...defaultInitialState
-  } = defaults;
+  } = defaults || {};
 
   const {
     plugins = [],

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1638,6 +1638,19 @@ storiesOf('Settings', module)
     );
   })
 
+storiesOf('core', module)
+  .add('Can replace core', () => {
+    const core = {
+      components: {
+        Layout: () => <h1>Core Replaced!</h1>,
+      },
+    };
+
+    return (
+      <Griddle core={core} />
+    );
+  })
+
 storiesOf('TypeScript', module)
   .add('GriddleComponent accepts expected types', () => {
     class Custom extends React.Component<{ value }> {

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1650,6 +1650,11 @@ storiesOf('core', module)
       <Griddle core={core} />
     );
   })
+  .add('Can handle null core', () => {
+    return (
+      <Griddle core={null} />
+    );
+  })
 
 storiesOf('TypeScript', module)
   .add('GriddleComponent accepts expected types', () => {

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -97,16 +97,27 @@ storiesOf('Griddle main', module)
   })
   .add('with local, delayed data', () => {
     class DeferredGriddle extends React.Component<GriddleProps<FakeData>, { data?: FakeData[] }> {
+      private timeout;
+
       constructor(props) {
         super(props);
         this.state = {};
+      }
+
+      componentDidMount() {
         this.resetData();
+      }
+
+      componentWillUnmount() {
+        this.timeout && clearTimeout(this.timeout);
       }
 
       resetData = () => {
         this.setState({ data: null });
 
-        setTimeout(() => {
+        this.timeout && clearTimeout(this.timeout);
+
+        this.timeout = setTimeout(() => {
           this.setState({ data: this.props.data });
         }, 2000);
       }


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

Pulls the default+plugin+props composition out of the Griddle constructor into a testable initializer.

This is really just prep to work on supporting function plugins for #733.

## Why these changes are made

Tests are good, especially for this sort of composition (which seems likely to get more complex).

## Are there tests?

Lots!