### PR TITLE
Release 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,13 @@
     "webpack-dev-server": "1.12.1"
   },
   "scripts": {
+    "grunt": "grunt",
     "test": "karma start --browsers PhantomJS",
     "test-single": "karma start --singleRun true --browsers PhantomJS",
-    "grunt": "grunt"
+    "postpublish": "git push --tags",
+    "prepare": "grunt build",
+    "preversion": "npm test",
+    "ship-it": "npm publish --tag version0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR aligns the build process with v1 as of #808.

I have published 0.8.2, to release https://github.com/GriddleGriddle/Griddle/pull/753, but the build is failing due to `react-addons-test-utils` dependency hell.

@vakopian do you have any ideas how to resolve the [failure](https://travis-ci.org/GriddleGriddle/Griddle/builds/362748586) due to `react-addons-test-utils` shift from `react` to `react-dom` peer dependency?