### PR TITLE
@types/prop-types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
   - '9'
+
+branches:
+  only:
+  - master
+
 install:
   - 'npm install'
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '5'
+  - '9'
 install:
   - 'npm install'
 script:

--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
   },
   "devDependencies": {
     "@kadira/storybook": "^2.5.2",
+    "@types/prop-types": "^15.5.4",
     "@types/react": "^15.0.34",
     "@types/react-redux": "^5.0.14",
+    "@types/recompose": "^0.26.4",
     "ava": "^0.17.0",
     "babel-cli": "^6.23.0",
     "babel-core": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "start": "start-storybook -p 6006",
     "test": "ava",
-    "check-ts": "tsc --strict src/module.d.ts",
+    "check-ts": "tsc --version && tsc --strict src/module.d.ts",
     "watch-test": "ava --watch",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@kadira/storybook": "^2.5.2",
-    "@types/prop-types": "^15.5.4",
+    "@types/prop-types": "15.5.3",
     "@types/react": "^15.0.34",
     "@types/react-redux": "^5.0.14",
     "@types/recompose": "^0.26.4",

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 import { module, storiesOf, action, linkTo } from '@kadira/storybook';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -13,7 +13,7 @@ import { createSelector } from 'reselect';
 import _ from 'lodash';
 
 import GenericGriddle, { connect, actions, components, selectors, plugins, utils, ColumnDefinition, RowDefinition, GriddleProps } from '../src/module';
-const { Cell, Row, Table, TableContainer, TableBody, TableHeading, TableHeadingCell } = components;
+const { Cell, Row, Table, TableBody, TableHeading, TableHeadingCell } = components;
 const { SettingsWrapper, SettingsToggle, Settings } = components;
 
 const { LegacyStylePlugin, LocalPlugin, PositionPlugin } = plugins;
@@ -1625,60 +1625,6 @@ storiesOf('Table', module)
         TableHeading={tableHeading}
         TableBody={tableBody}
       />
-    );
-  })
-
-storiesOf('TableContainer', module)
-  .add('base', () => {
-    const tableHeading = (props) => (
-      <thead>
-        <tr>
-          <th>One</th>
-          <th>Two</th>
-          <th>Three</th>
-        </tr>
-      </thead>
-    );
-
-    const tableBody = (props) => (
-      <tbody>
-        <tr>
-          <td>uno</td>
-          <td>dos</td>
-          <td>tres</td>
-        </tr>
-      </tbody>
-    );
-
-    class BaseWithContext extends React.Component<any> {
-      static childContextTypes = {
-        components: PropTypes.object.isRequired
-      }
-
-      getChildContext() {
-        return {
-          components: {
-            TableBody: tableBody,
-            TableHeading: tableHeading
-          }
-        };
-      }
-
-      render() {
-        return (
-          <div>
-            {this.props.children}
-          </div>
-        );
-      }
-    }
-
-    const TableComposed = TableContainer(Table);
-
-    return (
-      <BaseWithContext>
-        <TableComposed />
-      </BaseWithContext>
     );
   })
 


### PR DESCRIPTION
## Griddle major version

1.13.1

## Changes proposed in this pull request

* Fixes Storybook use of `PropTypes` (#654)
* Removes lone `TableContainer` story, from a simpler time (f70a712dea7cb1460b414062a8257648e1a05efd)

## Why these changes are made

Fixes #826 

## Are there tests?

Compiler!