### PR TITLE
Updated sort to allow sorting on nested columns

### DIFF
--- a/src/utils/__tests__/sortUtilsTests.js
+++ b/src/utils/__tests__/sortUtilsTests.js
@@ -1,0 +1,40 @@
+import test from 'ava';
+import { fromJS } from 'immutable';
+
+import { defaultSort } from '../sortUtils';
+
+const testData = fromJS([
+  {
+    name: 'cool2',
+    location: {
+      city: 'city2',
+    }
+  },
+  {
+    name: 'cool1',
+    location: {
+      city: 'city1',
+    }
+  },
+  {
+    name: 'cool3',
+    location: {
+      city: 'city0',
+    }
+  }
+]);
+
+test('defaultSort sorts on column value', test => {
+  const sortedData = defaultSort(testData, 'name');
+  test.is(sortedData.get('0').get('name'), 'cool1');
+});
+
+test('defaultSort sorts in descending order', test => {
+  const sortedData = defaultSort(testData, 'name', false);
+  test.is(sortedData.get('0').get('name'), 'cool3');
+});
+
+test('defaultSort sorts in by nested data', test => {
+  const sortedData = defaultSort(testData, 'location.city', true);
+  test.is(sortedData.get('0').get('name'), 'cool3');
+});

--- a/src/utils/sortUtils.js
+++ b/src/utils/sortUtils.js
@@ -8,14 +8,15 @@
 export function defaultSort(data, column, sortAscending = true) {
   return data.sort(
     (original, newRecord) => {
-      original = (!!original.get(column) && original.get(column)) || "";
-      newRecord = (!!newRecord.get(column) && newRecord.get(column)) || "";
+      const columnKey = column.split('.');
+      const originalValue = (original.hasIn(columnKey) && original.getIn(columnKey)) || '';
+      const newRecordValue = (newRecord.hasIn(columnKey) && newRecord.getIn(columnKey)) || '';
 
       //TODO: This is about the most cheezy sorting check ever.
       //Make it better
-      if(original === newRecord) {
+      if(originalValue === newRecordValue) {
         return 0;
-      } else if (original > newRecord) {
+      } else if (originalValue > newRecordValue) {
         return sortAscending ? 1 : -1;
       }
       else {


### PR DESCRIPTION
## Griddle major version
v1

## Changes proposed in this pull request
Fixes a bug that prevents sorting on nested columns (ex: `location.state`)

## Why these changes are made
To fix the bug!

## Are there tests?
Yep!