### PR TITLE
Improve Prop Change/State Update

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -63,9 +63,9 @@ export function setPageSize(pageSize) {
   }
 }
 
-export function updateState({ data, pageProperties = {}, sortProperties = {} }) {
+export function updateState(newState) {
   return {
     type: GRIDDLE_UPDATE_STATE,
-    newState: { data, pageProperties, sortProperties }
+    newState
   }
 }

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -315,6 +315,7 @@ export interface GriddleSortKey {
 export interface GriddleStyleElements<T> {
     Cell?: T;
     Filter?: T;
+    Layout?: T;
     Loading?: T;
     NextButton?: T;
     NoResults?: T;

--- a/src/reducers/__tests__/dataReducerTest.js
+++ b/src/reducers/__tests__/dataReducerTest.js
@@ -211,9 +211,8 @@ test('update state merges non-data', (t) => {
       changed: -3,
       unchanged: 4,
     },
-    // This seems wrong
-    data: undefined,
-    lookup: undefined,
+    data: [],
+    lookup: {},
   });
 });
 

--- a/src/reducers/__tests__/dataReducerTest.js
+++ b/src/reducers/__tests__/dataReducerTest.js
@@ -183,3 +183,76 @@ test('toggle column works when there is no visible property', (t) => {
 
 
 });
+
+test('update state merges non-data', (t) => {
+  const initialState = Immutable.fromJS({
+    changed: 1,
+    unchanged: 2,
+    nested: {
+      changed: 3,
+      unchanged: 4,
+    },
+    data: [],
+    lookup: {},
+    renderProperties: {},
+  });
+  const newState = {
+    changed: -1,
+    nested: {
+      changed: -3,
+    },
+  };
+
+  const state = reducers.GRIDDLE_UPDATE_STATE(initialState, { newState });
+
+  t.deepEqual(state.toJSON(), {
+    changed: -1,
+    unchanged: 2,
+    nested: {
+      changed: -3,
+      unchanged: 4,
+    },
+    // This seems wrong
+    data: undefined,
+    lookup: undefined,
+    renderProperties: {},
+  });
+});
+
+test('update state transforms data', (t) => {
+  const initialState = Immutable.fromJS({
+    unchanged: 2,
+    nested: {
+      unchanged: 4,
+    },
+    data: [
+      {name: "one", griddleKey: 0},
+      {name: "two", griddleKey: 1},
+    ],
+    lookup: { 0: 0, 1: 1 },
+    renderProperties: {},
+  });
+  const newState = {
+    data: [
+      { name: 'uno' },
+      { name: 'dos' },
+      { name: 'tre' },
+    ]
+  };
+
+  const state = reducers.GRIDDLE_UPDATE_STATE(initialState, { newState });
+
+  t.deepEqual(state.toJSON(), {
+    unchanged: 2,
+    nested: {
+      unchanged: 4,
+    },
+    data: [
+      {name: "uno", griddleKey: 0},
+      {name: "dos", griddleKey: 1},
+      {name: "tre", griddleKey: 2},
+    ],
+    lookup: { 0: 0, 1: 1, 2: 2 },
+    renderProperties: {},
+  });
+});

--- a/src/reducers/__tests__/dataReducerTest.js
+++ b/src/reducers/__tests__/dataReducerTest.js
@@ -194,7 +194,6 @@ test('update state merges non-data', (t) => {
     },
     data: [],
     lookup: {},
-    renderProperties: {},
   });
   const newState = {
     changed: -1,
@@ -215,7 +214,6 @@ test('update state merges non-data', (t) => {
     // This seems wrong
     data: undefined,
     lookup: undefined,
-    renderProperties: {},
   });
 });
 
@@ -230,7 +228,6 @@ test('update state transforms data', (t) => {
       {name: "two", griddleKey: 1},
     ],
     lookup: { 0: 0, 1: 1 },
-    renderProperties: {},
   });
   const newState = {
     data: [
@@ -253,6 +250,5 @@ test('update state transforms data', (t) => {
       {name: "tre", griddleKey: 2},
     ],
     lookup: { 0: 0, 1: 1, 2: 2 },
-    renderProperties: {},
   });
 });

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -132,9 +132,12 @@ export function GRIDDLE_TOGGLE_COLUMN(state, action) {
       new Immutable.Map({ id: action.columnId, visible: true }));
 }
 
+const defaultRenderProperties = Immutable.fromJS({});
 export function GRIDDLE_UPDATE_STATE(state, action) {
   const { data, ...newState } = action.newState;
-  const transformedData = transformData(data, state.get('renderProperties').toJSON());
+
+  const renderProperties = state.get('renderProperties', defaultRenderProperties).toJSON();
+  const transformedData = transformData(data, renderProperties);
 
   return state.mergeDeep(Immutable.fromJS(newState))
     .set('data', transformedData.data)

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -136,10 +136,15 @@ const defaultRenderProperties = Immutable.fromJS({});
 export function GRIDDLE_UPDATE_STATE(state, action) {
   const { data, ...newState } = action.newState;
 
+  var mergedState = state.mergeDeep(Immutable.fromJS(newState));
+  if (!data) {
+    return mergedState;
+  }
+
   const renderProperties = state.get('renderProperties', defaultRenderProperties).toJSON();
   const transformedData = transformData(data, renderProperties);
 
-  return state.mergeDeep(Immutable.fromJS(newState))
+  return mergedState
     .set('data', transformedData.data)
     .set('lookup', transformedData.lookup);
 }

--- a/src/utils/__tests__/initilizerTests.js
+++ b/src/utils/__tests__/initilizerTests.js
@@ -60,7 +60,7 @@ test('init succeeds given empty defaults and props', (assert) => {
 test('init returns defaults given minimum props', (assert) => {
   const ctx = { props: { data: [] } };
   const defaults = {
-    reducers: { REDUCE: () => ({ reduced: true }) },
+    reducer: { REDUCE: () => ({ reduced: true }) },
     components: { Layout: () => null },
     settingsComponentObjects: { mySettings: { order: 10 } },
     selectors: { aSelector: () => null },
@@ -82,7 +82,7 @@ test('init returns defaults given minimum props', (assert) => {
   });
 
   assert.is(typeof res.reducers, 'function');
-  assert.deepEqual(Object.keys(res.reducers), Object.keys(defaults.reducers));
+  assert.deepEqual(Object.keys(res.reducers), Object.keys(defaults.reducer));
   assert.deepEqual(res.reducers({}, { type: 'REDUCE' }), { reduced: true });
 
   assert.deepEqual(res.reduxMiddleware, []);
@@ -244,7 +244,7 @@ test('init returns composed reducer given plugins', (assert) => {
     },
   };
   const defaults = {
-    reducers: {
+    reducer: {
       DEFAULTS: () => ({ defaults: true }),
       PLUGIN: () => ({ plugin: false }),
     },

--- a/src/utils/initializer.js
+++ b/src/utils/initializer.js
@@ -7,7 +7,7 @@ module.exports = function initializer(defaults) {
   if (!this) throw new Error('this missing!');
 
   const {
-    reducers: dataReducers,
+    reducer: dataReducers,
     components,
     settingsComponentObjects,
     selectors,

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -105,6 +105,28 @@ storiesOf('Griddle main', module)
       </Griddle>
     )
   })
+  .add('with local with extra prop change', () => {
+    class Stateful extends React.Component<{}, { n: number }> {
+      constructor(props) {
+        super(props);
+        this.state = { n: 0 };
+      }
+
+      render() {
+        const { n } = this.state;
+        return (
+          <div>
+            <p>
+              Click me to change extra Griddle state:{' '}
+              <button onClick={() => this.setState(({ n }) => ({ n: n+1 }))}>{n}</button>
+            </p>
+            <Griddle n={n} data={fakeData} plugins={[LocalPlugin]} />
+          </div>
+        );
+      }
+    }
+    return <Stateful />;
+  })
   .add('with local, delayed data', () => {
     class DeferredGriddle extends React.Component<GriddleProps<FakeData>, { data?: FakeData[] }> {
       private timeout;

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -105,7 +105,20 @@ storiesOf('Griddle main', module)
       </Griddle>
     )
   })
-  .add('with local with extra prop change', () => {
+  .add('with external prop changes', () => {
+    const NoResultsWithN = connect(
+      (state: any) => ({
+        n: state.get('n'),
+        addTen: state.get('addTen'),
+      }),
+      () => {}
+    )(({ n, addTen }) => (
+      <div>
+        <p><code>n = {n}</code></p>
+        <button onClick={addTen}>+10</button>
+      </div>
+    ));
+
     class Stateful extends React.Component<{}, { n: number }> {
       constructor(props) {
         super(props);
@@ -117,10 +130,27 @@ storiesOf('Griddle main', module)
         return (
           <div>
             <p>
-              Click me to change extra Griddle state:{' '}
+              Click to change Griddle props:{' '}
               <button onClick={() => this.setState(({ n }) => ({ n: n+1 }))}>{n}</button>
+              <button onClick={() => this.setState({ n: 0 })}>Reset</button>
             </p>
-            <Griddle n={n} data={fakeData} plugins={[LocalPlugin]} />
+            <Griddle
+              n={n}
+              addTen={() => this.setState(({ n }) => ({ n: n + 10 }))}
+              plugins={[LocalPlugin]}
+              data={fakeData.filter((d,i) => i % n === 0)}
+              components={{
+                NoResults: NoResultsWithN
+              }}
+              styleConfig={{
+                styles: {
+                  Layout: { color: n % 3 ? 'blue' : 'inherit' },
+                },
+              }}
+              textProperties={{
+                settingsToggle: `Settings (${n})`
+              }}
+              />
           </div>
         );
       }


### PR DESCRIPTION
## Griddle major version

1.11

## Changes proposed in this pull request

Fixes #781 root cause (cc @sum32)

1. Includes first commit from #783.
2. Added tests for `GRIDDLE_UPDATE_STATE` and adjusted its behavior a bit (e.g. not losing `data`).
3. Updated `actions.updateState` to pass all state through, instead of only `data`, `pageProperties` and `sortProperties`. That limitation was introduced by @joellanciaux way back in #505, but it's not obvious why.
4. Added a story with a minimal repro (changing a `<Griddle />` prop), which I ultimately expanded to demonstrate changing several `<Griddle />` props, including `data` and `styleConfig`.

## Why these changes are made

Changes to props should be reflected in Griddle's store and its rendering.

## Are there tests?

Tests and stories!