### PR TITLE
relax recompose dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "max-safe-integer": "^1.0.0",
     "prop-types": "^15.5.8",
     "react-redux": "^5.0.6",
-    "recompose": "^0.21.2",
+    "recompose": ">=0.21.2 < 1.0.0",
     "redux": "^3.5.2",
     "reselect": "^2.5.3"
   },


### PR DESCRIPTION
to avoid ending up with duplicated versions of recompose.

the carret `^` usually only cares about the first version number, so `^1.0.0` won't match `2.0.0` but any of `1.x.x`

BUT: this is not true, if it starts with 0. Then, `^0.21.0` will match any `0.21.x` but not `0.22.0` or higher.

## Griddle major version

## Changes proposed in this pull request

## Why these changes are made

## Are there tests?