### PR TITLE
More types for Redux test store

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@kadira/storybook": "^2.5.2",
     "@types/react": "^15.0.34",
-    "@types/react-redux": "^5.0.3",
+    "@types/react-redux": "^5.0.14",
     "ava": "^0.17.0",
     "babel-cli": "^6.23.0",
     "babel-core": "^6.0.0",

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -73,7 +73,13 @@ const EnhanceWithRowData = connect((state, props) => ({
 
 const EnhancedCustomComponent = EnhanceWithRowData(MakeBlueComponent);
 
-function testReducer(state = { count: 1}, action) {
+interface TestState {
+  count: number;
+  data?: any;
+  searchString?: string;
+}
+
+function testReducer(state: TestState = { count: 1 }, action: any) {
   switch (action.type) {
     case 'INCREMENT':
       return { ...state, count: state.count + 1};
@@ -919,7 +925,7 @@ storiesOf('Griddle main', module)
 
     const setSearchStringActionCreator = searchString => ({ type: 'SET_SEARCH_STRING', searchString })
     const CustomFilterConnectedComponent = reduxConnect(
-      state => ({
+      (state: TestState) => ({
           searchString: state.searchString,
       }),
       dispatch => ({
@@ -943,7 +949,7 @@ storiesOf('Griddle main', module)
     );
 
     const SomePageConnected = reduxConnect(
-      state => ({
+      (state: TestState) => ({
         data: !state.searchString ? state.data :
           state.data.filter(r =>
             Object.keys(r).some(k => r[k] && r[k].toString().indexOf(state.searchString) > -1)),

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -918,7 +918,7 @@ storiesOf('Griddle main', module)
 
     const CustomFilterComponent = (props) => (
       <input
-        value={props.searchString}
+        value={props.searchString || ''}
         onChange={(e) => { props.setSearchString(e.target.value); }}
       />
     );


### PR DESCRIPTION
## Griddle major version

1.x

## Changes proposed in this pull request

Fix #777

Also, a fix for:

> CustomFilterComponent is changing an uncontrolled input of type undefined to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://fb.me/react-controlled-components

## Why these changes are made

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21400 broke type inference (or rather, defaulting to `any`) for our test store `connect` calls.

## Are there tests?

Who needs tests when you have types? :trollface: 