### PR TITLE
Upgrade recompose to ^0.25.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "max-safe-integer": "^1.0.0",
     "prop-types": "^15.5.8",
     "react-redux": "^5.0.6",
-    "recompose": "^0.21.2",
+    "recompose": "^0.25.1",
     "redux": "^3.5.2",
     "reselect": "^2.5.3"
   },


### PR DESCRIPTION
## Griddle major version
v1

## Changes proposed in this pull request
Upgrade recompose to ^0.25.1

## Why these changes are made
This is the first version of recompose "officially" compatible with React 16.
(https://github.com/acdlite/recompose/pull/530#issuecomment-332285889)

Griddle react seems to work fine in React 16 without this change.

#823 would achieve the same result, but seems to have failing CI tests.
This is minimal change required to resolve warning `"griddle-react > recompose@0.21.2" has incorrect peer dependency` from npm/yarn.

## Are there tests?
No additional tests.