### PR TITLE
Upgrade typescript to ^2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-dom": "^15.3.2",
     "rimraf": "^2.6.0",
     "ts-loader": "^2.0.2",
-    "typescript": "~2.5",
+    "typescript": "^2.8.0",
     "webpack": "^1.14.0",
     "webpack-dev-server": "^1.16.2",
     "webpack-fail-plugin": "^1.0.6"


### PR DESCRIPTION

## Griddle major version
v1

## Changes proposed in this pull request

Upgrade typescript to ^2.8.0

## Why these changes are made

This should hopefully fix error in travis build step `npm run check-ts`

Error:
```
node_modules/@types/recompose/index.d.ts(23,47): error TS2304:
Cannot find name 'Exclude'.
```
Failing builds:
https://travis-ci.org/GriddleGriddle/Griddle/builds/441174637
https://travis-ci.org/GriddleGriddle/Griddle/builds/450669719

Reason: The Exclude keyword used in @types/recompose was added in
Typescript 2.8
(https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#predefined-conditional-types).

## Are there tests?
Successful CI is the test.