### PR TITLE
Add external filter (via Redux) example

### DIFF
--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -916,10 +916,15 @@ storiesOf('Griddle main', module)
       })
     )(CustomFilterComponent);
 
+    const plugins = [
+      LocalPlugin,
+      {
+        components: { Filter: CustomFilterConnectedComponent },
+      },
+    ];
     const SomePage = props => (
       <div>
-        <Griddle data={props.data} plugins={[LocalPlugin]} storeKey="griddleStore"
-          components={{ Filter: CustomFilterConnectedComponent }} />
+        <Griddle data={props.data} plugins={plugins} storeKey="griddleStore" />
 
         Component outside of Griddle that's sharing state
         <CustomFilterConnectedComponent />

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -79,6 +79,8 @@ function testReducer(state = { count: 1}, action) {
       return { ...state, count: state.count + 1};
     case 'DECREMENT':
       return { ...state, count: state.count -1};
+    case 'SET_DATA':
+      return { ...state, data: action.data };
     case 'SET_SEARCH_STRING':
       return { ...state, searchString: action.searchString };
     default:
@@ -924,9 +926,19 @@ storiesOf('Griddle main', module)
       </div>
     );
 
+    const SomePageConnected = reduxConnect(
+      state => ({
+        data: !state.searchString ? state.data :
+          state.data.filter(r =>
+            Object.keys(r).some(k => r[k] && r[k].toString().indexOf(state.searchString) > -1)),
+      })
+    )(SomePage);
+
+    testStore.dispatch({ type: 'SET_DATA', data: fakeData });
+
     return (
       <Provider store={testStore}>
-        <SomePage data={fakeData} />
+        <SomePageConnected />
       </Provider>
     );
   })

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -79,6 +79,8 @@ function testReducer(state = { count: 1}, action) {
       return { ...state, count: state.count + 1};
     case 'DECREMENT':
       return { ...state, count: state.count -1};
+    case 'SET_SEARCH_STRING':
+      return { ...state, searchString: action.searchString };
     default:
       return state;
   }
@@ -889,6 +891,43 @@ storiesOf('Griddle main', module)
           </div>
         </Provider>
       </div>
+    );
+  })
+
+  .add('with custom filter connected to another Redux store', () => {
+    // https://stackoverflow.com/questions/47229902/griddle-v1-9-inputbox-in-customfiltercomponent-lose-focus
+
+    const CustomFilterComponent = (props) => (
+      <input
+        value={props.searchString}
+        onChange={(e) => { props.setSearchString(e.target.value); }}
+      />
+    );
+
+    const setSearchStringActionCreator = searchString => ({ type: 'SET_SEARCH_STRING', searchString })
+    const CustomFilterConnectedComponent = reduxConnect(
+      state => ({
+          searchString: state.searchString,
+      }),
+      dispatch => ({
+        setSearchString: (e) => dispatch(setSearchStringActionCreator(e))
+      })
+    )(CustomFilterComponent);
+
+    const SomePage = props => (
+      <div>
+        <Griddle data={props.data} plugins={[LocalPlugin]} storeKey="griddleStore"
+          components={{ Filter: CustomFilterConnectedComponent }} />
+
+        Component outside of Griddle that's sharing state
+        <CustomFilterConnectedComponent />
+      </div>
+    );
+
+    return (
+      <Provider store={testStore}>
+        <SomePage data={fakeData} />
+      </Provider>
     );
   })
 


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

Adds story to troubleshoot #767

@radziksh is this a reasonably faithful reproduction of your situation? I improvised `SomePageConnected`, but it seems to be approximately what you're trying to achieve. As implemented here, I'm able to filter data from either `input` without losing focus. Thoughts?