### PR TITLE
Fire onGetPage more reliably

### DIFF
--- a/src/components/FilterEnhancer.js
+++ b/src/components/FilterEnhancer.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import getContext from 'recompose/getContext';
-import mapProps from 'recompose/mapProps';
 import compose from 'recompose/compose';
-
+import mapProps from 'recompose/mapProps';
+import getContext from 'recompose/getContext';
 import { combineHandlers } from '../utils/compositionUtils';
 
 const EnhancedFilter = OriginalComponent => compose(

--- a/src/components/PageDropdownContainer.js
+++ b/src/components/PageDropdownContainer.js
@@ -6,20 +6,13 @@ import mapProps from 'recompose/mapProps';
 import getContext from 'recompose/getContext';
 import { currentPageSelector, maxPageSelector, classNamesForComponentSelector, stylesForComponentSelector } from '../selectors/dataSelectors';
 
-const enhance = OriginalComponent => compose(
-  getContext({
-    events: PropTypes.object,
-  }),
+const enhance = (
   connect((state, props) => ({
     maxPages: maxPageSelector(state, props),
     currentPage: currentPageSelector(state, props),
     className: classNamesForComponentSelector(state, 'PageDropdown'),
     style: stylesForComponentSelector(state, 'PageDropdown'),
-  })),
-  mapProps(({ events: { onGetPage: setPage }, ...props }) => ({
-    ...props,
-    setPage,
   }))
-)((props) => <OriginalComponent {...props} />);
+);
 
 export default enhance;

--- a/src/components/PageDropdownEnhancer.js
+++ b/src/components/PageDropdownEnhancer.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import compose from 'recompose/compose';
+import mapProps from 'recompose/mapProps';
+import getContext from 'recompose/getContext';
+import { combineHandlers } from '../utils/compositionUtils';
+
+const enhance = OriginalComponent => compose(
+  getContext({
+    events: PropTypes.object
+  }),
+  mapProps(({ events: { onGetPage }, ...props }) => ({
+    ...props,
+    setPage: combineHandlers([onGetPage, props.setPage]),
+  }))
+)((props) => <OriginalComponent {...props} />);
+
+export default enhance;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -39,6 +39,7 @@ import PreviousButtonEnhancer from './PreviousButtonEnhancer';
 import PreviousButtonContainer from './PreviousButtonContainer';
 import PageDropdown from './PageDropdown';
 import PageDropdownContainer from './PageDropdownContainer';
+import PageDropdownEnhancer from './PageDropdownEnhancer';
 
 const components = {
   Cell,
@@ -67,6 +68,7 @@ const components = {
   NoResultsContainer,
   PageDropdown,
   PageDropdownContainer,
+  PageDropdownEnhancer,
   Pagination,
   PaginationContainer,
   PreviousButton,

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -283,10 +283,10 @@ export interface GriddleComponents {
     NextButtonContainer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
     NextButtonContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
 
-    PageDropDown?: GriddleComponent<any>;
-    PageDropDownEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
-    PageDropDownContainer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
-    PageDropDownContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    PageDropdown?: GriddleComponent<any>;
+    PageDropdownEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    PageDropdownContainer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
+    PageDropdownContainerEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;
 
     PreviousButton?: GriddleComponent<any>;
     PreviousButtonEnhancer?: (OriginalComponent: GriddleComponent<any>) => GriddleComponent<any>;


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

This moves `events.onGetPage` event handling from the default `PageDropdownContainer` into a new `PageDropdownEnhancer`, in alignment with `events` handling in the other enhancers.

## Why these changes are made

`onGetPage` should work with `LocalPlugin` (and other scenarios that replace `PageDropdownContainer`). 

Fixes #672

## Are there tests?

Existing "with local and events" story now fires `onGetPage` as expected.