### PR TITLE
Include settingsComponentObjects in CorePlugin

### DIFF
--- a/src/core/__tests__/corePluginTests.js
+++ b/src/core/__tests__/corePluginTests.js
@@ -1,0 +1,15 @@
+import test from 'ava';
+
+import corePlugin from '../';
+
+test('has expected keys', test => {
+  test.truthy(corePlugin.components);
+  test.truthy(corePlugin.settingsComponentObjects);
+  test.truthy(corePlugin.reducer);
+  test.truthy(corePlugin.selectors);
+  test.truthy(corePlugin.actions);
+
+  test.truthy(corePlugin.pageProperties);
+  test.truthy(corePlugin.styleConfig);
+  test.truthy(corePlugin.textProperties);
+});

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -2,10 +2,12 @@ import components from '../components';
 import * as reducer from '../reducers/dataReducer';
 import * as selectors from '../selectors/dataSelectors';
 import * as actions from '../actions';
+import settingsComponentObjects from '../settingsComponentObjects';
 import initialState from './initialState';
 
 const CorePlugin = {
   components,
+  settingsComponentObjects,
   reducer,
   selectors,
   actions,


### PR DESCRIPTION
Accidentally omitted in 3577f8fbeaf480f316e29e0f701acfcf108637c7

## Griddle major version

1.11.x

## Changes proposed in this pull request

Fix #801 

## Why these changes are made

I broke it

## Are there tests?

Yep