### PR TITLE
when <RowDefinition> children contains <ColumnDefinition> and an arra…

### DIFF
--- a/src/utils/columnUtils.js
+++ b/src/utils/columnUtils.js
@@ -25,7 +25,14 @@ export function getColumnProperties(rowProperties, allColumns=[]) {
     // build one object that contains all of the column properties keyed by id
     children.reduce((previous, current, i) => {
       if (current) {
-        previous[current.props.id] = {order: offset + i, ...current.props};
+        if(Array.isArray(current)){
+          current.forEach((c)=>{
+            previous[c.props.id] = {order: offset + i, ...c.props};
+          });
+        }else{
+          previous[current.props.id] = {order: offset + i, ...current.props};
+        }
+        
       }
       return previous;
     }, columnProperties);


### PR DESCRIPTION
…y of <ColumnDefinition>

## Griddle major version
1.13.1
## Changes proposed in this pull request
Wish <RowDefinition> could have props.Children is <ColumnDefinition> and array of <ColumnDefinition> at the same time.
## Why these changes are made
#836 
## Are there tests?
No