### PR TITLE
Release 0.8.2 -- Fixed Tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,6 +5,7 @@ module.exports = function(config) {
     basePath: '',
     frameworks: ['jasmine'],
     files: [
+      './node_modules/@babel/polyfill/dist/polyfill.js',
       './node_modules/phantomjs-polyfill/bind-polyfill.js',
       './scripts/__tests__/**/*.js'
     ],

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "phantomjs-polyfill": "0.0.1",
     "phantomjs-prebuilt": "^2.1.7",
     "prop-types": "^15.6.0",
-    "react": "^0.14.3 || ^15.0.1 || ^16.0.0",
+    "react": "^15.5.4 || ^16.0.0",
     "react-chartist": "^0.10.2",
-    "react-dom": "^0.14.3 || ^15.0.1 || ^16.0.0",
-    "react-test-renderer": "^16.3.2",
+    "react-dom": "^15.5.4 || ^16.0.0",
+    "react-test-renderer": "^15.5.4 || ^16.3.2",
     "webpack": "1.12.3",
     "webpack-dev-server": "1.12.1"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lodash": "^4.17.4"
   },
   "devDependencies": {
+    "@babel/polyfill": "^7.0.0-beta.44",
     "babel-jest": "^5.2.1",
     "babel-loader": "^5.3.3",
     "create-react-class": "15.6.2",
@@ -42,9 +43,9 @@
     "phantomjs-prebuilt": "^2.1.7",
     "prop-types": "^15.6.0",
     "react": "^0.14.3 || ^15.0.1 || ^16.0.0",
-    "react-addons-test-utils": "^0.14.3 || ^15.0.1",
     "react-chartist": "^0.10.2",
     "react-dom": "^0.14.3 || ^15.0.1 || ^16.0.0",
+    "react-test-renderer": "^16.3.2",
     "webpack": "1.12.3",
     "webpack-dev-server": "1.12.1"
   },

--- a/scripts/__tests__/gridFilter-test.js
+++ b/scripts/__tests__/gridFilter-test.js
@@ -1,12 +1,12 @@
 var React = require('react');
 var createReactClass = require('create-react-class');
-var TestUtils = require('react-addons-test-utils');
+var TestUtils = require('react-dom/test-utils');
 var GridFilter = require('../gridFilter.jsx');
 
 describe('GridFilter', function(){
 
 	it('calls change filter when clicked', function(){
-		var mock = jasmine.createSpy(); 
+		var mock = jasmine.createSpy();
 		var filter = TestUtils.renderIntoDocument(<GridFilter changeFilter={mock}/>);
 
 		var someEvent = {
@@ -15,7 +15,7 @@ describe('GridFilter', function(){
 			}
 		};
 
-		var input = TestUtils.findRenderedDOMComponentWithTag(filter, 'input');		
+		var input = TestUtils.findRenderedDOMComponentWithTag(filter, 'input');
 		TestUtils.Simulate.change(input, someEvent);
 
 		expect(mock.calls.argsFor(0)).toEqual(["hi"]);

--- a/scripts/__tests__/gridPagination-test.js
+++ b/scripts/__tests__/gridPagination-test.js
@@ -1,7 +1,7 @@
 var React = require('react');
 var createReactClass = require('create-react-class');
 var GridPagination = require('../gridPagination.jsx');
-var TestUtils = require('react-addons-test-utils');
+var TestUtils = require('react-dom/test-utils');
 
 describe('GridPagination', function(){
 	it('calls change filter when clicked', function(){

--- a/scripts/__tests__/gridRow-test.js
+++ b/scripts/__tests__/gridRow-test.js
@@ -3,9 +3,9 @@ var createReactClass = require('create-react-class');
 var GridRow = require('../gridRow.jsx');
 var ColumnProperties = require('../columnProperties.js');
 var RowProperties = require('../rowProperties.js');
-var TestUtils = require('react-addons-test-utils');
+var TestUtils = require('react-dom/test-utils');
 
-	  var fakeData = [
+    var fakeData = [
       {
         "id": 0,
         "name": "Mayer Leonard",
@@ -30,183 +30,183 @@ var TestUtils = require('react-addons-test-utils');
       }
     ];
 
-	  var fakeSubgridData =  [
-	  {
-	    "id": 0,
-	    "name": "Mayer Leonard",
+    var fakeSubgridData =  [
+    {
+      "id": 0,
+      "name": "Mayer Leonard",
       "address": {
         "city": "Kapowsin",
         "state": "Hawaii"
       },
-	    "country": "United Kingdom",
-	    "company": "Ovolo",
-	    "favoriteNumber": 7,
-	    "children": [
-	        {
-	          "id": 273,
-	          "name": "Hull Wade",
+      "country": "United Kingdom",
+      "company": "Ovolo",
+      "favoriteNumber": 7,
+      "children": [
+          {
+            "id": 273,
+            "name": "Hull Wade",
             "address": {
               "city": "Monument",
               "state": "Nebraska"
             },
-	          "country": "Cyprus",
-	          "company": "Indexia",
-	          "favoriteNumber": 10,
-	          "children":[
-	            {
-	              "id": 5,
-	              "name": "Ola Fernandez",
+            "country": "Cyprus",
+            "company": "Indexia",
+            "favoriteNumber": 10,
+            "children":[
+              {
+                "id": 5,
+                "name": "Ola Fernandez",
                 "address": {
                   "city": "Deltaville",
                   "state": "Delaware"
                 },
-	              "country": "Virgin Islands (US)",
-	              "company": "Pawnagra",
-	              "favoriteNumber": 7
-	            },
-	            {
-	              "id": 6,
-	              "name": "Park Carr",
+                "country": "Virgin Islands (US)",
+                "company": "Pawnagra",
+                "favoriteNumber": 7
+              },
+              {
+                "id": 6,
+                "name": "Park Carr",
                 "address": {
                   "city": "Welda",
                   "state": "Kentucky"
                 },
-	              "country": "Sri Lanka",
-	              "company": "Cosmetex",
-	              "favoriteNumber": 7
-	            },
-	            {
-	              "id": 7,
-	              "name": "Laverne Johnson",
+                "country": "Sri Lanka",
+                "company": "Cosmetex",
+                "favoriteNumber": 7
+              },
+              {
+                "id": 7,
+                "name": "Laverne Johnson",
                 "address": {
                   "city": "Rosburg",
                   "state": "New Mexico"
                 },
-	              "country": "Croatia",
-	              "company": "Housedown",
-	              "favoriteNumber": 9
-	            }
-	          ]
-	        },
-	        {
-	          "id": 274,
-	          "name": "Blanca Sheppard",
+                "country": "Croatia",
+                "company": "Housedown",
+                "favoriteNumber": 9
+              }
+            ]
+          },
+          {
+            "id": 274,
+            "name": "Blanca Sheppard",
             "address": {
               "city": "Wadsworth",
               "state": "West Virginia"
             },
-	          "country": "Nicaragua",
-	          "company": "Gogol",
-	          "favoriteNumber": 7
-	        },
-	        {
-	          "id": 275,
-	          "name": "Stella Luna",
+            "country": "Nicaragua",
+            "company": "Gogol",
+            "favoriteNumber": 7
+          },
+          {
+            "id": 275,
+            "name": "Stella Luna",
             "address": {
               "city": "Dubois",
               "state": "Oregon"
             },
-	          "country": "Czech Republic",
-	          "company": "Intrawear",
-	          "favoriteNumber": 1
-	        }
-	    ]
-	  },
-	  {
-	    "id": 1,
-	    "name": "Koch Becker",
+            "country": "Czech Republic",
+            "company": "Intrawear",
+            "favoriteNumber": 1
+          }
+      ]
+    },
+    {
+      "id": 1,
+      "name": "Koch Becker",
       "address": {
         "city": "Johnsonburg",
         "state": "New Jersey"
       },
-	    "country": "Madagascar",
-	    "company": "Eventage",
-	    "favoriteNumber": 2,
-	    "children": [
-	        {
-	          "id": 273,
-	          "name": "Hull Wade",
+      "country": "Madagascar",
+      "company": "Eventage",
+      "favoriteNumber": 2,
+      "children": [
+          {
+            "id": 273,
+            "name": "Hull Wade",
             "address": {
               "city": "Monument",
               "state": "Nebraska"
             },
-	          "country": "Cyprus",
-	          "company": "Indexia",
-	          "favoriteNumber": 10
-	        },
-	        {
-	          "id": 274,
-	          "name": "Blanca Sheppard",
+            "country": "Cyprus",
+            "company": "Indexia",
+            "favoriteNumber": 10
+          },
+          {
+            "id": 274,
+            "name": "Blanca Sheppard",
             "address": {
               "city": "Wadsworth",
               "state": "West Virginia"
             },
-	          "country": "Nicaragua",
-	          "company": "Gogol",
-	          "favoriteNumber": 7
-	        },
-	        {
-	          "id": 275,
-	          "name": "Stella Luna",
+            "country": "Nicaragua",
+            "company": "Gogol",
+            "favoriteNumber": 7
+          },
+          {
+            "id": 275,
+            "name": "Stella Luna",
             "address": {
               "city": "Dubois",
               "state": "Oregon"
             },
-	          "country": "Czech Republic",
-	          "company": "Intrawear",
-	          "favoriteNumber": 1
-	        }
-	    ]
-	  },
-	  {
-	    "id": 2,
-	    "name": "Lowery Hopkins",
+            "country": "Czech Republic",
+            "company": "Intrawear",
+            "favoriteNumber": 1
+          }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "Lowery Hopkins",
       "address": {
         "city": "Blanco",
         "state": "Arizona"
       },
-	    "country": "Ukraine",
-	    "company": "Comtext",
-	    "favoriteNumber": 3,
-	     "children": [
-	        {
-	          "id": 273,
-	          "name": "Hull Wade",
+      "country": "Ukraine",
+      "company": "Comtext",
+      "favoriteNumber": 3,
+       "children": [
+          {
+            "id": 273,
+            "name": "Hull Wade",
             "address": {
               "city": "Monument",
               "state": "Nebraska"
             },
-	          "country": "Cyprus",
-	          "company": "Indexia",
-	          "favoriteNumber": 10
-	        },
-	        {
-	          "id": 274,
-	          "name": "Blanca Sheppard",
+            "country": "Cyprus",
+            "company": "Indexia",
+            "favoriteNumber": 10
+          },
+          {
+            "id": 274,
+            "name": "Blanca Sheppard",
             "address": {
               "city": "Wadsworth",
               "state": "West Virginia"
             },
-	          "country": "Nicaragua",
-	          "company": "Gogol",
-	          "favoriteNumber": 7
-	        },
-	        {
-	          "id": 275,
-	          "name": "Stella Luna",
+            "country": "Nicaragua",
+            "company": "Gogol",
+            "favoriteNumber": 7
+          },
+          {
+            "id": 275,
+            "name": "Stella Luna",
             "address": {
               "city": "Dubois",
               "state": "Oregon"
             },
-	          "country": "Czech Republic",
-	          "company": "Intrawear",
-	          "favoriteNumber": 1
-	        }
-	    ]
-	  }];
+            "country": "Czech Republic",
+            "company": "Intrawear",
+            "favoriteNumber": 1
+          }
+      ]
+    }];
 
 describe('GridRow', function(){
-	it('does not call toggleChildren if no child rows are specified', function(){
+  it('does not call toggleChildren if no child rows are specified', function(){
    var columnSettings = new ColumnProperties(
         ['id', 'name', 'address.city', 'address.state', 'country', 'company', 'favoriteNumber'],
         [],
@@ -216,16 +216,16 @@ describe('GridRow', function(){
     );
    var rowSettings = new RowProperties();
    var multipleSelectOptions =  {
-			isMultipleSelection: false,
-			toggleSelectAll: function(){},
-			getIsSelectAllChecked: function(){},
+      isMultipleSelection: false,
+      toggleSelectAll: function(){},
+      getIsSelectAllChecked: function(){},
 
-			toggleSelectRow: function(){},
-			getSelectedRowIds: function(){},
+      toggleSelectRow: function(){},
+      getSelectedRowIds: function(){},
       getIsRowChecked: function(){}
-		};
+    };
 
-		var mock = jasmine.createSpy();
+    var mock = jasmine.createSpy();
 
     const FakeTable = createReactClass({
       render() {
@@ -241,25 +241,25 @@ describe('GridRow', function(){
       }
     });
 
-	  var row = TestUtils.renderIntoDocument(<FakeTable />);
-		expect(TestUtils.isCompositeComponent(row)).toBe(true);
+    var row = TestUtils.renderIntoDocument(<FakeTable />);
+    expect(TestUtils.isCompositeComponent(row)).toBe(true);
 
-		expect(mock.calls.count()).toEqual(0);
-		var tr = TestUtils.findRenderedDOMComponentWithTag(row, 'tr');
-		expect(tr.length).not.toBe(null);
+    expect(mock.calls.count()).toEqual(0);
+    var tr = TestUtils.findRenderedDOMComponentWithTag(row, 'tr');
+    expect(tr.length).not.toBe(null);
 
-		var td = TestUtils.scryRenderedDOMComponentsWithTag(row, 'td');
+    var td = TestUtils.scryRenderedDOMComponentsWithTag(row, 'td');
 
-		expect(td.length).toBeGreaterThan(0);
-		var first = td[0];
+    expect(td.length).toBeGreaterThan(0);
+    var first = td[0];
 
-		TestUtils.Simulate.click(first);
+    TestUtils.Simulate.click(first);
 
-		expect(mock.calls.count()).toEqual(0);
-	})
+    expect(mock.calls.count()).toEqual(0);
+  })
 
 
-	it('calls toggleChildren if child rows are specified', function(){
+  it('calls toggleChildren if child rows are specified', function(){
     var columnSettings = new ColumnProperties(
         ['id', 'name', 'address.city', 'address.state', 'country', 'company', 'favoriteNumber'],
         [],
@@ -268,16 +268,16 @@ describe('GridRow', function(){
         []
     );
     var multipleSelectOptions =  {
-			isMultipleSelection: false,
-			toggleSelectAll: function(){},
-			getIsSelectAllChecked: function(){},
+      isMultipleSelection: false,
+      toggleSelectAll: function(){},
+      getIsSelectAllChecked: function(){},
 
-			toggleSelectRow: function(){},
-			getSelectedRowIds: function(){},
+      toggleSelectRow: function(){},
+      getSelectedRowIds: function(){},
       getIsRowChecked: function(){}
-		};
+    };
 
-		var mock = jasmine.createSpy();
+    var mock = jasmine.createSpy();
 
     const FakeTable = createReactClass({
       render() {
@@ -293,19 +293,19 @@ describe('GridRow', function(){
       }
     });
 
-	  const row2 = TestUtils.renderIntoDocument(<FakeTable />);
-	  expect(TestUtils.isCompositeComponent(row2)).toBe(true);
+    const row2 = TestUtils.renderIntoDocument(<FakeTable />);
+    expect(TestUtils.isCompositeComponent(row2)).toBe(true);
 
-		expect(mock.calls.count()).toEqual(0);
-		var tr = TestUtils.findRenderedDOMComponentWithTag(row2, 'tr');
-		expect(tr.length).not.toBe(null);
-		var td = TestUtils.scryRenderedDOMComponentsWithTag(row2, 'td');
-		
-		expect(td.length).toBeGreaterThan(0);
-		var first = td[0];
+    expect(mock.calls.count()).toEqual(0);
+    var tr = TestUtils.findRenderedDOMComponentWithTag(row2, 'tr');
+    expect(tr.length).not.toBe(null);
+    var td = TestUtils.scryRenderedDOMComponentsWithTag(row2, 'td');
+    
+    expect(td.length).toBeGreaterThan(0);
+    var first = td[0];
 
-		TestUtils.Simulate.click(first);
+    TestUtils.Simulate.click(first);
 
-		expect(mock.calls.count()).toEqual(1);
-	})
+    expect(mock.calls.count()).toEqual(1);
+  })
 });

--- a/scripts/__tests__/gridSettings-test.js
+++ b/scripts/__tests__/gridSettings-test.js
@@ -1,7 +1,7 @@
 var React = require('react');
 var createReactClass = require('create-react-class');
 var GridSettings = require('../gridSettings.jsx');
-var TestUtils = require('react-addons-test-utils');
+var TestUtils = require('react-dom/test-utils');
 
 describe('GridSettings', function() {
 

--- a/scripts/__tests__/gridTitle-test.js
+++ b/scripts/__tests__/gridTitle-test.js
@@ -1,46 +1,48 @@
 var React = require('react');
 var createReactClass = require('create-react-class');
 var GridTitle = require('../gridTitle.jsx');
-var TestUtils = require('react-addons-test-utils');
+var TestUtils = require('react-dom/test-utils');
+var ShallowRenderer = require('react-test-renderer/shallow');
 var ColumnProperties = require('../columnProperties.js');
 
 describe('GridTitle', function() {
-	var title;
-	var columns;
-	var columnSettings;
-	var sortObject;
-	var multipleSelectOptions;
-	var multipleSelectSettings;
+  var title;
+  var columns;
+  var columnSettings;
+  var sortObject;
+  var multipleSelectOptions;
+  var multipleSelectSettings;
 
-	beforeEach(function(){
-		columns = ["one", "two", "three"];
-		columnSettings = new ColumnProperties(columns, [], "children", [], []);
-    sortObject =  {
-        enableSort: true,
-        changeSort: null,
-        sortColumn: "",
-        sortDefaultComponent: null,
-        sortAscendingClassName: "",
-        sortDescendingClassName: "",
-        sortAscendingComponent: null,
-        sortDescendingComponent: null
+  beforeEach(function() {
+    columns = ["one", "two", "three"];
+    columnSettings = new ColumnProperties(columns, [], "children", [], []);
+    sortObject = {
+      enableSort: true,
+      changeSort: null,
+      sortColumn: "",
+      sortDefaultComponent: null,
+      sortAscendingClassName: "",
+      sortDescendingClassName: "",
+      sortAscendingComponent: null,
+      sortDescendingComponent: null
     };
+
     multipleSelectSettings = {
-			isMultipleSelection: false,
-			toggleSelectAll: function(){},
-			getIsSelectAllChecked: function(){},
+      isMultipleSelection: false,
+      toggleSelectAll: function(){},
+      getIsSelectAllChecked: function(){},
 
-			toggleSelectRow: function(){},
-			getSelectedRowIds: function(){},
+      toggleSelectRow: function(){},
+      getSelectedRowIds: function(){},
       getIsRowChecked: function(){}
-		};
+    };
 
-    var renderer = TestUtils.createRenderer();
+    var renderer = new ShallowRenderer();
     renderer.render(<GridTitle columns={columns} columnSettings={columnSettings} sortSettings={sortObject} multipleSelectionSettings={multipleSelectSettings} />);
     title = renderer.getRenderOutput();
-	});
-  
-	it('calls sortDefaultComponent in table init', function(){
+  });
+
+  it('calls sortDefaultComponent in table init', function(){
     expect(title.type).toBe('thead');
     const headings = title.props.children.props.children.length;
     expect(headings).toEqual(3);
@@ -49,5 +51,5 @@ describe('GridTitle', function() {
       var heading = headings[i];
       expect(heading.props.children[1]).toEqual(sortObject['sortDefaultComponent']);
     }
-	});
+  });
 });

--- a/scripts/__tests__/griddle-test.js
+++ b/scripts/__tests__/griddle-test.js
@@ -2,7 +2,7 @@ var React = require('react');
 var createReactClass = require('create-react-class');
 var ReactDOM = require('react-dom');
 var Griddle = require('../griddle.jsx');
-var TestUtils = require('react-addons-test-utils');
+var TestUtils = require('react-dom/test-utils');
 var assign = require('lodash/assign');
 
 var SomeCustomComponent = createReactClass({
@@ -352,7 +352,7 @@ describe('Griddle', function() {
 
   it('sets sort direction correctly', function(){
     expect(grid.state.sortColumn).toBeFalsy();
-      console.log(grid.state.sortColumn);
+    // console.log(grid.state.sortColumn);
 
     grid.changeSort("address.state");
     expect(grid.state.sortColumn).toEqual("address.state");


### PR DESCRIPTION
Note: went ahead and made the react/react-dom 0.14.x and 15.4.x devDependencies changes discussed briefly in [#809](https://github.com/GriddleGriddle/Griddle/pull/809). I can easily revert that if anyone is uncomfortable with the idea, but then a discussion needs to be had around how to fix `react-addons-test-utils` issues.

## Griddle major version
0.8.2 (fixes targeted for this version release)

## Changes proposed in this pull request
* Deprecating React 0.14.x and 15.4.x support in devDependencies
* Fixing React Test Utils package dependency, along with related dependencies (ShallowRenderer)
* Fixing es2015 Map constructor errors with a babel polyfill

## Why these changes are made
To get passing tests!

## Are there tests?
No new tests; all existing tests pass (as of this branch)